### PR TITLE
fix: 리딩 결과 텍스트 단락 분리 깨짐 수정

### DIFF
--- a/src/app/saju/result/[id]/page.tsx
+++ b/src/app/saju/result/[id]/page.tsx
@@ -3,6 +3,7 @@ import Image from "next/image";
 import { createClient } from "@/lib/supabase/server";
 import { cleanReadingText } from "@/services/core/text-cleaner";
 import { SajuResultClient } from "./SajuResultClient";
+import { ReadingText } from "@/components/common/ReadingText";
 import { SajuResultShareButton } from "./SajuResultShareButton";
 import type { SajuResult } from "@/services/saju/saju-types";
 
@@ -58,7 +59,7 @@ export default async function SajuResultPage({ params }: { params: Promise<{ id:
                 <span className="text-lg">☯</span>
                 <h2 className="text-arcana-purple font-serif font-bold text-base md:text-lg">종합 해석</h2>
               </div>
-              <p className="text-arcana-text reading-text">{overallReading}</p>
+              <ReadingText text={overallReading} />
             </div>
           )}
 
@@ -68,7 +69,7 @@ export default async function SajuResultPage({ params }: { params: Promise<{ id:
                 <span className="text-lg">🔍</span>
                 <h2 className="text-arcana-gold font-serif font-bold text-base md:text-lg">주제별 해석</h2>
               </div>
-              <p className="text-arcana-text reading-text">{topicReading}</p>
+              <ReadingText text={topicReading} />
             </div>
           )}
 
@@ -78,7 +79,7 @@ export default async function SajuResultPage({ params }: { params: Promise<{ id:
                 <span className="text-lg">✨</span>
                 <h2 className="text-arcana-gold font-serif font-bold text-base md:text-lg">조언</h2>
               </div>
-              <p className="text-arcana-text reading-text">{advice}</p>
+              <ReadingText text={advice} />
             </div>
           )}
         </div>

--- a/src/app/saju/session/page.tsx
+++ b/src/app/saju/session/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState, useRef } from "react";
 import { useRouter } from "next/navigation";
 import Image from "next/image";
+import { ReadingText } from "@/components/common/ReadingText";
 import { motion } from "framer-motion";
 import { useSajuSessionStore } from "@/hooks/useSajuSession";
 import { useCharacterStore } from "@/hooks/useCharacter";
@@ -182,7 +183,7 @@ export default function SajuSessionPage() {
                       <span className="text-lg">☯</span>
                       <span className="text-arcana-purple font-serif font-bold text-base md:text-lg">종합 해석</span>
                     </div>
-                    <p className="text-arcana-text reading-text">{readingResult.overallReading}</p>
+                    <ReadingText text={readingResult.overallReading} />
                   </div>
                 )}
 
@@ -192,7 +193,7 @@ export default function SajuSessionPage() {
                       <span className="text-lg">🔍</span>
                       <span className="text-arcana-gold font-serif font-bold text-base md:text-lg">주제별 해석</span>
                     </div>
-                    <p className="text-arcana-text reading-text">{readingResult.topicReading}</p>
+                    <ReadingText text={readingResult.topicReading || ""} />
                   </div>
                 )}
 
@@ -204,7 +205,7 @@ export default function SajuSessionPage() {
                       <span className="text-lg">✨</span>
                       <span className="text-arcana-gold font-serif font-bold text-base md:text-lg">조언</span>
                     </div>
-                    <p className="text-arcana-text reading-text">{readingResult.advice}</p>
+                    <ReadingText text={readingResult.advice} />
                   </div>
                 )}
                 <div ref={resultBottomRef} />

--- a/src/app/tarot/result/[id]/page.tsx
+++ b/src/app/tarot/result/[id]/page.tsx
@@ -7,6 +7,7 @@ import { spreads } from "@/data/spreads";
 import { SpreadType } from "@/types/session";
 import { ResultShareButton } from "./ResultShareButton";
 import { ResultCardFace } from "./ResultCardFace";
+import { ReadingText } from "@/components/common/ReadingText";
 
 const deckManager = new DeckManager();
 
@@ -82,7 +83,7 @@ export default async function ResultPage({ params }: { params: Promise<{ id: str
                 <h2 className="font-serif font-bold text-xl text-arcana-purple">종합 해석</h2>
               </div>
               {overallReading
-                ? <p className="text-arcana-text reading-text">{overallReading}</p>
+                ? <ReadingText text={overallReading} />
                 : <p className="text-arcana-muted text-sm">해석 결과를 불러올 수 없습니다.</p>
               }
             </div>
@@ -94,7 +95,7 @@ export default async function ResultPage({ params }: { params: Promise<{ id: str
                   <span className="text-lg">✨</span>
                   <h2 className="font-serif font-bold text-xl text-arcana-gold">조언</h2>
                 </div>
-                <p className="text-arcana-text reading-text">{advice}</p>
+                <ReadingText text={advice} />
               </div>
             )}
           </div>
@@ -121,7 +122,7 @@ export default async function ResultPage({ params }: { params: Promise<{ id: str
                       </div>
                     </div>
                   </div>
-                  <p className="text-arcana-text reading-text">{interp.interpretation}</p>
+                  <ReadingText text={interp.interpretation} />
                 </div>
               );
             })}

--- a/src/app/tarot/session/page.tsx
+++ b/src/app/tarot/session/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useCallback, useState, useRef } from "react";
 import { useRouter } from "next/navigation";
 import Image from "next/image";
+import { ReadingText } from "@/components/common/ReadingText";
 import { motion, AnimatePresence } from "framer-motion";
 import { useSessionStore } from "@/hooks/useSession";
 import { useCharacterStore } from "@/hooks/useCharacter";
@@ -500,7 +501,7 @@ export default function TarotSessionPage() {
                           <span className="text-arcana-gold text-xs md:text-sm font-serif font-bold px-2 py-0.5 bg-arcana-gold/10 rounded-full">{posLabel}</span>
                           <span className="text-arcana-text font-bold text-sm md:text-base">{displayName}</span>
                         </div>
-                        <p className="text-arcana-text reading-text">{interp.interpretation}</p>
+                        <ReadingText text={interp.interpretation} />
                       </div>
                     );
                   })}
@@ -512,7 +513,7 @@ export default function TarotSessionPage() {
                         <span className="text-lg">🔮</span>
                         <span className="text-arcana-purple font-serif font-bold text-base md:text-lg">종합 해석</span>
                       </div>
-                      <p className="text-arcana-text reading-text">{readingResult.overallReading}</p>
+                      <ReadingText text={readingResult.overallReading} />
                     </div>
                   )}
 
@@ -523,7 +524,7 @@ export default function TarotSessionPage() {
                         <span className="text-lg">✨</span>
                         <span className="text-arcana-gold font-serif font-bold text-base md:text-lg">조언</span>
                       </div>
-                      <p className="text-arcana-text reading-text">{readingResult.advice}</p>
+                      <ReadingText text={readingResult.advice} />
                     </div>
                   )}
 

--- a/src/components/common/ReadingText.tsx
+++ b/src/components/common/ReadingText.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+interface ReadingTextProps {
+  text: string;
+  className?: string;
+}
+
+/** AI 리딩 텍스트를 단락별로 분리하여 렌더링 */
+export function ReadingText({ text, className = "" }: ReadingTextProps) {
+  // 리터럴 \\n이 남아있을 경우 실제 줄바꿈으로 변환
+  const normalized = text.replace(/\\n/g, "\n");
+
+  // 빈 줄(\n\n) 기준으로 단락 분리
+  const paragraphs = normalized
+    .split(/\n{2,}/)
+    .map((p) => p.trim())
+    .filter(Boolean);
+
+  if (paragraphs.length === 0) return null;
+
+  return (
+    <div className={`space-y-3 ${className}`}>
+      {paragraphs.map((paragraph, i) => (
+        <p key={i} className="text-arcana-text reading-text whitespace-pre-wrap">
+          {paragraph}
+        </p>
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- 종합 해석, 카드별 해석, 조언 텍스트가 단락 구분 없이 한 덩어리로 표시되던 문제 수정
- `ReadingText` 공통 컴포넌트 신규 생성 — `\n\n` 기준 단락 분리 후 개별 `<p>` 태그 렌더링
- 리터럴 `\n` 잔여물도 실제 줄바꿈으로 변환
- 타로 세션/공유 결과, 사주 세션/공유 결과 4개 페이지 전체 적용

## Test plan
- [ ] 타로 리딩 완료 후 종합 해석이 단락별로 분리되어 표시되는지 확인
- [ ] 공유 결과 페이지에서도 동일하게 단락 분리 확인
- [ ] 사주 결과 페이지 종합/주제별/조언 모두 단락 분리 확인
- [ ] 원카드~조디악 다양한 스프레드에서 카드별 해석 텍스트 정상 표시

🤖 Generated with [Claude Code](https://claude.com/claude-code)