### PR TITLE
fix: 타로 결과 페이지 깨짐 수정

### DIFF
--- a/src/app/tarot/result/[id]/page.tsx
+++ b/src/app/tarot/result/[id]/page.tsx
@@ -16,8 +16,11 @@ export default async function ResultPage({ params }: { params: Promise<{ id: str
   const { data: reading } = await supabase.from("readings").select("*, sessions(*)").eq("share_token", id).single();
   if (!reading) notFound();
   const session = reading.sessions;
-  const spread = spreads[session.spread_type as SpreadType];
-  const rawInterpretations = reading.card_interpretation as { cardId: string; position: number; interpretation: string; isReversed?: boolean }[];
+  const spreadType = session?.spread_type as SpreadType | undefined;
+  const spread = spreadType ? spreads[spreadType] : undefined;
+  const rawInterpretations = Array.isArray(reading.card_interpretation)
+    ? (reading.card_interpretation as { cardId: string; position: number; interpretation: string; isReversed?: boolean }[])
+    : [];
   const interpretations = rawInterpretations.map((interp) => ({
     ...interp,
     interpretation: cleanReadingText(interp.interpretation),
@@ -50,16 +53,22 @@ export default async function ResultPage({ params }: { params: Promise<{ id: str
           <div className="w-full md:w-[50%] space-y-4">
             <div className="bg-arcana-card/70 backdrop-blur-sm border border-arcana-border rounded-2xl p-6">
               <h2 className="font-serif font-bold text-lg text-arcana-gold mb-4">{spread?.nameKo} 스프레드</h2>
-              <div className="flex flex-wrap justify-center gap-4">
+              <div className={
+                interpretations.length <= 5
+                  ? "flex flex-wrap justify-center gap-4"
+                  : interpretations.length <= 10
+                    ? "grid grid-cols-5 gap-2 justify-items-center"
+                    : "grid grid-cols-6 gap-2 justify-items-center"
+              }>
                 {interpretations.map((interp) => {
                   const card = deckManager.getCardById(interp.cardId);
                   const pos = spread?.positions[interp.position];
                   if (!card) return null;
                   return (
-                    <div key={interp.cardId} className="flex flex-col items-center gap-2">
+                    <div key={interp.cardId} className="flex flex-col items-center gap-1">
                       <ResultCardFace card={card} isReversed={!!interp.isReversed} />
-                      <span className="text-arcana-gold text-xs font-serif font-bold">{pos?.labelKo}</span>
-                      <span className="text-arcana-text text-xs text-center max-w-[80px] truncate">{card.nameKo}</span>
+                      <span className="text-arcana-gold text-[10px] font-serif font-bold text-center leading-tight">{pos?.labelKo}</span>
+                      <span className="text-arcana-text text-[10px] text-center max-w-[60px] truncate">{card.nameKo}</span>
                     </div>
                   );
                 })}
@@ -72,17 +81,22 @@ export default async function ResultPage({ params }: { params: Promise<{ id: str
                 <span className="text-lg">🔮</span>
                 <h2 className="font-serif font-bold text-xl text-arcana-purple">종합 해석</h2>
               </div>
-              <p className="text-arcana-text reading-text">{overallReading}</p>
+              {overallReading
+                ? <p className="text-arcana-text reading-text">{overallReading}</p>
+                : <p className="text-arcana-muted text-sm">해석 결과를 불러올 수 없습니다.</p>
+              }
             </div>
 
             {/* 조언 */}
-            <div className="bg-arcana-card/70 backdrop-blur-sm border border-arcana-gold/30 rounded-2xl p-6">
-              <div className="flex items-center gap-2 mb-3">
-                <span className="text-lg">✨</span>
-                <h2 className="font-serif font-bold text-xl text-arcana-gold">조언</h2>
+            {advice && (
+              <div className="bg-arcana-card/70 backdrop-blur-sm border border-arcana-gold/30 rounded-2xl p-6">
+                <div className="flex items-center gap-2 mb-3">
+                  <span className="text-lg">✨</span>
+                  <h2 className="font-serif font-bold text-xl text-arcana-gold">조언</h2>
+                </div>
+                <p className="text-arcana-text reading-text">{advice}</p>
               </div>
-              <p className="text-arcana-text reading-text">{advice}</p>
-            </div>
+            )}
           </div>
 
           {/* 오른쪽: 카드별 해석 */}

--- a/src/app/tarot/session/page.tsx
+++ b/src/app/tarot/session/page.tsx
@@ -490,12 +490,15 @@ export default function TarotSessionPage() {
                   {/* 카드별 해석 */}
                   {readingResult.cardInterpretations?.map((interp, i) => {
                     const card = selectedCards.find(c => c.card.id === interp.cardId);
+                    const fallbackCard = !card && interp.position < selectedCards.length
+                      ? selectedCards[interp.position] : null;
+                    const displayName = card?.card.nameKo || fallbackCard?.card.nameKo || "";
                     const posLabel = spread?.positions[interp.position]?.labelKo || `위치 ${interp.position + 1}`;
                     return (
                       <div key={`card-${i}`} className="bg-arcana-card/70 backdrop-blur-sm border border-arcana-border rounded-2xl p-4 md:p-5">
                         <div className="flex items-center gap-2 mb-3 pb-2 border-b border-arcana-border/50">
                           <span className="text-arcana-gold text-xs md:text-sm font-serif font-bold px-2 py-0.5 bg-arcana-gold/10 rounded-full">{posLabel}</span>
-                          <span className="text-arcana-text font-bold text-sm md:text-base">{card?.card.nameKo || ""}</span>
+                          <span className="text-arcana-text font-bold text-sm md:text-base">{displayName}</span>
                         </div>
                         <p className="text-arcana-text reading-text">{interp.interpretation}</p>
                       </div>


### PR DESCRIPTION
## Summary
- 공유 결과 페이지(`/tarot/result/[id]`): card_interpretation null 시 크래시 방지, spread_type null 안전 처리
- 카드 수 많은 스프레드(6~12장)에서 그리드 레이아웃으로 자동 분기 (오버플로우 해소)
- overallReading 빈 값 시 기본 메시지 표시, advice 빈 값 시 영역 숨김
- 세션 결과 페이지: AI가 잘못된 cardId 반환 시 position 기반 fallback 매칭으로 카드명 표시

## Test plan
- [ ] 원카드(1장) 결과 페이지 정상 표시
- [ ] 쓰리카드(3장) 결과 페이지 정상 표시
- [ ] 켈틱 크로스(10장) 결과 페이지 카드 그리드 오버플로우 없음
- [ ] 조디악(12장) 결과 페이지 카드 그리드 정상 표시
- [ ] `pnpm type-check` + `pnpm lint` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)