### PR TITLE
chore: 주간 QA 스케줄 토요일 오전 9시로 변경

### DIFF
--- a/.github/workflows/weekly-qa.yml
+++ b/.github/workflows/weekly-qa.yml
@@ -2,8 +2,8 @@ name: Weekly QA — 주간 품질 테스트
 
 on:
   schedule:
-    # 매주 월요일 오전 9시 (KST) = 일요일 24:00 UTC
-    - cron: "0 0 * * 1"
+    # 매주 토요일 오전 9시 (KST) = 금요일 24:00 UTC
+    - cron: "0 0 * * 6"
   workflow_dispatch: # 수동 실행 가능
 
 jobs:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -286,7 +286,7 @@ NEXT_PUBLIC_SITE_URL=       # 사이트 URL
 
 ### 주간 QA (`.github/workflows/weekly-qa.yml`)
 
-- **매주 월요일 오전 9시 (KST)** 자동 실행 + `workflow_dispatch`로 수동 실행 가능
+- **매주 토요일 오전 9시 (KST)** 자동 실행 + `workflow_dispatch`로 수동 실행 가능
 - 4개 job 병렬: quality-check → e2e-desktop / e2e-mobile-android / e2e-mobile-ios
 - 디바이스별 Playwright 리포트 30일 보존
 - **실패 시 자동 GitHub Issue 생성** (`🚨 주간 QA 실패` 라벨: bug, qa)


### PR DESCRIPTION
## Summary
- 주간 QA cron: `0 0 * * 1` (월요일) → `0 0 * * 6` (토요일)
- CLAUDE.md 문서 동기화

## Test plan
- [ ] cron 표현식 확인: `0 0 * * 6` = 매주 토 00:00 UTC = 토 09:00 KST

🤖 Generated with [Claude Code](https://claude.com/claude-code)