### PR TITLE
fix: Supabase 장애 시에도 AI 리딩 정상 진행

### DIFF
--- a/src/app/api/tarot/reading/route.ts
+++ b/src/app/api/tarot/reading/route.ts
@@ -17,13 +17,13 @@ export async function POST(request: NextRequest) {
   try {
     const body = await request.json();
     const { sessionId, topic, characterId, userInfo, cards } = body as {
-      sessionId: string; topic: Topic; characterId?: string;
+      sessionId?: string | null; topic: Topic; characterId?: string;
       userInfo?: { name: string; birthDate: string; gender: string; birthHour: string };
       cards: { cardId: string; position: number; isReversed: boolean }[];
     };
 
-    // 입력 검증
-    if (!sessionId || !topic || !Array.isArray(cards) || cards.length === 0) {
+    // 입력 검증 — sessionId는 선택 (Supabase 연결 실패 시에도 리딩 가능)
+    if (!topic || !Array.isArray(cards) || cards.length === 0) {
       return new Response(JSON.stringify({ error: "Missing required fields" }), { status: 400, headers: { "Content-Type": "application/json" } });
     }
 
@@ -41,7 +41,7 @@ export async function POST(request: NextRequest) {
     const systemPrompt = tarotService.getSystemPrompt(characterId);
     const userInfoPrompt = buildUserInfoPrompt(userInfo);
     const readingPrompt = tarotService.getReadingPrompt({
-      session: { id: sessionId, userId: null, serviceType: "tarot", topic, status: "in_progress",
+      session: { id: sessionId || "anonymous", userId: null, serviceType: "tarot", topic, status: "in_progress",
         spreadType: spreadResolver.resolveForTopic(topic).type, selectedCards, createdAt: new Date(), completedAt: null },
       selectedCards, chatHistory: [], topic,
     });
@@ -55,19 +55,28 @@ export async function POST(request: NextRequest) {
             controller.enqueue(encoder.encode(`data: ${JSON.stringify({ chunk })}\n\n`));
           }
           const result = tarotService.parseResult(fullResponse);
-          const supabase = await createClient();
-          // DB 쿼리 병렬 실행으로 대기 시간 단축
-          const [, readingResult] = await Promise.all([
-            supabase.from("session_cards").insert(
-              cards.map((c) => ({ session_id: sessionId, card_id: c.cardId, position: c.position, is_reversed: c.isReversed }))
-            ),
-            supabase.from("readings").insert({
-              session_id: sessionId, card_interpretation: result.cardInterpretations,
-              overall_reading: result.overallReading, advice: result.advice,
-            }).select("share_token").single(),
-            supabase.from("sessions").update({ status: "completed", completed_at: new Date().toISOString() }).eq("id", sessionId),
-          ]);
-          const shareToken = readingResult.data?.share_token ?? null;
+
+          // DB 저장 — sessionId가 있을 때만 (Supabase 실패해도 리딩 결과는 전달)
+          let shareToken: string | null = null;
+          if (sessionId) {
+            try {
+              const supabase = await createClient();
+              const [, readingResult] = await Promise.all([
+                supabase.from("session_cards").insert(
+                  cards.map((c) => ({ session_id: sessionId, card_id: c.cardId, position: c.position, is_reversed: c.isReversed }))
+                ),
+                supabase.from("readings").insert({
+                  session_id: sessionId, card_interpretation: result.cardInterpretations,
+                  overall_reading: result.overallReading, advice: result.advice,
+                }).select("share_token").single(),
+                supabase.from("sessions").update({ status: "completed", completed_at: new Date().toISOString() }).eq("id", sessionId),
+              ]);
+              shareToken = readingResult.data?.share_token ?? null;
+            } catch (dbError) {
+              console.error("DB 저장 실패 (리딩 결과는 정상 전달):", dbError);
+            }
+          }
+
           controller.enqueue(encoder.encode(`data: ${JSON.stringify({ done: true, result: { ...result, shareToken } })}\n\n`));
         } catch (e) {
           console.error("리딩 생성 실패:", e);

--- a/src/app/tarot/session/page.tsx
+++ b/src/app/tarot/session/page.tsx
@@ -130,31 +130,8 @@ export default function TarotSessionPage() {
     // 대기 연출 시작 (API 호출과 동시 실행)
     const stopSequence = startWaitingSequence(cards, characterId || "arcana");
 
-    // sessionId가 아직 없으면 세션 생성 재시도
-    let sessionId = useSessionStore.getState().sessionId;
-    if (!sessionId) {
-      try {
-        const sessionRes = await fetch("/api/tarot/session", {
-          method: "POST", headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ topic }),
-        });
-        const sessionData = await sessionRes.json();
-        if (sessionData.session?.id) {
-          sessionId = sessionData.session.id as string;
-          useSessionStore.getState().setSessionId(sessionId);
-        }
-      } catch { /* 세션 생성 재시도 실패 — 아래에서 처리 */ }
-    }
-
-    if (!sessionId) {
-      stopSequence();
-      addChatMessage({ id: crypto.randomUUID(), role: "character", content: "세션을 생성하지 못했어요. 네트워크를 확인하고 다시 시도해주세요.", mood: "surprised", timestamp: new Date() });
-      setMood("surprised");
-      setReadingError(true);
-      setLoading(false);
-      return;
-    }
-
+    // sessionId가 없어도 리딩은 진행 (DB 저장만 스킵됨)
+    const sessionId = useSessionStore.getState().sessionId;
     try {
       const response = await fetch("/api/tarot/reading", {
         method: "POST", headers: { "Content-Type": "application/json" },
@@ -162,8 +139,7 @@ export default function TarotSessionPage() {
       });
       if (!response.ok || !response.body) {
         stopSequence();
-        const errorText = response.ok ? "응답 스트림 없음" : `서버 오류 (${response.status})`;
-        console.error("리딩 API 응답 실패:", errorText);
+        console.error("리딩 API 응답 실패:", response.status);
         addChatMessage({ id: crypto.randomUUID(), role: "character", content: "서버 연결에 문제가 생겼어요. 다시 시도해주세요.", mood: "surprised", timestamp: new Date() });
         setMood("surprised");
         setReadingError(true);


### PR DESCRIPTION
## Summary
Supabase 연결 실패 시에도 AI 타로 리딩이 정상 진행되도록 아키텍처 개선:

- **reading API**: `sessionId`를 필수 → 선택으로 변경. 없으면 AI 리딩은 정상 진행, DB 저장만 스킵
- **DB 저장 격리**: sessionId가 있어도 DB 저장 실패 시 리딩 결과는 정상 전달 (try-catch 분리)
- **클라이언트 간소화**: sessionId 재시도 로직 제거 (서버가 graceful 처리)

## Test plan
- [ ] Supabase 미연결 상태에서도 카드 리딩 결과가 정상 표시되는지 확인
- [ ] Supabase 정상 연결 시 DB 저장 + share token 발급 정상 동작 확인
- [ ] "해석에 문제가 발생했어요" 대신 리딩 결과가 표시되는지 확인

https://claude.ai/code/session_01NEeHuJYR7o8aTvaJrM4LCT