### PR TITLE
feat: CLAUDE.md 업데이트 + 리딩 결과 개선 + 스프레드 카드 반응형

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,17 +6,25 @@
 
 ArcanaInsight는 애니메이션 캐릭터와 상담하듯 대화하며 타로 카드를 선택하고, Grok AI가 해석을 제공하는 웹 애플리케이션입니다. MVP는 타로 서비스에 집중하며, 사주/신점/오늘의 운세로 확장 가능한 모듈 구조입니다.
 
+### 서비스 흐름 (4단계)
+
+1. **캐릭터 선택** → 4캐릭터 중 상담사 선택 (아르카나/미코/선화/호시)
+2. **개인정보 입력** → 생년월일, 출생시간(12시진), 성별, 혈액형 + 3자 제공 동의
+3. **주제 선택 + 카드 선택** → 5가지 주제(연애/재물/직업/건강/종합) → 카드 뽑기 (1/3/5장)
+4. **AI 리딩 결과** → Grok AI가 SSE 스트리밍으로 해석 제공 → 결과 공유
+
 ## 기술 스택
 
 - **언어**: TypeScript (strict)
-- **프레임워크**: Next.js 16+ (App Router)
+- **프레임워크**: Next.js 16.2 (App Router) / React 19.2
 - **스타일링**: Tailwind CSS v4 (CSS-based `@theme` config)
-- **애니메이션**: Framer Motion
+- **애니메이션**: Framer Motion v12
 - **AI**: Grok API (xAI) — `src/services/core/grok-provider.ts`에서 추상화
 - **인증**: Supabase Auth Helpers (카카오/구글)
 - **데이터베이스**: Supabase (PostgreSQL)
-- **상태관리**: Zustand
-- **패키지 매니저**: pnpm
+- **상태관리**: Zustand v5
+- **패키지 매니저**: pnpm 10.33
+- **런타임**: Node.js >= 20
 - **CI/CD**: GitHub Actions → Railway 자동 배포
 - **호스팅**: Railway
 
@@ -24,34 +32,85 @@ ArcanaInsight는 애니메이션 캐릭터와 상담하듯 대화하며 타로 �
 
 ```
 src/
-├── app/                    # Next.js App Router 페이지 & API
-│   ├── api/tarot/          # API 라우트 (session, reading SSE, result)
-│   ├── auth/               # 로그인, OAuth 콜백
-│   ├── mypage/             # 리딩 히스토리
-│   └── tarot/              # 주제 선택, 상담 세션, 결과
+├── app/                        # Next.js App Router 페이지 & API
+│   ├── api/
+│   │   ├── daily-card/         # 캐릭터별 일일 카드 API (Grok AI + Supabase 캐시)
+│   │   └── tarot/              # API 라우트 (session, reading SSE, result/[id])
+│   ├── auth/                   # 로그인, OAuth 콜백
+│   ├── mypage/                 # 리딩 히스토리, 대시보드
+│   ├── tarot/                  # 주제 선택, 상담 세션, 결과(/result/[id])
+│   ├── page.tsx                # 홈 페이지 (8개 섹션)
+│   ├── layout.tsx              # 루트 레이아웃
+│   └── globals.css             # Tailwind v4 @theme 정의
 ├── components/
-│   ├── card/               # CardItem, CardDeck, CardSpread, CardSwiper
-│   ├── character/          # CharacterDisplay, CharacterSelector, TypingDialogue
-│   ├── chat/               # ChatBubble, ChatWindow
-│   └── layout/             # Header, Footer, MobileNav
+│   ├── card/                   # CardBack, CardDeck, CardFace, CardItem, CardSpread
+│   ├── character/              # CharacterCard, CharacterDisplay, SpriteAnimator, TypingDialogue
+│   ├── chat/                   # ChatBubble, DialogueBox
+│   ├── effects/                # ParticleOverlay (배경 파티클), ScrollReveal (스크롤 페이드인)
+│   ├── home/                   # HeroSection, CharacterGallery, ServiceFlow, DailyCard,
+│   │                           # ReviewCarousel, StatsCounter, FAQ, BottomCTA
+│   ├── layout/                 # Header (스크롤/드롭다운), Footer, MobileNav (4탭)
+│   └── tarot/                  # UserInfoForm (개인정보 입력), PrivacyConsentModal (동의)
 ├── data/
-│   ├── cards/              # 메이저 22장 + 마이너 56장 정적 데이터
-│   ├── characters/         # 4캐릭터 설정 (아르카나/미코/선화/호시)
-│   └── spreads/            # 스프레드 정의 (1/3/5카드)
-├── hooks/                  # Zustand 스토어 (useSession, useCharacter, useCardAnimation)
-├── lib/supabase/           # Supabase 클라이언트 (browser/server/middleware)
+│   ├── cards/                  # 메이저 22장 (major-arcana.ts) + 마이너 56장 (minor-arcana.ts) + symbols.ts
+│   ├── characters/             # 4캐릭터 설정 (index.ts)
+│   ├── home/                   # faq.ts, reviews.ts, stats.ts (홈 페이지 정적 데이터)
+│   ├── spreads/                # 스프레드 정의 (1/3/5카드)
+│   └── birth-hours.ts          # 12시진 데이터
+├── hooks/                      # Zustand 스토어 (useSession, useCharacter, useCardAnimation)
+├── lib/supabase/               # Supabase 클라이언트 (client.ts, server.ts, middleware.ts)
 ├── services/
-│   ├── core/               # AI Provider 추상화, Grok 구현체, 프롬프트 빌더
-│   └── tarot/              # TarotService, DeckManager, SpreadResolver
-└── types/                  # card, character, session, service 인터페이스
+│   ├── core/                   # ai-provider.ts (인터페이스), grok-provider.ts (구현체), prompt-builder.ts
+│   └── tarot/                  # tarot-service.ts, deck-manager.ts, spread-resolver.ts
+└── types/                      # card.ts, character.ts, session.ts, service.ts
+
+public/images/
+├── backgrounds/                # 페이지별 배경 이미지 (hero-bg, session-bg, result-bg 등)
+├── cards/
+│   ├── major/                  # 메이저 아르카나 22장 SVG (00-fool ~ 21-world)
+│   ├── cups/wands/swords/pentacles/  # 마이너 아르카나 슈트별 SVG
+│   └── card-back.svg           # 카드 뒷면
+└── characters/
+    ├── arcana/                 # 6표정 JPG + nukki/ (누끼 PNG) + sprites/ (스프라이트)
+    ├── miko/                   # 위와 동일 구조
+    ├── seonhwa/                # 위와 동일 구조
+    └── hoshi/                  # 위와 동일 구조
+
+scripts/                        # 유틸리티 스크립트
+├── pre-push-checks.sh          # git push 전 자동 검증 (tsc + lint + build)
+├── generate-characters.ts      # 캐릭터 이미지 생성
+├── generate-backgrounds.ts     # 배경 이미지 생성
+├── generate-nukki-images.mjs   # 누끼(배경제거) 이미지 생성
+├── generate-character-images.mjs
+├── generate-placeholders.sh    # 플레이스홀더 이미지 생성
+└── regenerate-all-nukki.mjs
+
+supabase/migrations/            # DB 마이그레이션 파일
+├── 001_initial_schema.sql      # 초기 스키마 (sessions, readings 등)
+├── 003_daily_cards.sql         # daily_cards 테이블 + profiles.favorite_character_id
+└── 004_user_info.sql           # 사용자 정보 (생년월일, 성별, 혈액형 등)
 ```
+
+## 캐릭터 시스템
+
+4명의 캐릭터, 각각 다른 서비스 타입 전문:
+
+| ID | 이름 | 전문 | 말투 |
+|---|---|---|---|
+| `arcana` | 아르카나 | 타로 (tarot) | ~네요/~해요, 부드럽고 신비로운 톤 |
+| `miko` | 미코 | 신점 (shinjeom) | ~입니다/~합니다, 차분하고 엄숙한 톤 |
+| `seonhwa` | 선화 | 사주 (saju) | ~세요/~랍니다, 우아하고 따뜻한 톤 |
+| `hoshi` | 호시 | 오늘의 운세 (fortune) | ~야/~지, 반말 + 이모지 |
+
+각 캐릭터는 6가지 표정(Mood): `default`, `smile`, `serious`, `surprised`, `wink`, `mystical`
 
 ## 핵심 아키텍처 패턴
 
 - **DivinationService 인터페이스**: 모든 운세 서비스는 이 인터페이스를 구현. 새 서비스 추가 = 구현체 + 프롬프트
 - **AIProvider 추상화**: Grok API를 직접 호출하지 않고 인터페이스 통해 호출. 모델 교체 용이
 - **SSE 스트리밍**: `/api/tarot/reading`에서 Grok 응답을 SSE로 클라이언트에 스트리밍
-- **Tailwind v4**: CSS `@theme` 블록에서 커스텀 컬러 정의 (`arcana-*` 계열)
+- **Tailwind v4**: CSS `@theme` 블록(`globals.css`)에서 커스텀 컬러 정의 (`arcana-*` 계열)
+- **Path alias**: `@/*` → `./src/*` (tsconfig.json)
 
 ## 코딩 컨벤션
 
@@ -60,7 +119,7 @@ src/
 - 한국어 주석 및 커밋 메시지 사용
 - 함수/변수명은 영어 camelCase
 - 컴포넌트명은 PascalCase
-- 파일명은 kebab-case (컴포넌트 파일 제외)
+- 파일명은 kebab-case (컴포넌트 파일은 PascalCase)
 
 ### TypeScript
 
@@ -80,6 +139,13 @@ src/
 - 복잡한 애니메이션은 Framer Motion 사용
 - 다크 모드가 기본 테마 (점술/타로의 신비로운 분위기)
 - 커스텀 컬러: `arcana-bg`, `arcana-surface`, `arcana-card`, `arcana-border`, `arcana-purple`, `arcana-indigo`, `arcana-gold`, `arcana-text`, `arcana-muted`
+
+### 이미지 리소스
+
+- 캐릭터 이미지: JPG (표정별) + PNG 누끼 (투명 배경)
+- 카드 이미지: SVG
+- 배경 이미지: JPG
+- 새 이미지 생성 시 `scripts/` 디렉토리의 생성 스크립트 활용
 
 ## 명령어
 
@@ -117,7 +183,7 @@ NEXT_PUBLIC_SITE_URL=       # 사이트 URL
 
 ### Railway 설정
 
-- `railway.toml`에 빌드/배포 설정 정의
+- `railway.toml`에 빌드/배포 설정 정의 (nixpacks 빌더)
 - GitHub Secrets 필요:
   - `RAILWAY_TOKEN`: Railway API 토큰
   - `RAILWAY_SERVICE_ID`: Railway 서비스 ID
@@ -149,6 +215,7 @@ pnpm build             # 프로덕션 빌드 확인
 
 ### 자동화
 - `.claude/settings.json`의 PreToolUse 훅으로 `git push` 시 자동 검증
+- `scripts/pre-push-checks.sh` 실행: tsc → lint → build 순서
 - 하나라도 실패하면 push 차단
 
 ## 레이아웃 규칙 (필수 준수)
@@ -158,12 +225,27 @@ pnpm build             # 프로덕션 빌드 확인
 - **데스크탑(md 이상)**: 좌측 캐릭터 50% + 우측 콘텐츠(카드/카테고리 등) 50% — 가로 5:5 비율 flex 레이아웃
 - **모바일(md 미만)**: 위에서 아래로 세로 배치 — 캐릭터 → 콘텐츠 순서
 - 캐릭터 이미지 테두리는 CSS mask로 투명도 그라디언트를 적용하여 배경과 자연스럽게 블렌딩
-- 이 규칙은 타로 주제 선택 페이지, 세션 페이지, 향후 추가되는 모든 캐릭터 등장 페이지에 동일 적용
+- 이 규칙은 타로 주제 선택 페이지, 세션 페이지, 결과 페이지, 향후 추가되는 모든 캐릭터 등장 페이지에 동일 적용
+
+## 홈 페이지 구성
+
+`src/app/page.tsx`에서 8개 섹션을 순서대로 조합:
+
+1. **HeroSection** — 풀스크린 히어로 (캐릭터 + 카피 + CTA)
+2. **CharacterGallery** — 4캐릭터 갤러리 (카드형)
+3. **ServiceFlow** — 서비스 이용 흐름 소개
+4. **DailyCard** — 캐릭터별 일일 운세 (탭 전환 + 카드 뒤집기 + 공유)
+5. **StatsCounter** — 서비스 통계 카운터
+6. **ReviewCarousel** — 사용자 후기 캐러셀
+7. **FAQ** — 아코디언 FAQ
+8. **BottomCTA** — 하단 행동 유도
 
 ## 작업 시 주의사항
 
 - 타로 카드 데이터는 `src/data/` 디렉토리에 정적으로 관리
+- 홈 페이지 데이터(후기, FAQ, 통계)는 `src/data/home/`에 정적으로 관리
 - 이미지 리소스는 `public/images/`에 저장
-- DB 스키마는 `supabase/migrations/`에서 관리
+- DB 스키마는 `supabase/migrations/`에서 관리 (번호 순서 유지)
 - `main` 브랜치에 직접 push 금지, PR을 통해 머지
 - `.env` 파일은 절대 커밋하지 않음 (Railway 환경변수로 관리)
+- 캐릭터 이미지 표정은 864x1296 세로 규격 통일 (JPG), 누끼는 PNG

--- a/src/app/tarot/result/[id]/page.tsx
+++ b/src/app/tarot/result/[id]/page.tsx
@@ -65,7 +65,7 @@ export default async function ResultPage({ params }: { params: Promise<{ id: str
                 <span className="text-lg">🔮</span>
                 <h2 className="font-serif font-bold text-xl text-arcana-purple">종합 해석</h2>
               </div>
-              <p className="text-arcana-text leading-relaxed">{reading.overall_reading}</p>
+              <p className="text-arcana-text leading-relaxed whitespace-pre-wrap">{reading.overall_reading}</p>
             </div>
 
             {/* 조언 */}
@@ -74,7 +74,7 @@ export default async function ResultPage({ params }: { params: Promise<{ id: str
                 <span className="text-lg">✨</span>
                 <h2 className="font-serif font-bold text-xl text-arcana-gold">조언</h2>
               </div>
-              <p className="text-arcana-text leading-relaxed">{reading.advice}</p>
+              <p className="text-arcana-text leading-relaxed whitespace-pre-wrap">{reading.advice}</p>
             </div>
           </div>
 
@@ -100,7 +100,7 @@ export default async function ResultPage({ params }: { params: Promise<{ id: str
                       </div>
                     </div>
                   </div>
-                  <p className="text-arcana-text text-sm leading-relaxed">{interp.interpretation}</p>
+                  <p className="text-arcana-text text-sm leading-relaxed whitespace-pre-wrap">{interp.interpretation}</p>
                 </div>
               );
             })}

--- a/src/components/card/CardBack.tsx
+++ b/src/components/card/CardBack.tsx
@@ -2,6 +2,8 @@
 
 interface CardBackProps {
   size?: "sm" | "md" | "lg";
+  width?: number;
+  height?: number;
   className?: string;
 }
 
@@ -11,8 +13,10 @@ const sizeDimensions = {
   lg: { w: 128, h: 192 },
 };
 
-export function CardBack({ size = "md", className = "" }: CardBackProps) {
-  const { w, h } = sizeDimensions[size];
+export function CardBack({ size = "md", width, height, className = "" }: CardBackProps) {
+  const preset = sizeDimensions[size];
+  const w = width ?? preset.w;
+  const h = height ?? preset.h;
   const cx = w / 2;
   const cy = h / 2;
   const r1 = Math.min(w, h) * 0.3;

--- a/src/components/card/CardFace.tsx
+++ b/src/components/card/CardFace.tsx
@@ -7,6 +7,8 @@ interface CardFaceProps {
   card: TarotCard;
   isReversed: boolean;
   size?: "sm" | "md" | "lg";
+  width?: number;
+  height?: number;
   className?: string;
 }
 
@@ -16,8 +18,10 @@ const sizeDimensions = {
   lg: { w: 128, h: 192 },
 };
 
-export function CardFace({ card, isReversed, size = "md", className = "" }: CardFaceProps) {
-  const { w, h } = sizeDimensions[size];
+export function CardFace({ card, isReversed, size = "md", width, height, className = "" }: CardFaceProps) {
+  const preset = sizeDimensions[size];
+  const w = width ?? preset.w;
+  const h = height ?? preset.h;
   const symbol = card.type === "major"
     ? majorSymbols[card.id]
     : card.suit ? suitSymbols[card.suit] : null;

--- a/src/components/card/CardItem.tsx
+++ b/src/components/card/CardItem.tsx
@@ -12,12 +12,16 @@ interface CardItemProps {
   isReversed?: boolean;
   onClick?: () => void;
   size?: "sm" | "md" | "lg";
+  width?: number;
+  height?: number;
   className?: string;
 }
 
 const sizeClasses = { sm: "w-10 h-[60px]", md: "w-24 h-36", lg: "w-32 h-48" };
 
-export function CardItem({ card, isFlipped, isSelected, isReversed = false, onClick, size = "md", className = "" }: CardItemProps) {
+export function CardItem({ card, isFlipped, isSelected, isReversed = false, onClick, size = "md", width, height, className = "" }: CardItemProps) {
+  const useCustomSize = width !== undefined && height !== undefined;
+
   return (
     <motion.div
       onClick={onClick}
@@ -26,8 +30,8 @@ export function CardItem({ card, isFlipped, isSelected, isReversed = false, onCl
         scale: 1.02,
         transition: { duration: 0.2 },
       } : undefined}
-      className={`relative cursor-pointer ${sizeClasses[size]} ${className}`}
-      style={{ perspective: "1000px" }}
+      className={`relative cursor-pointer ${useCustomSize ? "" : sizeClasses[size]} ${className}`}
+      style={{ perspective: "1000px", ...(useCustomSize ? { width, height } : {}) }}
     >
       {!isFlipped && (
         <motion.div
@@ -50,14 +54,14 @@ export function CardItem({ card, isFlipped, isSelected, isReversed = false, onCl
           className={`absolute inset-0 ${isSelected ? "ring-2 ring-arcana-gold shadow-lg shadow-arcana-gold/20" : ""}`}
           style={{ backfaceVisibility: "hidden", borderRadius: "0.5rem" }}
         >
-          <CardBack size={size} className="w-full h-full" />
+          <CardBack size={size} width={width} height={height} className="w-full h-full" />
         </div>
 
         <div
           className="absolute inset-0"
           style={{ backfaceVisibility: "hidden", transform: "rotateY(180deg)", borderRadius: "0.5rem" }}
         >
-          <CardFace card={card} isReversed={isReversed} size={size} className="w-full h-full" />
+          <CardFace card={card} isReversed={isReversed} size={size} width={width} height={height} className="w-full h-full" />
         </div>
       </motion.div>
 

--- a/src/components/card/CardSpread.tsx
+++ b/src/components/card/CardSpread.tsx
@@ -3,7 +3,7 @@
 import { useRef, useState, useEffect, useMemo } from "react";
 import { motion } from "framer-motion";
 import { SelectedCard } from "@/types/card";
-import { SpreadDefinition } from "@/types/session";
+import { SpreadDefinition, SpreadPosition } from "@/types/session";
 import { CardItem } from "./CardItem";
 
 interface CardSpreadProps {
@@ -29,60 +29,89 @@ export function CardSpread({ selectedCards, spread, revealedPositions }: CardSpr
     return () => window.removeEventListener("resize", measure);
   }, []);
 
-  // 컨테이너 크기 + 스프레드 포지션 기반으로 카드 크기 동적 계산
+  // 1단계: 컨테이너 비율 기반 카드 크기 계산
   const cardDimensions = useMemo(() => {
     if (!containerWidth || !containerHeight) return { w: 40, h: 60 };
 
-    const positions = spread.positions;
+    const count = spread.positions.length;
 
-    // X/Y 좌표에서 최소 여백과 최소 간격 계산
-    const xValues = positions.map((p) => p.x);
-    const yValues = positions.map((p) => p.y);
+    // 카드 수가 많을수록 작게, 적을수록 크게
+    // 1장: 컨테이너의 28%, 3장: 20%, 5장: 16%
+    const ratio = count <= 1 ? 0.28 : count <= 3 ? 0.20 : 0.16;
 
-    const minEdgeX = Math.min(...xValues.map((x) => Math.min(x, 100 - x)));
-    const minEdgeY = Math.min(...yValues.map((y) => Math.min(y, 100 - y)));
-
-    const uniqueX = [...new Set(xValues)].sort((a, b) => a - b);
-    const uniqueY = [...new Set(yValues)].sort((a, b) => a - b);
-
-    const minGapX = uniqueX.length > 1
-      ? Math.min(...uniqueX.slice(1).map((x, i) => x - uniqueX[i]))
-      : 100;
-    const minGapY = uniqueY.length > 1
-      ? Math.min(...uniqueY.slice(1).map((y, i) => y - uniqueY[i]))
-      : 100;
-
-    // 카드가 넘치지 않도록: 카드 반폭 < 최소 여백, 카드 전폭 < 최소 간격
-    const maxWFromEdge = (minEdgeX * 2) * containerWidth / 100;
-    const maxWFromGap = minGapX * containerWidth / 100;
-    const maxHFromEdge = (minEdgeY * 2) * containerHeight / 100;
-    const maxHFromGap = minGapY * containerHeight / 100;
-
-    // 가로/세로 각각의 제한치 (간격의 80%까지 사용)
-    const maxW = Math.min(maxWFromEdge, maxWFromGap) * 0.8;
-    const maxH = Math.min(maxHFromEdge, maxHFromGap) * 0.8;
-
-    // 2:3 비율 유지하며 양쪽 제한 모두 충족
-    let cardW = maxW;
+    let cardW = containerWidth * ratio;
     let cardH = cardW * 1.5;
+
+    // 세로도 넘치지 않도록 제한
+    const maxH = containerHeight * ratio * 1.2;
     if (cardH > maxH) {
       cardH = maxH;
       cardW = cardH / 1.5;
     }
 
     // 최소/최대 클램프
-    cardW = Math.max(Math.min(cardW, 96), 32);
+    cardW = Math.max(Math.min(cardW, 110), 30);
     cardH = cardW * 1.5;
 
     return { w: Math.round(cardW), h: Math.round(cardH) };
-  }, [containerWidth, containerHeight, spread.positions]);
+  }, [containerWidth, containerHeight, spread.positions.length]);
+
+  // 2단계: 카드 크기 기반으로 포지션을 동적 재계산
+  const adjustedPositions = useMemo((): SpreadPosition[] => {
+    if (!containerWidth || !containerHeight) return spread.positions;
+
+    const positions = spread.positions;
+    if (positions.length <= 1) return positions;
+
+    // 카드 크기를 컨테이너 비율(%)로 변환
+    const cardWPct = (cardDimensions.w / containerWidth) * 100;
+    const cardHPct = (cardDimensions.h / containerHeight) * 100;
+
+    // 카드 간격 = 카드 크기의 30% (반응형 — 카드가 크면 간격도 커짐)
+    const gapXPct = cardWPct * 0.30;
+    const gapYPct = cardHPct * 0.30;
+
+    // 필요한 최소 중심-중심 거리
+    const requiredDistX = cardWPct + gapXPct;
+    const requiredDistY = cardHPct + gapYPct;
+
+    // 원본 레이아웃의 중심점
+    const xs = positions.map((p) => p.x);
+    const ys = positions.map((p) => p.y);
+    const centerX = (Math.min(...xs) + Math.max(...xs)) / 2;
+    const centerY = (Math.min(...ys) + Math.max(...ys)) / 2;
+
+    // 원본 레이아웃의 최소 인접 거리
+    const uniqueX = [...new Set(xs)].sort((a, b) => a - b);
+    const uniqueY = [...new Set(ys)].sort((a, b) => a - b);
+    const origMinDistX = uniqueX.length > 1
+      ? Math.min(...uniqueX.slice(1).map((x, i) => x - uniqueX[i]))
+      : 100;
+    const origMinDistY = uniqueY.length > 1
+      ? Math.min(...uniqueY.slice(1).map((y, i) => y - uniqueY[i]))
+      : 100;
+
+    // 스케일 팩터: 필요 거리 / 원본 거리 (카드+간격이 확보되도록)
+    const scaleX = origMinDistX > 0 ? requiredDistX / origMinDistX : 1;
+    const scaleY = origMinDistY > 0 ? requiredDistY / origMinDistY : 1;
+
+    // 카드 가장자리가 컨테이너 안에 들어오도록 패딩
+    const padX = cardWPct / 2 + 2;
+    const padY = cardHPct / 2 + 2;
+
+    return positions.map((p) => ({
+      ...p,
+      x: Math.max(padX, Math.min(100 - padX, centerX + (p.x - centerX) * scaleX)),
+      y: Math.max(padY, Math.min(100 - padY, centerY + (p.y - centerY) * scaleY)),
+    }));
+  }, [containerWidth, containerHeight, cardDimensions, spread.positions]);
 
   return (
     <div
       ref={containerRef}
       className="relative w-full mx-auto aspect-[4/3] overflow-hidden"
     >
-      {containerWidth > 0 && containerHeight > 0 && spread.positions.map((pos) => {
+      {containerWidth > 0 && containerHeight > 0 && adjustedPositions.map((pos) => {
         const selectedCard = selectedCards.find((sc) => sc.position === pos.index);
         const isRevealed = revealedPositions.includes(pos.index);
 

--- a/src/components/card/CardSpread.tsx
+++ b/src/components/card/CardSpread.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRef, useState, useEffect } from "react";
+import { useRef, useState, useEffect, useMemo } from "react";
 import { motion } from "framer-motion";
 import { SelectedCard } from "@/types/card";
 import { SpreadDefinition } from "@/types/session";
@@ -15,11 +15,13 @@ interface CardSpreadProps {
 export function CardSpread({ selectedCards, spread, revealedPositions }: CardSpreadProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const [containerWidth, setContainerWidth] = useState(0);
+  const [containerHeight, setContainerHeight] = useState(0);
 
   useEffect(() => {
     const measure = () => {
       if (containerRef.current) {
         setContainerWidth(containerRef.current.offsetWidth);
+        setContainerHeight(containerRef.current.offsetHeight);
       }
     };
     measure();
@@ -27,17 +29,60 @@ export function CardSpread({ selectedCards, spread, revealedPositions }: CardSpr
     return () => window.removeEventListener("resize", measure);
   }, []);
 
-  // 컨테이너 너비 기반으로 카드 사이즈 결정
-  // 카드 5장이 겹침 없이 들어가려면 카드폭 < 컨테이너/5 * 1.5
-  const cardSize: "sm" | "md" | "lg" = containerWidth >= 500 ? "md" : "sm";
-  const placeholderW = containerWidth >= 500 ? "w-24 h-36" : "w-10 h-[60px]";
+  // 컨테이너 크기 + 스프레드 포지션 기반으로 카드 크기 동적 계산
+  const cardDimensions = useMemo(() => {
+    if (!containerWidth || !containerHeight) return { w: 40, h: 60 };
+
+    const positions = spread.positions;
+
+    // X/Y 좌표에서 최소 여백과 최소 간격 계산
+    const xValues = positions.map((p) => p.x);
+    const yValues = positions.map((p) => p.y);
+
+    const minEdgeX = Math.min(...xValues.map((x) => Math.min(x, 100 - x)));
+    const minEdgeY = Math.min(...yValues.map((y) => Math.min(y, 100 - y)));
+
+    const uniqueX = [...new Set(xValues)].sort((a, b) => a - b);
+    const uniqueY = [...new Set(yValues)].sort((a, b) => a - b);
+
+    const minGapX = uniqueX.length > 1
+      ? Math.min(...uniqueX.slice(1).map((x, i) => x - uniqueX[i]))
+      : 100;
+    const minGapY = uniqueY.length > 1
+      ? Math.min(...uniqueY.slice(1).map((y, i) => y - uniqueY[i]))
+      : 100;
+
+    // 카드가 넘치지 않도록: 카드 반폭 < 최소 여백, 카드 전폭 < 최소 간격
+    const maxWFromEdge = (minEdgeX * 2) * containerWidth / 100;
+    const maxWFromGap = minGapX * containerWidth / 100;
+    const maxHFromEdge = (minEdgeY * 2) * containerHeight / 100;
+    const maxHFromGap = minGapY * containerHeight / 100;
+
+    // 가로/세로 각각의 제한치 (간격의 80%까지 사용)
+    const maxW = Math.min(maxWFromEdge, maxWFromGap) * 0.8;
+    const maxH = Math.min(maxHFromEdge, maxHFromGap) * 0.8;
+
+    // 2:3 비율 유지하며 양쪽 제한 모두 충족
+    let cardW = maxW;
+    let cardH = cardW * 1.5;
+    if (cardH > maxH) {
+      cardH = maxH;
+      cardW = cardH / 1.5;
+    }
+
+    // 최소/최대 클램프
+    cardW = Math.max(Math.min(cardW, 96), 32);
+    cardH = cardW * 1.5;
+
+    return { w: Math.round(cardW), h: Math.round(cardH) };
+  }, [containerWidth, containerHeight, spread.positions]);
 
   return (
     <div
       ref={containerRef}
       className="relative w-full mx-auto aspect-[4/3] overflow-hidden"
     >
-      {containerWidth > 0 && spread.positions.map((pos) => {
+      {containerWidth > 0 && containerHeight > 0 && spread.positions.map((pos) => {
         const selectedCard = selectedCards.find((sc) => sc.position === pos.index);
         const isRevealed = revealedPositions.includes(pos.index);
 
@@ -71,16 +116,28 @@ export function CardSpread({ selectedCards, spread, revealedPositions }: CardSpr
                     isFlipped={isRevealed}
                     isSelected={true}
                     isReversed={selectedCard.isReversed}
-                    size={cardSize}
+                    width={cardDimensions.w}
+                    height={cardDimensions.h}
                   />
                 </div>
-                <span className="text-arcana-gold text-[8px] md:text-sm font-serif font-bold drop-shadow-[0_0_4px_rgba(212,175,55,0.4)] truncate max-w-[60px] md:max-w-none">
+                <span
+                  className="text-arcana-gold font-serif font-bold drop-shadow-[0_0_4px_rgba(212,175,55,0.4)] truncate text-center"
+                  style={{ fontSize: Math.max(cardDimensions.w * 0.18, 8), maxWidth: cardDimensions.w * 1.5 }}
+                >
                   {pos.labelKo}
                 </span>
               </div>
             ) : (
-              <div className={`${placeholderW} rounded border border-dashed border-arcana-purple/30 flex items-center justify-center bg-arcana-purple/5`}>
-                <span className="text-arcana-gold/60 text-[8px] md:text-sm font-serif font-bold truncate">{pos.labelKo}</span>
+              <div
+                className="rounded border border-dashed border-arcana-purple/30 flex items-center justify-center bg-arcana-purple/5"
+                style={{ width: cardDimensions.w, height: cardDimensions.h }}
+              >
+                <span
+                  className="text-arcana-gold/60 font-serif font-bold truncate"
+                  style={{ fontSize: Math.max(cardDimensions.w * 0.18, 8) }}
+                >
+                  {pos.labelKo}
+                </span>
               </div>
             )}
           </motion.div>

--- a/src/services/tarot/tarot-service.ts
+++ b/src/services/tarot/tarot-service.ts
@@ -52,20 +52,35 @@ export class TarotService implements DivinationService {
     try {
       const parsed = JSON.parse(jsonStr);
       return {
-        cardInterpretations: parsed.cardInterpretations || [],
-        overallReading: parsed.overallReading || "",
-        advice: parsed.advice || "",
+        cardInterpretations: (parsed.cardInterpretations || []).map(
+          (interp: { cardId: string; position: number; interpretation: string; isReversed?: boolean }) => ({
+            ...interp,
+            interpretation: this.cleanReadingText(interp.interpretation),
+          })
+        ),
+        overallReading: this.cleanReadingText(parsed.overallReading || ""),
+        advice: this.cleanReadingText(parsed.advice || ""),
       };
     } catch {
       // JSON 파싱 실패 시 코드/태그 제거 후 텍스트만 표시
       const cleanText = aiResponse
         .replace(/```[\s\S]*?```/g, "")
         .replace(/[{}[\]"]/g, "")
-        .replace(/cardInterpretations|cardId|position|interpretation|overallReading|advice/g, "")
-        .replace(/:\s*,/g, "")
-        .replace(/,\s*,/g, "")
+        .replace(/\b(cardInterpretations|cardId|position|interpretation|overallReading|advice|isReversed)\b\s*:/g, "")
+        .replace(/,\s*,+/g, "")
+        .replace(/^\s*,|,\s*$/gm, "")
+        .replace(/\n{3,}/g, "\n\n")
         .trim();
       return { cardInterpretations: [], overallReading: cleanText || "해석 결과를 처리하는 중 문제가 발생했습니다. 다시 시도해주세요.", advice: "" };
     }
+  }
+
+  /** JSON 파싱 후 텍스트에 남은 이스케이프/코드 잔여물 정리 */
+  private cleanReadingText(text: string): string {
+    return text
+      .replace(/\\n/g, "\n")           // 리터럴 \n → 실제 개행
+      .replace(/\\"/g, '"')            // 이스케이프된 따옴표 복원
+      .replace(/\n{3,}/g, "\n\n")      // 과도한 개행 정리
+      .trim();
   }
 }


### PR DESCRIPTION
## Summary
- CLAUDE.md 최신 코드베이스 상태로 업데이트 (서비스 흐름, 캐릭터 시스템, 홈 페이지 구성 등)
- 리딩 결과 JSON 문법 노출 방지 + whitespace-pre-wrap 개행 처리
- 스프레드 카드 컨테이너 기반 반응형 크기 계산 (모바일 넘침 해소)
- 카드 수·크기에 따라 카드 간격도 동적 재계산

## Test plan
- [ ] 모바일(375px)에서 1장/3장/5장 스프레드 카드가 화면 내에 표시되는지 확인
- [ ] 태블릿/데스크탑에서 카드 크기와 간격이 자연스럽게 확대되는지 확인
- [ ] 리딩 결과에서 JSON 문법이 노출되지 않고 문단 개행이 정상 렌더링되는지 확인
- [ ] 결과 공유 페이지(/result/[id])에서도 개행이 정상 표시되는지 확인

https://claude.ai/code/session_01NEeHuJYR7o8aTvaJrM4LCT