### PR TITLE
ci: QA 프로세스 완전 자동화 루프 구축

### DIFF
--- a/.github/workflows/qa-recheck.yml
+++ b/.github/workflows/qa-recheck.yml
@@ -1,0 +1,43 @@
+name: QA Recheck — 수정 후 자동 재검증
+
+# QA 실패 Issue가 열려있는 상태에서 main에 push되면 자동으로 주간 QA 재실행
+on:
+  push:
+    branches: [main]
+
+jobs:
+  check-open-qa-issues:
+    name: QA Issue 확인
+    runs-on: ubuntu-latest
+    outputs:
+      has_open_issues: ${{ steps.check.outputs.has_issues }}
+    steps:
+      - uses: actions/github-script@v7
+        id: check
+        with:
+          script: |
+            const { data: issues } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: 'qa',
+              state: 'open',
+            });
+            const hasIssues = issues.some(i => i.title.startsWith('🚨 주간 QA 실패'));
+            core.setOutput('has_issues', hasIssues ? 'true' : 'false');
+
+  trigger-recheck:
+    name: 주간 QA 재실행 트리거
+    runs-on: ubuntu-latest
+    needs: check-open-qa-issues
+    if: needs.check-open-qa-issues.outputs.has_open_issues == 'true'
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'weekly-qa.yml',
+              ref: 'main',
+            });
+            console.log('🔄 QA 실패 Issue가 열려있어 주간 QA를 자동 재실행합니다.');

--- a/.github/workflows/weekly-qa.yml
+++ b/.github/workflows/weekly-qa.yml
@@ -139,12 +139,26 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: GitHub Issue 생성
+      - name: 실패 상세 수집 및 Issue 생성
         uses: actions/github-script@v7
         with:
           script: |
             const date = new Date().toISOString().split('T')[0];
             const runUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+
+            // 실패한 job 목록 수집
+            const { data: jobs } = await github.rest.actions.listJobsForWorkflowRun({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: context.runId,
+            });
+            const failedJobs = jobs.jobs
+              .filter(j => j.conclusion === 'failure')
+              .map(j => `- **${j.name}**: [로그 확인](${j.html_url})`);
+            const passedJobs = jobs.jobs
+              .filter(j => j.conclusion === 'success')
+              .map(j => `- ✅ ${j.name}`);
+
             await github.rest.issues.create({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -153,12 +167,56 @@ jobs:
                 `## 주간 품질 테스트 실패`,
                 ``,
                 `**실행 일시**: ${date}`,
-                `**워크플로우**: [Weekly QA 실행 결과](${runUrl})`,
+                `**워크플로우**: [실행 결과](${runUrl})`,
                 ``,
-                `위 링크에서 실패 상세 및 Playwright 리포트를 확인해주세요.`,
+                `### 실패한 항목`,
+                ...failedJobs,
+                ``,
+                `### 통과한 항목`,
+                ...passedJobs,
+                ``,
+                `### 수정 프로세스`,
+                `1. 위 실패 로그 및 Playwright 리포트 확인`,
+                `2. \`fix/*\` 브랜치에서 수정 → PR 생성`,
+                `3. PR CI 통과 → 머지 → 주간 QA 자동 재검증`,
+                `4. 재검증 통과 시 이 Issue 자동 닫힘`,
                 ``,
                 `---`,
                 `*이 이슈는 GitHub Actions에 의해 자동 생성되었습니다.*`,
               ].join('\n'),
               labels: ['bug', 'qa'],
             });
+
+  # QA 전체 통과 시 열린 QA Issue 자동 닫기
+  close-resolved-issues:
+    name: 통과 시 QA Issue 닫기
+    runs-on: ubuntu-latest
+    needs: [quality-check, e2e-desktop, e2e-mobile-android, e2e-mobile-ios]
+    if: success()
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const { data: issues } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: 'qa',
+              state: 'open',
+            });
+            for (const issue of issues) {
+              if (issue.title.startsWith('🚨 주간 QA 실패')) {
+                await github.rest.issues.update({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issue.number,
+                  state: 'closed',
+                  state_reason: 'completed',
+                });
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issue.number,
+                  body: `✅ 주간 QA 재검증 통과 — 자동 닫힘\n\n[검증 결과](https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId})`,
+                });
+              }
+            }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -302,7 +302,31 @@ NEXT_PUBLIC_SITE_URL=       # 사이트 URL
 - **매주 토요일 오전 9시 (KST)** 자동 실행 + `workflow_dispatch`로 수동 실행 가능
 - 4개 job 병렬: quality-check → e2e-desktop / e2e-mobile-android / e2e-mobile-ios
 - 디바이스별 Playwright 리포트 30일 보존
-- **실패 시 자동 GitHub Issue 생성** (`🚨 주간 QA 실패` 라벨: bug, qa)
+- **실패 시**: 자동 GitHub Issue 생성 (실패 job 목록 + 로그 링크 + 수정 프로세스 안내)
+- **통과 시**: 열린 QA Issue 자동 닫기 + 검증 결과 코멘트
+
+### QA 자동 재검증 (`.github/workflows/qa-recheck.yml`)
+
+- QA 실패 Issue(`🚨 주간 QA 실패`)가 열려있는 상태에서 main에 push 시 자동으로 주간 QA 재실행
+- 재실행 → 전체 통과 시 → QA Issue 자동 닫힘 (완전 자동 루프)
+
+### QA 프로세스 전체 흐름
+
+```
+주간 QA 실행 (토요일 09:00)
+  ├─ 통과 → 열린 QA Issue 자동 닫기 → 끝
+  └─ 실패 → Issue 자동 생성 (실패 상세 + 수정 안내)
+       └─ fix/* 브랜치 수정 → PR CI 통과 → main 머지
+            └─ QA Issue 열림 감지 → 주간 QA 자동 재실행
+                 ├─ 통과 → Issue 자동 닫기 → 끝
+                 └─ 실패 → Issue 업데이트 → 수정 반복
+```
+
+### 브랜치 보호 규칙 (GitHub Settings에서 수동 설정 필요)
+
+- `main` 브랜치에 **branch protection rule** 적용
+- **Required status checks**: `Lint & Type Check`, `Build`, `E2E Tests` 통과 필수
+- CI 실패 시 main 머지 자체가 차단되어 Railway 배포도 자동으로 방어됨
 
 ### Railway 설정
 


### PR DESCRIPTION
## Summary
기존 QA 파이프라인의 3가지 GAP을 해소하여 완전 자동화 루프를 구축합니다.

### 개선 1: 주간 QA Issue 상세 정보
- 실패 job 목록 + 로그 링크를 Issue 본문에 포함
- 수정 프로세스 안내 (fix 브랜치 → PR → 머지 → 자동 재검증)

### 개선 2: 자동 Issue 닫기
- 주간 QA 전체 통과 시 열린 QA Issue(`🚨 주간 QA 실패`) 자동 닫기 + 검증 결과 코멘트

### 개선 3: 자동 재검증 (`qa-recheck.yml` 신규)
- QA 실패 Issue가 열린 상태에서 main에 push 시 주간 QA를 workflow_dispatch로 자동 재실행
- 재검증 통과 → Issue 자동 닫기 → 완전 자동 루프

### 브랜치 보호 규칙 (수동 설정 필요)
- GitHub Settings → Branch protection rules → main
- Required status checks: `Lint & Type Check`, `Build`, `E2E Tests`
- CI 실패 시 main 머지 차단 → Railway 배포 자동 방어

## Test plan
- [ ] workflow_dispatch로 weekly-qa 수동 실행 → 실패 시 Issue에 상세 정보 포함 확인
- [ ] 전체 통과 시 열린 QA Issue 자동 닫힘 확인
- [ ] GitHub Settings에서 브랜치 보호 규칙 설정

🤖 Generated with [Claude Code](https://claude.com/claude-code)