### PR TITLE
fix: 대기 연출과 UI 충돌 해소 — 스피너·타이핑 제거

### DIFF
--- a/src/app/tarot/session/page.tsx
+++ b/src/app/tarot/session/page.tsx
@@ -17,7 +17,6 @@ import { waitingLines, buildCardPreviewLine } from "@/data/characters/waiting-li
 import { DeckManager } from "@/services/tarot/deck-manager";
 import { getSpreadForTopic } from "@/data/spreads";
 import { TarotCard, SelectedCard } from "@/types/card";
-import { Mood } from "@/types/character";
 
 const deckManager = new DeckManager();
 
@@ -106,7 +105,7 @@ export default function TarotSessionPage() {
         const posLabel = currentSpread?.positions[sc.position]?.labelKo || `위치 ${sc.position + 1}`;
         const keywords = sc.isReversed ? sc.card.reversed.keywords : sc.card.upright.keywords;
         const preview = buildCardPreviewLine(charId, sc.card.nameKo, keywords, posLabel);
-        addChatMessage({ id: crypto.randomUUID(), role: "character", content: preview, mood: "serious" as Mood, timestamp: new Date() });
+        addChatMessage({ id: crypto.randomUUID(), role: "character", content: preview, mood: "serious", timestamp: new Date() });
       }, (i + 1) * 2000));
     });
 
@@ -277,14 +276,7 @@ export default function TarotSessionPage() {
                   spread={spread}
                   revealedPositions={revealedPositions}
                 />
-                {isLoading && (
-                  <div className="absolute inset-0 flex items-center justify-center z-10">
-                    <div className="flex flex-col items-center gap-3">
-                      <div className="w-10 h-10 border-2 border-arcana-purple/30 border-t-arcana-purple rounded-full animate-spin" />
-                      <p className="text-arcana-muted text-xs font-serif">카드를 해석하고 있어요...</p>
-                    </div>
-                  </div>
-                )}
+                {/* 스피너 제거 — 카드 순차 뒤집기 연출이 로딩 상태를 시각적으로 대체 */}
                 {readingError && !isLoading && (
                   <div className="absolute inset-0 flex items-center justify-center z-10">
                     <div className="flex flex-col items-center gap-3">
@@ -397,7 +389,7 @@ export default function TarotSessionPage() {
               <DialogueBox
                 messages={chatMessages}
                 characterName={character?.name ?? ""}
-                isTyping={isLoading && phase === "reading"}
+                isTyping={false}
               />
             </div>
           )}


### PR DESCRIPTION
## Summary
코드 검수에서 발견된 대기 연출 ↔ UI 충돌 이슈 수정:

- DialogueBox `isTyping` 비활성화: 대기 대사가 타이핑 점 애니메이션에 가려지던 문제 해소
- reading 중 스피너 오버레이 제거: 카드 순차 뒤집기 연출과 시각적 충돌 해소
- 미사용 Mood import 및 불필요한 타입 단언 제거

## Test plan
- [ ] 리딩 대기 중 대기 대사가 DialogueBox에 정상 표시되는지 확인
- [ ] 카드 순차 뒤집기 glow 이펙트가 스피너 없이 잘 보이는지 확인

https://claude.ai/code/session_01NEeHuJYR7o8aTvaJrM4LCT