### PR TITLE
fix: 모바일 주제 선택 화면 레이아웃 겹침 수정

### DIFF
--- a/src/app/tarot/page.tsx
+++ b/src/app/tarot/page.tsx
@@ -105,9 +105,10 @@ export default function TarotPage() {
             initial={{ opacity: 0, x: 50 }}
             animate={{ opacity: 1, x: 0 }}
             exit={{ opacity: 0 }}
-            className="relative z-20 h-[calc(100vh-3.5rem)] flex flex-col"
+            className="relative z-20 min-h-[calc(100vh-3.5rem)] flex flex-col"
           >
-            <div className="flex-1 flex flex-col md:flex-row items-end relative min-h-0">
+            {/* 데스크톱: 가로 배치 / 모바일: 세로 배치 (스크롤 가능) */}
+            <div className="flex flex-col md:flex-row md:items-end md:flex-1 relative">
               {selectedCharacter && (
                 <div className="w-full md:w-[50%] md:max-w-[480px] flex-shrink-0 flex justify-center">
                   <CharacterDisplay
@@ -119,7 +120,7 @@ export default function TarotPage() {
                 </div>
               )}
 
-              <div className="flex-1 flex flex-col justify-center px-4 md:px-6 pb-4 md:pb-8 w-full">
+              <div className="flex flex-col justify-center px-4 md:px-6 py-4 md:pb-8 w-full">
                 <button
                   onClick={handleBack}
                   className="self-start mb-3 md:mb-4 text-arcana-muted text-sm hover:text-arcana-purple transition-colors"
@@ -148,7 +149,7 @@ export default function TarotPage() {
               </div>
             </div>
 
-            <div className="flex-shrink-0">
+            <div className="flex-shrink-0 mt-auto">
               <DialogueBox
                 messages={dialogueMessages}
                 characterName={selectedCharacter?.name}

--- a/src/components/character/CharacterDisplay.tsx
+++ b/src/components/character/CharacterDisplay.tsx
@@ -22,7 +22,7 @@ export function CharacterDisplay({ character, mood, size = "normal", className =
   }, [mood, setMood]);
 
   const sizeClasses = size === "large"
-    ? "max-w-[500px] max-h-[70vh]"
+    ? "max-w-[500px] max-h-[40vh] md:max-h-[70vh]"
     : "max-w-[280px] max-h-[420px]";
 
   return (


### PR DESCRIPTION
## Summary
- 모바일에서 캐릭터 이미지가 토픽 선택 버튼과 대화 박스를 침범하는 레이아웃 겹침 문제 수정
- 고정 높이(h-fixed) → 최소 높이(min-h)로 변경하여 콘텐츠 스크롤 가능하도록 개선
- 모바일 캐릭터 이미지 높이 제한 (max-h 40vh) 추가

## Test plan
- [ ] 모바일에서 캐릭터 이미지와 토픽 버튼이 겹치지 않는지 확인
- [ ] 토픽 버튼 5개가 모두 보이고 클릭 가능한지 확인
- [ ] 데스크톱에서 기존 가로 배치 레이아웃이 정상 동작하는지 확인

https://claude.ai/code/session_01V3Jp6ZHSZJvsLUUkRX5gZE