### PR TITLE
fix: 스프레드 카드 반응형 크기·간격 수학적 정합성 확보

### DIFF
--- a/src/components/card/CardSpread.tsx
+++ b/src/components/card/CardSpread.tsx
@@ -12,6 +12,84 @@ interface CardSpreadProps {
   revealedPositions: number[];
 }
 
+/**
+ * 카드 크기 + 포지션을 동시에 계산하여 컨테이너에 꽉 맞게 배치.
+ *
+ * 핵심 공식 (각 축):
+ *   maxDim = (minGap × containerDim) / (origRange × (1 + gapRatio) + minGap)
+ *
+ * 이 공식은 "원본 레이아웃 비율을 유지하면서, 카드+간격이 컨테이너 안에
+ * 겹침 없이 들어가는 최대 카드 크기"를 정확히 구합니다.
+ */
+function computeLayout(
+  positions: SpreadPosition[],
+  containerW: number,
+  containerH: number,
+) {
+  const GAP_RATIO = 0.12; // 카드 크기의 12%를 간격으로
+
+  const xs = positions.map((p) => p.x);
+  const ys = positions.map((p) => p.y);
+
+  const uniqueX = [...new Set(xs)].sort((a, b) => a - b);
+  const uniqueY = [...new Set(ys)].sort((a, b) => a - b);
+
+  const origRangeX = (uniqueX[uniqueX.length - 1] ?? 0) - (uniqueX[0] ?? 0);
+  const origRangeY = (uniqueY[uniqueY.length - 1] ?? 0) - (uniqueY[0] ?? 0);
+
+  const minXGap = uniqueX.length > 1
+    ? Math.min(...uniqueX.slice(1).map((x, i) => x - uniqueX[i]))
+    : 0;
+  const minYGap = uniqueY.length > 1
+    ? Math.min(...uniqueY.slice(1).map((y, i) => y - uniqueY[i]))
+    : 0;
+
+  // 각 축의 최대 카드 크기 계산
+  const maxW = minXGap > 0 && origRangeX > 0
+    ? (minXGap * containerW) / (origRangeX * (1 + GAP_RATIO) + minXGap)
+    : containerW * 0.30; // 단일 열이면 넉넉하게
+
+  const maxH = minYGap > 0 && origRangeY > 0
+    ? (minYGap * containerH) / (origRangeY * (1 + GAP_RATIO) + minYGap)
+    : containerH * 0.40; // 단일 행이면 넉넉하게
+
+  // 2:3 비율 유지하며 양쪽 제한 충족
+  let cardW = maxW;
+  let cardH = cardW * 1.5;
+  if (cardH > maxH) {
+    cardH = maxH;
+    cardW = cardH / 1.5;
+  }
+
+  // 클램프
+  cardW = Math.max(Math.min(Math.round(cardW), 120), 30);
+  cardH = Math.round(cardW * 1.5);
+
+  // 포지션 매핑: 카드 중심이 [cardW/2, containerW - cardW/2] 범위에 들어오도록
+  // position_px = margin + (pos - origMin) / origRange * available
+  const marginX = cardW / 2;
+  const marginY = cardH / 2;
+  const availX = containerW - cardW; // 중심이 이동할 수 있는 범위(px)
+  const availY = containerH - cardH;
+
+  const origMinX = uniqueX[0] ?? 50;
+  const origMinY = uniqueY[0] ?? 50;
+
+  const adjusted: SpreadPosition[] = positions.map((p) => {
+    const px = origRangeX > 0
+      ? marginX + ((p.x - origMinX) / origRangeX) * availX
+      : containerW / 2; // 단일 열이면 중앙
+
+    const py = origRangeY > 0
+      ? marginY + ((p.y - origMinY) / origRangeY) * availY
+      : containerH / 2; // 단일 행이면 중앙
+
+    return { ...p, x: (px / containerW) * 100, y: (py / containerH) * 100 };
+  });
+
+  return { cardW, cardH, positions: adjusted };
+}
+
 export function CardSpread({ selectedCards, spread, revealedPositions }: CardSpreadProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const [containerWidth, setContainerWidth] = useState(0);
@@ -29,89 +107,19 @@ export function CardSpread({ selectedCards, spread, revealedPositions }: CardSpr
     return () => window.removeEventListener("resize", measure);
   }, []);
 
-  // 1단계: 컨테이너 비율 기반 카드 크기 계산
-  const cardDimensions = useMemo(() => {
-    if (!containerWidth || !containerHeight) return { w: 40, h: 60 };
-
-    const count = spread.positions.length;
-
-    // 카드 수가 많을수록 작게, 적을수록 크게
-    // 1장: 컨테이너의 28%, 3장: 20%, 5장: 16%
-    const ratio = count <= 1 ? 0.28 : count <= 3 ? 0.20 : 0.16;
-
-    let cardW = containerWidth * ratio;
-    let cardH = cardW * 1.5;
-
-    // 세로도 넘치지 않도록 제한
-    const maxH = containerHeight * ratio * 1.2;
-    if (cardH > maxH) {
-      cardH = maxH;
-      cardW = cardH / 1.5;
+  const layout = useMemo(() => {
+    if (!containerWidth || !containerHeight) {
+      return { cardW: 40, cardH: 60, positions: spread.positions };
     }
-
-    // 최소/최대 클램프
-    cardW = Math.max(Math.min(cardW, 110), 30);
-    cardH = cardW * 1.5;
-
-    return { w: Math.round(cardW), h: Math.round(cardH) };
-  }, [containerWidth, containerHeight, spread.positions.length]);
-
-  // 2단계: 카드 크기 기반으로 포지션을 동적 재계산
-  const adjustedPositions = useMemo((): SpreadPosition[] => {
-    if (!containerWidth || !containerHeight) return spread.positions;
-
-    const positions = spread.positions;
-    if (positions.length <= 1) return positions;
-
-    // 카드 크기를 컨테이너 비율(%)로 변환
-    const cardWPct = (cardDimensions.w / containerWidth) * 100;
-    const cardHPct = (cardDimensions.h / containerHeight) * 100;
-
-    // 카드 간격 = 카드 크기의 30% (반응형 — 카드가 크면 간격도 커짐)
-    const gapXPct = cardWPct * 0.30;
-    const gapYPct = cardHPct * 0.30;
-
-    // 필요한 최소 중심-중심 거리
-    const requiredDistX = cardWPct + gapXPct;
-    const requiredDistY = cardHPct + gapYPct;
-
-    // 원본 레이아웃의 중심점
-    const xs = positions.map((p) => p.x);
-    const ys = positions.map((p) => p.y);
-    const centerX = (Math.min(...xs) + Math.max(...xs)) / 2;
-    const centerY = (Math.min(...ys) + Math.max(...ys)) / 2;
-
-    // 원본 레이아웃의 최소 인접 거리
-    const uniqueX = [...new Set(xs)].sort((a, b) => a - b);
-    const uniqueY = [...new Set(ys)].sort((a, b) => a - b);
-    const origMinDistX = uniqueX.length > 1
-      ? Math.min(...uniqueX.slice(1).map((x, i) => x - uniqueX[i]))
-      : 100;
-    const origMinDistY = uniqueY.length > 1
-      ? Math.min(...uniqueY.slice(1).map((y, i) => y - uniqueY[i]))
-      : 100;
-
-    // 스케일 팩터: 필요 거리 / 원본 거리 (카드+간격이 확보되도록)
-    const scaleX = origMinDistX > 0 ? requiredDistX / origMinDistX : 1;
-    const scaleY = origMinDistY > 0 ? requiredDistY / origMinDistY : 1;
-
-    // 카드 가장자리가 컨테이너 안에 들어오도록 패딩
-    const padX = cardWPct / 2 + 2;
-    const padY = cardHPct / 2 + 2;
-
-    return positions.map((p) => ({
-      ...p,
-      x: Math.max(padX, Math.min(100 - padX, centerX + (p.x - centerX) * scaleX)),
-      y: Math.max(padY, Math.min(100 - padY, centerY + (p.y - centerY) * scaleY)),
-    }));
-  }, [containerWidth, containerHeight, cardDimensions, spread.positions]);
+    return computeLayout(spread.positions, containerWidth, containerHeight);
+  }, [containerWidth, containerHeight, spread.positions]);
 
   return (
     <div
       ref={containerRef}
-      className="relative w-full mx-auto aspect-[4/3] overflow-hidden"
+      className="relative w-full h-full overflow-hidden"
     >
-      {containerWidth > 0 && containerHeight > 0 && adjustedPositions.map((pos) => {
+      {containerWidth > 0 && containerHeight > 0 && layout.positions.map((pos) => {
         const selectedCard = selectedCards.find((sc) => sc.position === pos.index);
         const isRevealed = revealedPositions.includes(pos.index);
 
@@ -145,13 +153,13 @@ export function CardSpread({ selectedCards, spread, revealedPositions }: CardSpr
                     isFlipped={isRevealed}
                     isSelected={true}
                     isReversed={selectedCard.isReversed}
-                    width={cardDimensions.w}
-                    height={cardDimensions.h}
+                    width={layout.cardW}
+                    height={layout.cardH}
                   />
                 </div>
                 <span
                   className="text-arcana-gold font-serif font-bold drop-shadow-[0_0_4px_rgba(212,175,55,0.4)] truncate text-center"
-                  style={{ fontSize: Math.max(cardDimensions.w * 0.18, 8), maxWidth: cardDimensions.w * 1.5 }}
+                  style={{ fontSize: Math.max(layout.cardW * 0.18, 8), maxWidth: layout.cardW * 1.5 }}
                 >
                   {pos.labelKo}
                 </span>
@@ -159,11 +167,11 @@ export function CardSpread({ selectedCards, spread, revealedPositions }: CardSpr
             ) : (
               <div
                 className="rounded border border-dashed border-arcana-purple/30 flex items-center justify-center bg-arcana-purple/5"
-                style={{ width: cardDimensions.w, height: cardDimensions.h }}
+                style={{ width: layout.cardW, height: layout.cardH }}
               >
                 <span
                   className="text-arcana-gold/60 font-serif font-bold truncate"
-                  style={{ fontSize: Math.max(cardDimensions.w * 0.18, 8) }}
+                  style={{ fontSize: Math.max(layout.cardW * 0.18, 8) }}
                 >
                   {pos.labelKo}
                 </span>


### PR DESCRIPTION
## Summary
- 스프레드 카드 크기·포지션을 동시에 계산하는 computeLayout 공식 적용
- 컨테이너 aspect-[4/3] 제거 → h-full로 부모 전체 높이 활용
- 간격 비율 30% → 12%로 촘촘하게 조정
- 단일 행/열 자동 중앙 정렬 (1장·3장 수직 중앙)

## Test plan
- [ ] 모바일(375px)에서 1장/3장/5장 스프레드가 화면 내 표시되는지 확인
- [ ] 카드 간 겹침 없이 촘촘하게 배치되는지 확인
- [ ] 데스크탑에서 카드 크기가 자연스럽게 확대되는지 확인

https://claude.ai/code/session_01NEeHuJYR7o8aTvaJrM4LCT