### PR TITLE
docs: 문서-코드 정합성 동기화

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,14 +55,15 @@ ArcanaInsight는 애니메이션 캐릭터와 상담하듯 대화하며 타로 �
 ## 기술 스택
 
 - **언어**: TypeScript (strict)
-- **프레임워크**: Next.js 16.2 (App Router) / React 19.2
+- **프레임워크**: Next.js 16.2.1 (App Router) / React 19.2.4
 - **스타일링**: Tailwind CSS v4 (CSS-based `@theme` config)
-- **애니메이션**: Framer Motion v12
+- **애니메이션**: Framer Motion v12.38
 - **AI**: Grok API (xAI) — `src/services/core/grok-provider.ts`에서 추상화
 - **인증**: Supabase Auth Helpers (카카오/구글)
 - **데이터베이스**: Supabase (PostgreSQL)
-- **상태관리**: Zustand v5
-- **패키지 매니저**: pnpm 10.33
+- **상태관리**: Zustand v5.0
+- **패키지 매니저**: pnpm 10.33.0
+- **E2E 테스트**: Playwright (Chromium + WebKit, 3개 디바이스 프로필)
 - **런타임**: Node.js >= 20
 - **CI/CD**: GitHub Actions → Railway 자동 배포
 - **호스팅**: Railway
@@ -248,8 +249,11 @@ supabase/migrations/            # DB 마이그레이션 파일 (번호 순서 �
 ```bash
 pnpm dev              # 개발 서버 실행
 pnpm build            # 프로덕션 빌드
+pnpm start            # 프로덕션 서버 실행
 pnpm lint             # ESLint 실행
-pnpm tsc --noEmit     # TypeScript 타입 체크
+pnpm type-check       # TypeScript 타입 체크 (tsc --noEmit)
+pnpm test:e2e         # Playwright E2E 테스트 (3개 디바이스)
+pnpm test:e2e:ui      # Playwright UI 모드 (시각적 디버깅)
 ```
 
 ## 환경 변수
@@ -274,8 +278,11 @@ NEXT_PUBLIC_SITE_URL=       # 사이트 URL
 
 ### GitHub Actions (`.github/workflows/deploy.yml`)
 
-- **PR → main**: lint + type-check + build 검증
-- **push → main**: lint + type-check + build + Railway 배포
+- **PR → main / push → main**: 3단계 순차 실행
+  1. `lint-and-typecheck`: ESLint + TypeScript 타입 체크
+  2. `build`: 프로덕션 빌드 (환경변수 주입)
+  3. `e2e`: Playwright E2E 테스트 (Chromium + WebKit, 실패 시 리포트 아티팩트 업로드)
+- Railway 배포는 별도 GitHub 연동이 담당 (이 워크플로우는 코드 품질 검증 전용)
 
 ### Railway 설정
 
@@ -291,9 +298,9 @@ NEXT_PUBLIC_SITE_URL=       # 사이트 URL
 ### 1단계: 코드 변경
 - 요청된 수정 사항 구현
 
-### 2단계: 3단계 검증 (tsc + lint + build)
+### 2단계: 3단계 검증 (type-check + lint + build)
 ```bash
-pnpm tsc --noEmit      # TypeScript 타입 체크
+pnpm type-check        # TypeScript 타입 체크
 pnpm lint              # ESLint 코드 품질 검사
 pnpm build             # 프로덕션 빌드 확인
 ```
@@ -311,7 +318,7 @@ pnpm build             # 프로덕션 빌드 확인
 
 ### 자동화 (Claude Code 전용)
 - `.claude/settings.json`의 PreToolUse 훅으로 `git push` 시 자동 검증
-- `scripts/pre-push-checks.sh` 실행: tsc → lint → build 순서
+- `scripts/pre-push-checks.sh` 실행: type-check → lint → build 순서
 - 하나라도 실패하면 push 차단
 
 ## 레이아웃 규칙 (필수 준수)

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ ArcanaInsight는 일본 애니메이션 스타일의 캐릭터와 상담하듯 �
 | 분류 | 기술 |
 |------|------|
 | 언어 | TypeScript (strict) |
-| 프레임워크 | Next.js 16.2 (App Router) · React 19.2 |
+| 프레임워크 | Next.js 16.2.1 (App Router) · React 19.2.4 |
 | 스타일링 | Tailwind CSS v4 (`@theme` CSS-based config) |
 | 애니메이션 | Framer Motion v12 |
 | AI | Grok API (xAI) — SSE 스트리밍 |
@@ -154,8 +154,10 @@ ArcanaInsight는 일본 애니메이션 스타일의 캐릭터와 상담하듯 �
 ```bash
 pnpm dev           # 개발 서버
 pnpm build         # 프로덕션 빌드
+pnpm start         # 프로덕션 서버
 pnpm lint          # ESLint
-pnpm tsc --noEmit  # 타입 체크
+pnpm type-check    # 타입 체크
+pnpm test:e2e      # E2E 테스트 (Desktop/Android/iOS)
 ```
 
 ---

--- a/process.md
+++ b/process.md
@@ -403,22 +403,20 @@ erDiagram
 
 ```mermaid
 flowchart TD
-    subgraph HomePage["홈 페이지 (page.tsx)"]
+    subgraph HomePage["홈 페이지 (page.tsx) — 7개 섹션"]
         H1["HeroSection<br/>풀스크린 히어로 + CTA"]
         H2["CharacterGallery<br/>12캐릭터 카드 갤러리"]
-        H3["ServiceFlow<br/>서비스 이용 흐름 소개"]
-        H4["DailyCard<br/>캐릭터별 일일 운세"]
-        H5["SkinGallery<br/>카드 스킨 6종"]
-        H6["StatsCounter<br/>서비스 통계"]
-        H7["ReviewCarousel<br/>사용자 후기"]
-        H8["FAQ<br/>자주 묻는 질문"]
-        H9["BottomCTA<br/>하단 행동 유도"]
+        H3["DailyCard<br/>캐릭터별 일일 운세"]
+        H4["SkinGallery<br/>카드 스킨 6종"]
+        H5["ServiceFlow<br/>서비스 이용 흐름 소개"]
+        H6["FAQ<br/>자주 묻는 질문"]
+        H7["BottomCTA<br/>하단 행동 유도"]
 
-        H1 --> H2 --> H3 --> H4 --> H5 --> H6 --> H7 --> H8 --> H9
+        H1 --> H2 --> H3 --> H4 --> H5 --> H6 --> H7
     end
 
     H1 --> |"타로 상담 시작"| TAROT["/tarot"]
-    H4 --> |"캐릭터 탭 클릭"| DAILY_API["POST /api/daily-card"]
+    H3 --> |"캐릭터 탭 클릭"| DAILY_API["POST /api/daily-card"]
     H2 --> |"캐릭터 클릭"| CHAR["/character/[id]"]
     CHAR --> TAROT & SAJU["/saju"]
 ```


### PR DESCRIPTION
## Summary
- CLAUDE.md/README.md 기술 스택 패치 버전 반영 (16.2→16.2.1, 19.2→19.2.4 등)
- 명령어 섹션에 `start`, `test:e2e`, `test:e2e:ui` 추가, `tsc --noEmit` → `type-check` 통일
- CI/CD 설명에 e2e job 반영, Playwright 기술 스택 추가
- process.md 홈 페이지 다이어그램을 실제 page.tsx 7개 섹션과 동기화 (미사용 StatsCounter/ReviewCarousel 제거)

## Test plan
- [ ] 문서 내용이 package.json, deploy.yml, page.tsx와 일치하는지 확인
- [ ] `pnpm type-check` 통과
- [ ] `pnpm lint` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)