### PR TITLE
fix: 선화 캐릭터 카드 이미지 크기 불일치 수정

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -33,7 +33,7 @@
           {
             "type": "command",
             "if": "Bash(git push*)",
-            "command": "cd F:/DEVELOPMENT/SOURCE/CLAUDE/ArcanaInsight && bash scripts/pre-push-checks.sh",
+            "command": "cd $(git rev-parse --show-toplevel) && bash scripts/pre-push-checks.sh",
             "timeout": 180,
             "statusMessage": "코드 품질 검증 중 (tsc + lint + build)..."
           }

--- a/src/components/character/CharacterCard.tsx
+++ b/src/components/character/CharacterCard.tsx
@@ -30,7 +30,7 @@ export function CharacterCard({ character, isSelected, onClick, index }: Charact
           src={`/images/characters/${character.id}/nukki/idle.png`}
           alt={character.name}
           fill
-          className="object-contain object-bottom"
+          className="object-cover object-top"
         />
         <div className="absolute bottom-0 left-0 right-0 h-1/3 bg-gradient-to-t from-arcana-card/90 to-transparent" />
       </div>


### PR DESCRIPTION
## Summary
- 선화 캐릭터의 nukki 이미지가 가로(1408x768) 비율이라 다른 캐릭터(세로 896x1280)와 카드 크기가 불일치하던 문제 수정
- CharacterCard의 `object-contain`을 `object-cover`로 변경하여 모든 캐릭터 카드가 균일하게 표시되도록 함
- pre-push hook의 하드코딩된 Windows 경로를 플랫폼 독립적으로 수정

## Test plan
- [ ] 타로 페이지에서 4개 캐릭터 카드 이미지 크기가 동일한지 확인
- [ ] 선화 이미지가 카드 영역을 적절히 채우는지 확인
- [ ] 다른 캐릭터(아르카나, 미코, 호시) 이미지가 잘리지 않고 정상 표시되는지 확인

https://claude.ai/code/session_01V3Jp6ZHSZJvsLUUkRX5gZE