### PR TITLE
feat: 리딩 대기 중 캐릭터 연출 — 순차 뒤집기 + 대사 + 미리보기

### DIFF
--- a/src/app/tarot/session/page.tsx
+++ b/src/app/tarot/session/page.tsx
@@ -13,9 +13,11 @@ import { CardSpread } from "@/components/card/CardSpread";
 import { DialogueBox } from "@/components/chat/DialogueBox";
 import { ParticleOverlay } from "@/components/effects/ParticleOverlay";
 import { getCharacterById } from "@/data/characters";
+import { waitingLines, buildCardPreviewLine } from "@/data/characters/waiting-lines";
 import { DeckManager } from "@/services/tarot/deck-manager";
 import { getSpreadForTopic } from "@/data/spreads";
 import { TarotCard, SelectedCard } from "@/types/card";
+import { Mood } from "@/types/character";
 
 const deckManager = new DeckManager();
 
@@ -88,9 +90,47 @@ export default function TarotSessionPage() {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [shuffledDeck, selectedCards, requiredCards]);
 
+  // 대기 연출: 카드 순차 뒤집기 + 캐릭터 대사 + 카드 미리보기
+  const startWaitingSequence = useCallback((cards: SelectedCard[], charId: string) => {
+    const timers: ReturnType<typeof setTimeout>[] = [];
+    const currentSpread = topic ? getSpreadForTopic(topic) : null;
+    const lines = waitingLines[charId] || waitingLines["arcana"];
+
+    // 1단계: 카드 순차 뒤집기 (2초 간격) + 카드 정보 미리보기
+    cards.forEach((sc, i) => {
+      timers.push(setTimeout(() => {
+        setRevealedPositions((prev) => [...prev, sc.position]);
+        setMood(i % 2 === 0 ? "serious" : "mystical");
+
+        // 카드 키워드 미리보기 대사
+        const posLabel = currentSpread?.positions[sc.position]?.labelKo || `위치 ${sc.position + 1}`;
+        const keywords = sc.isReversed ? sc.card.reversed.keywords : sc.card.upright.keywords;
+        const preview = buildCardPreviewLine(charId, sc.card.nameKo, keywords, posLabel);
+        addChatMessage({ id: crypto.randomUUID(), role: "character", content: preview, mood: "serious" as Mood, timestamp: new Date() });
+      }, (i + 1) * 2000));
+    });
+
+    // 2단계: 캐릭터 대기 대사 (카드 뒤집기 끝난 후 3초 간격)
+    const baseDelay = (cards.length + 1) * 2000;
+    lines.forEach((line, i) => {
+      timers.push(setTimeout(() => {
+        setMood(line.mood);
+        addChatMessage({ id: crypto.randomUUID(), role: "character", content: line.content, mood: line.mood, timestamp: new Date() });
+      }, baseDelay + i * 3000));
+    });
+
+    return () => timers.forEach(clearTimeout);
+  }, [topic, addChatMessage, setMood]);
+
   const startReading = async (cards: SelectedCard[]) => {
     setPhase("reading"); setLoading(true); setMood("mystical"); setReadingError(false);
+    // 카드 뒤집기 초기화 (reading 시작 시 전부 뒷면으로)
+    setRevealedPositions([]);
     addChatMessage({ id: crypto.randomUUID(), role: "character", content: "카드가 모두 모였네요... 이제 카드의 이야기를 들어볼게요", mood: "mystical", timestamp: new Date() });
+
+    // 대기 연출 시작 (API 호출과 동시 실행)
+    const stopSequence = startWaitingSequence(cards, characterId || "arcana");
+
     const sessionId = useSessionStore.getState().sessionId;
     try {
       const response = await fetch("/api/tarot/reading", {
@@ -98,6 +138,7 @@ export default function TarotSessionPage() {
         body: JSON.stringify({ sessionId, topic, characterId, userInfo: useSessionStore.getState().userInfo, cards: cards.map((c) => ({ cardId: c.card.id, position: c.position, isReversed: c.isReversed })) }),
       });
       if (!response.ok || !response.body) {
+        stopSequence();
         addChatMessage({ id: crypto.randomUUID(), role: "character", content: "서버 연결에 문제가 생겼어요. 다시 시도해주세요.", mood: "surprised", timestamp: new Date() });
         setMood("surprised");
         setReadingError(true);
@@ -106,9 +147,6 @@ export default function TarotSessionPage() {
       }
       const reader = response.body.getReader();
       const decoder = new TextDecoder();
-
-      const loadingMsgId = crypto.randomUUID();
-      addChatMessage({ id: loadingMsgId, role: "character", content: "카드를 읽고 있어요...", mood: "mystical", timestamp: new Date() });
 
       while (true) {
         const { done, value } = await reader.read();
@@ -120,6 +158,11 @@ export default function TarotSessionPage() {
           try {
             const data = JSON.parse(line.slice(6));
             if (data.done && data.result) {
+              // 연출 중단 — 결과 도착
+              stopSequence();
+              // 모든 카드 뒤집기 완료
+              setRevealedPositions(cards.map((c) => c.position));
+
               setReadingResult(data.result);
               const currentSpread = topic ? getSpreadForTopic(topic) : null;
               if (data.result.cardInterpretations) {
@@ -154,6 +197,7 @@ export default function TarotSessionPage() {
       }
     } catch (e) {
       console.error("리딩 요청 실패:", e);
+      stopSequence();
       addChatMessage({ id: crypto.randomUUID(), role: "character", content: "카드의 메시지를 읽는 데 문제가 생겼어요. 다시 시도해주세요.", mood: "surprised", timestamp: new Date() });
       setMood("surprised");
       setReadingError(true);

--- a/src/data/characters/waiting-lines.ts
+++ b/src/data/characters/waiting-lines.ts
@@ -1,0 +1,61 @@
+import { Mood } from "@/types/character";
+
+interface WaitingLine {
+  content: string;
+  mood: Mood;
+}
+
+/** 리딩 대기 중 캐릭터별 대사 시퀀스 (3초 간격으로 표시) */
+export const waitingLines: Record<string, WaitingLine[]> = {
+  arcana: [
+    { content: "음... 이 카드 조합이 아주 흥미롭네요 ✨", mood: "serious" },
+    { content: "카드의 에너지가 점점 선명해지고 있어요", mood: "mystical" },
+    { content: "수정구슬에 뭔가 비치기 시작했어요... 냥~", mood: "smile" },
+    { content: "거의 다 읽었어요! 조금만 기다려주세요", mood: "surprised" },
+    { content: "와, 정말 의미 있는 메시지가 담겨 있어요!", mood: "smile" },
+  ],
+  miko: [
+    { content: "...영혼의 울림이 느껴집니다", mood: "serious" },
+    { content: "카드의 기운이 하나로 모이고 있습니다", mood: "mystical" },
+    { content: "운명의 실타래가 풀리기 시작합니다", mood: "mystical" },
+    { content: "거의 완성입니다. 조용히 기다려주십시오", mood: "serious" },
+    { content: "카드의 진의가 드러났습니다", mood: "smile" },
+  ],
+  seonhwa: [
+    { content: "어머, 이 배치가 참 독특하네요~", mood: "surprised" },
+    { content: "별의 흐름이 카드와 공명하고 있어요", mood: "mystical" },
+    { content: "부채를 펼쳐 운명의 바람을 읽고 있어요", mood: "mystical" },
+    { content: "거의 다 되었어요, 조금만요~", mood: "smile" },
+    { content: "아름다운 메시지가 보이기 시작했어요", mood: "smile" },
+  ],
+  hoshi: [
+    { content: "오오~ 이 카드 조합 대박인데?! 🌟", mood: "surprised" },
+    { content: "별빛이 반짝반짝 모이고 있어! ✨", mood: "mystical" },
+    { content: "잠깐만~ 거의 다 읽었어!", mood: "smile" },
+    { content: "헐 이거 진짜 재밌는 결과 나올 것 같아!", mood: "surprised" },
+    { content: "다 됐다~! 엄청 기대해도 좋아! 🎉", mood: "smile" },
+  ],
+};
+
+/** 선택한 카드 정보를 캐릭터 말투로 소개하는 템플릿 */
+export function buildCardPreviewLine(
+  characterId: string,
+  cardNameKo: string,
+  keywords: string[],
+  position: string,
+): string {
+  const keywordText = keywords.slice(0, 2).join(", ");
+
+  switch (characterId) {
+    case "arcana":
+      return `[${position}] '${cardNameKo}'... ${keywordText}의 에너지가 느껴지네요`;
+    case "miko":
+      return `[${position}] '${cardNameKo}'... ${keywordText}의 기운이 서려 있습니다`;
+    case "seonhwa":
+      return `[${position}] '${cardNameKo}'... ${keywordText}의 기운이 흐르고 있어요`;
+    case "hoshi":
+      return `[${position}] '${cardNameKo}'! ${keywordText} 느낌이야~`;
+    default:
+      return `[${position}] '${cardNameKo}' — ${keywordText}`;
+  }
+}


### PR DESCRIPTION
## Summary
리딩 대기 중(10~15초) 사용자 이탈을 방지하기 위한 캐릭터 연출 시스템:

- **카드 순차 뒤집기**: reading 진입 시 모든 카드 뒷면 → 2초 간격으로 한 장씩 뒤집기 + glow 이펙트
- **카드 키워드 미리보기**: 뒤집힐 때 해당 카드의 키워드를 캐릭터 말투로 소개 (로컬 데이터, AI 불필요)
- **캐릭터 대기 대사**: 카드 뒤집기 완료 후 3초 간격으로 표정 변화 + 개성 있는 대사 시퀀스 (4캐릭터 × 5대사)
- API 응답 도착 시 연출 즉시 중단 + 결과 전환

## Test plan
- [ ] 리딩 대기 중 카드가 하나씩 뒤집히는지 확인
- [ ] 카드 뒤집힐 때 키워드 미리보기 대사가 표시되는지 확인
- [ ] 캐릭터별(아르카나/미코/선화/호시) 대기 대사와 표정이 다르게 나오는지 확인
- [ ] API 응답이 빨리 오면 연출이 즉시 중단되는지 확인

https://claude.ai/code/session_01NEeHuJYR7o8aTvaJrM4LCT