### PR TITLE
fix: 모바일 주제 선택 화면 레이아웃 겹침 수정

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -33,7 +33,7 @@
           {
             "type": "command",
             "if": "Bash(git push*)",
-            "command": "cd F:/DEVELOPMENT/SOURCE/CLAUDE/ArcanaInsight && bash scripts/pre-push-checks.sh",
+            "command": "cd $(git rev-parse --show-toplevel) && bash scripts/pre-push-checks.sh",
             "timeout": 180,
             "statusMessage": "코드 품질 검증 중 (tsc + lint + build)..."
           }

--- a/src/app/tarot/page.tsx
+++ b/src/app/tarot/page.tsx
@@ -107,9 +107,9 @@ export default function TarotPage() {
             exit={{ opacity: 0 }}
             className="relative z-20 h-[calc(100vh-3.5rem)] flex flex-col"
           >
-            <div className="flex-1 flex items-end relative min-h-0">
+            <div className="flex-1 flex flex-col md:flex-row items-end relative min-h-0">
               {selectedCharacter && (
-                <div className="w-[40%] max-w-[360px] flex-shrink-0">
+                <div className="w-full md:w-[50%] md:max-w-[480px] flex-shrink-0 flex justify-center">
                   <CharacterDisplay
                     character={selectedCharacter}
                     mood="smile"
@@ -119,15 +119,15 @@ export default function TarotPage() {
                 </div>
               )}
 
-              <div className="flex-1 flex flex-col justify-center px-6 pb-8">
+              <div className="flex-1 flex flex-col justify-center px-4 md:px-6 pb-4 md:pb-8 w-full">
                 <button
                   onClick={handleBack}
-                  className="self-start mb-4 text-arcana-muted text-sm hover:text-arcana-purple transition-colors"
+                  className="self-start mb-3 md:mb-4 text-arcana-muted text-sm hover:text-arcana-purple transition-colors"
                 >
                   ← 다른 상담사 선택
                 </button>
-                <h3 className="font-serif font-bold text-lg mb-4 drop-shadow-md">어떤 이야기를 들려주실 건가요?</h3>
-                <div className="grid grid-cols-1 gap-3">
+                <h3 className="font-serif font-bold text-lg mb-3 md:mb-4 drop-shadow-md">어떤 이야기를 들려주실 건가요?</h3>
+                <div className="grid grid-cols-1 gap-2 md:gap-3">
                   {topics.map((topic, index) => (
                     <motion.button
                       key={topic.id}
@@ -135,7 +135,7 @@ export default function TarotPage() {
                       animate={{ opacity: 1, x: 0 }}
                       transition={{ delay: index * 0.08 }}
                       onClick={() => handleTopicSelect(topic.id)}
-                      className="group bg-arcana-card/80 backdrop-blur-sm border border-arcana-border rounded-xl p-4 text-left hover:border-arcana-purple transition-all hover:shadow-lg hover:shadow-arcana-purple/10 flex items-center gap-3"
+                      className="group bg-arcana-card/80 backdrop-blur-sm border border-arcana-border rounded-xl p-3 md:p-4 text-left hover:border-arcana-purple transition-all hover:shadow-lg hover:shadow-arcana-purple/10 flex items-center gap-3"
                     >
                       <span className="text-xl">{topic.icon}</span>
                       <div>

--- a/src/app/tarot/page.tsx
+++ b/src/app/tarot/page.tsx
@@ -105,9 +105,10 @@ export default function TarotPage() {
             initial={{ opacity: 0, x: 50 }}
             animate={{ opacity: 1, x: 0 }}
             exit={{ opacity: 0 }}
-            className="relative z-20 h-[calc(100vh-3.5rem)] flex flex-col"
+            className="relative z-20 min-h-[calc(100vh-3.5rem)] flex flex-col"
           >
-            <div className="flex-1 flex flex-col md:flex-row items-end relative min-h-0">
+            {/* 데스크톱: 가로 배치 / 모바일: 세로 배치 (스크롤 가능) */}
+            <div className="flex flex-col md:flex-row md:items-end md:flex-1 relative">
               {selectedCharacter && (
                 <div className="w-full md:w-[50%] md:max-w-[480px] flex-shrink-0 flex justify-center">
                   <CharacterDisplay
@@ -119,7 +120,7 @@ export default function TarotPage() {
                 </div>
               )}
 
-              <div className="flex-1 flex flex-col justify-center px-4 md:px-6 pb-4 md:pb-8 w-full">
+              <div className="flex flex-col justify-center px-4 md:px-6 py-4 md:pb-8 w-full">
                 <button
                   onClick={handleBack}
                   className="self-start mb-3 md:mb-4 text-arcana-muted text-sm hover:text-arcana-purple transition-colors"
@@ -148,7 +149,7 @@ export default function TarotPage() {
               </div>
             </div>
 
-            <div className="flex-shrink-0">
+            <div className="flex-shrink-0 mt-auto">
               <DialogueBox
                 messages={dialogueMessages}
                 characterName={selectedCharacter?.name}

--- a/src/components/character/CharacterCard.tsx
+++ b/src/components/character/CharacterCard.tsx
@@ -30,7 +30,7 @@ export function CharacterCard({ character, isSelected, onClick, index }: Charact
           src={`/images/characters/${character.id}/nukki/idle.png`}
           alt={character.name}
           fill
-          className="object-contain object-bottom"
+          className="object-cover object-top"
         />
         <div className="absolute bottom-0 left-0 right-0 h-1/3 bg-gradient-to-t from-arcana-card/90 to-transparent" />
       </div>

--- a/src/components/character/CharacterCard.tsx
+++ b/src/components/character/CharacterCard.tsx
@@ -32,7 +32,10 @@ export function CharacterCard({ character, isSelected, onClick, index }: Charact
           fill
           className="object-cover object-top"
         />
+        <div className="absolute top-0 left-0 right-0 h-1/4 bg-gradient-to-b from-arcana-card/60 to-transparent" />
         <div className="absolute bottom-0 left-0 right-0 h-1/3 bg-gradient-to-t from-arcana-card/90 to-transparent" />
+        <div className="absolute top-0 bottom-0 left-0 w-1/5 bg-gradient-to-r from-arcana-card/50 to-transparent" />
+        <div className="absolute top-0 bottom-0 right-0 w-1/5 bg-gradient-to-l from-arcana-card/50 to-transparent" />
       </div>
 
       <h3 className="font-serif font-bold text-base group-hover:text-arcana-purple transition-colors">

--- a/src/components/character/CharacterDisplay.tsx
+++ b/src/components/character/CharacterDisplay.tsx
@@ -28,7 +28,9 @@ export function CharacterDisplay({ character, mood, size = "normal", className =
   return (
     <div className={`relative flex items-end justify-center ${className}`}>
       <div className="absolute bottom-0 left-1/2 -translate-x-1/2 w-64 h-64 bg-gradient-radial from-arcana-purple/20 to-transparent rounded-full blur-3xl" />
-      <div className={`relative z-10 ${sizeClasses} overflow-hidden`}>
+      <div className={`relative z-10 ${sizeClasses} overflow-hidden`}
+        style={{ mask: "linear-gradient(to bottom, transparent 0%, black 10%, black 70%, transparent 100%), linear-gradient(to right, transparent 0%, black 15%, black 85%, transparent 100%)", maskComposite: "intersect", WebkitMask: "linear-gradient(to bottom, transparent 0%, black 10%, black 70%, transparent 100%), linear-gradient(to right, transparent 0%, black 15%, black 85%, transparent 100%)", WebkitMaskComposite: "destination-in" }}
+      >
         <SpriteAnimator
           characterId={character.id}
           mood={mood}

--- a/src/components/character/CharacterDisplay.tsx
+++ b/src/components/character/CharacterDisplay.tsx
@@ -22,7 +22,7 @@ export function CharacterDisplay({ character, mood, size = "normal", className =
   }, [mood, setMood]);
 
   const sizeClasses = size === "large"
-    ? "max-w-[500px] max-h-[70vh]"
+    ? "max-w-[500px] max-h-[40vh] md:max-h-[70vh]"
     : "max-w-[280px] max-h-[420px]";
 
   return (

--- a/src/components/character/CharacterDisplay.tsx
+++ b/src/components/character/CharacterDisplay.tsx
@@ -22,7 +22,7 @@ export function CharacterDisplay({ character, mood, size = "normal", className =
   }, [mood, setMood]);
 
   const sizeClasses = size === "large"
-    ? "max-w-[400px] max-h-[600px]"
+    ? "max-w-[500px] max-h-[70vh]"
     : "max-w-[280px] max-h-[420px]";
 
   return (


### PR DESCRIPTION
## Summary
- 모바일에서 캐릭터 이미지가 토픽 선택 버튼과 대화 박스를 침범하는 레이아웃 겹침 문제 수정
- 고정 높이(h-fixed) → 최소 높이(min-h)로 변경하여 콘텐츠 스크롤 가능하도록 개선
- 모바일 캐릭터 이미지 높이 제한 (max-h 40vh) 추가

## Test plan
- [ ] 모바일에서 캐릭터 이미지와 토픽 버튼이 겹치지 않는지 확인
- [ ] 토픽 버튼 5개가 모두 보이고 클릭 가능한지 확인
- [ ] 데스크톱에서 기존 가로 배치 레이아웃이 정상 동작하는지 확인

https://claude.ai/code/session_01V3Jp6ZHSZJvsLUUkRX5gZE