### PR TITLE
fix: 리딩 서버 연결 실패 해소 — GrokProvider 지연 초기화 + sessionId 재시도

### DIFF
--- a/src/app/tarot/session/page.tsx
+++ b/src/app/tarot/session/page.tsx
@@ -130,7 +130,31 @@ export default function TarotSessionPage() {
     // 대기 연출 시작 (API 호출과 동시 실행)
     const stopSequence = startWaitingSequence(cards, characterId || "arcana");
 
-    const sessionId = useSessionStore.getState().sessionId;
+    // sessionId가 아직 없으면 세션 생성 재시도
+    let sessionId = useSessionStore.getState().sessionId;
+    if (!sessionId) {
+      try {
+        const sessionRes = await fetch("/api/tarot/session", {
+          method: "POST", headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ topic }),
+        });
+        const sessionData = await sessionRes.json();
+        if (sessionData.session?.id) {
+          sessionId = sessionData.session.id as string;
+          useSessionStore.getState().setSessionId(sessionId);
+        }
+      } catch { /* 세션 생성 재시도 실패 — 아래에서 처리 */ }
+    }
+
+    if (!sessionId) {
+      stopSequence();
+      addChatMessage({ id: crypto.randomUUID(), role: "character", content: "세션을 생성하지 못했어요. 네트워크를 확인하고 다시 시도해주세요.", mood: "surprised", timestamp: new Date() });
+      setMood("surprised");
+      setReadingError(true);
+      setLoading(false);
+      return;
+    }
+
     try {
       const response = await fetch("/api/tarot/reading", {
         method: "POST", headers: { "Content-Type": "application/json" },
@@ -138,6 +162,8 @@ export default function TarotSessionPage() {
       });
       if (!response.ok || !response.body) {
         stopSequence();
+        const errorText = response.ok ? "응답 스트림 없음" : `서버 오류 (${response.status})`;
+        console.error("리딩 API 응답 실패:", errorText);
         addChatMessage({ id: crypto.randomUUID(), role: "character", content: "서버 연결에 문제가 생겼어요. 다시 시도해주세요.", mood: "surprised", timestamp: new Date() });
         setMood("surprised");
         setReadingError(true);

--- a/src/services/core/grok-provider.ts
+++ b/src/services/core/grok-provider.ts
@@ -1,15 +1,25 @@
 import { AIProvider } from "@/types/service";
 
 export class GrokProvider implements AIProvider {
-  private apiKey: string;
-  private model: string;
+  private _apiKey: string | null = null;
+  private _model: string | null = null;
   private baseUrl = "https://api.x.ai/v1";
 
-  constructor() {
-    const apiKey = process.env.GROK_API_KEY;
-    if (!apiKey) throw new Error("GROK_API_KEY environment variable is required");
-    this.apiKey = apiKey;
-    this.model = process.env.GROK_MODEL || "grok-3";
+  /** 환경변수를 지연 로드 — 모듈 로드 시점이 아니라 첫 호출 시점에 확인 */
+  private get apiKey(): string {
+    if (!this._apiKey) {
+      const key = process.env.GROK_API_KEY;
+      if (!key) throw new Error("GROK_API_KEY environment variable is required");
+      this._apiKey = key;
+    }
+    return this._apiKey;
+  }
+
+  private get model(): string {
+    if (!this._model) {
+      this._model = process.env.GROK_MODEL || "grok-3";
+    }
+    return this._model;
   }
 
   private static readonly TIMEOUT_MS = 60_000; // 60초 타임아웃


### PR DESCRIPTION
## Summary
카드 리딩 시 "서버 연결에 문제가 생겼어요" 에러의 두 가지 원인을 수정:

- **GrokProvider 지연 초기화**: 생성자에서 `process.env.GROK_API_KEY`를 즉시 확인하던 것을 getter로 변경. 모듈 로드 시점(빌드 타임)에 환경변수가 없어도 route가 crash하지 않고, 첫 API 호출 시점에 확인
- **sessionId 재시도**: 세션 생성 API 실패 시 `sessionId`가 null인 채로 reading API를 호출하여 400 에러 발생 → reading 시작 전 자동 재시도 로직 추가

## Test plan
- [ ] GROK_API_KEY 설정 후 카드 리딩이 정상 완료되는지 확인
- [ ] 네트워크 불안정 시 세션 재생성 후 리딩이 진행되는지 확인
- [ ] 세션 생성이 2번 모두 실패하면 명확한 에러 메시지가 표시되는지 확인

https://claude.ai/code/session_01NEeHuJYR7o8aTvaJrM4LCT