### PR TITLE
fix: 대화상자를 토픽 선택지 위로 이동

### DIFF
--- a/src/app/tarot/page.tsx
+++ b/src/app/tarot/page.tsx
@@ -107,10 +107,16 @@ export default function TarotPage() {
             exit={{ opacity: 0 }}
             className="relative z-20 min-h-[calc(100vh-3.5rem)] flex flex-col"
           >
-            {/* 데스크톱: 가로 배치 / 모바일: 세로 배치 (스크롤 가능) */}
+            <div className="flex-shrink-0">
+              <DialogueBox
+                messages={dialogueMessages}
+                characterName={selectedCharacter?.name}
+              />
+            </div>
+
             <div className="flex flex-col md:flex-row md:items-end md:flex-1 relative">
               {selectedCharacter && (
-                <div className="w-full md:w-[50%] md:max-w-[480px] flex-shrink-0 flex justify-center">
+                <div className="hidden md:flex w-[50%] max-w-[480px] flex-shrink-0 justify-center">
                   <CharacterDisplay
                     character={selectedCharacter}
                     mood="smile"
@@ -147,13 +153,6 @@ export default function TarotPage() {
                   ))}
                 </div>
               </div>
-            </div>
-
-            <div className="flex-shrink-0 mt-auto">
-              <DialogueBox
-                messages={dialogueMessages}
-                characterName={selectedCharacter?.name}
-              />
             </div>
           </motion.div>
         )}


### PR DESCRIPTION
## Summary
- 대화상자(DialogueBox)를 토픽 선택지 위로 이동 (캐릭터 인사 → 토픽 선택 자연스러운 흐름)
- 모바일에서 캐릭터 이미지 숨기고 대화상자와 토픽 선택에 집중

## Test plan
- [ ] 모바일에서 대화상자가 토픽 버튼 위에 표시되는지 확인
- [ ] 데스크톱에서 캐릭터 이미지가 좌측에 정상 표시되는지 확인

https://claude.ai/code/session_01V3Jp6ZHSZJvsLUUkRX5gZE