### PR TITLE
fix: 스프레드된 카드 간헐적 선택 불가 수정

### DIFF
--- a/src/components/card/CardDeck.tsx
+++ b/src/components/card/CardDeck.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState, useEffect, useRef, useCallback } from "react";
+import { useMemo, useState, useEffect, useRef } from "react";
 import { motion } from "framer-motion";
 import { TarotCard } from "@/types/card";
 import { CardItem } from "./CardItem";
@@ -19,7 +19,6 @@ export function CardDeck({ cards, isSpread, selectedIndices, onCardSelect }: Car
   const [containerWidth, setContainerWidth] = useState(0);
   const [containerHeight, setContainerHeight] = useState(0);
   const [hoveredIndex, setHoveredIndex] = useState<number | null>(null);
-  const cardRefs = useRef<Map<number, HTMLDivElement>>(new Map());
 
   useEffect(() => {
     const measure = () => {
@@ -79,41 +78,16 @@ export function CardDeck({ cards, isSpread, selectedIndices, onCardSelect }: Car
 
   const displayCards = useMemo(() => cards.slice(0, layout.maxDisplay), [cards, layout.maxDisplay]);
 
-  /** 컨테이너 클릭 → 클릭 좌표에 있는 가장 위(z-index 높은) 카드를 선택 */
-  const handleContainerClick = useCallback((e: React.MouseEvent) => {
-    if (!containerRef.current) return;
-    const containerRect = containerRef.current.getBoundingClientRect();
-    const clickX = e.clientX - containerRect.left;
-    const clickY = e.clientY - containerRect.top;
-
-    // z-index가 높은 카드(인덱스 큰 카드)부터 역순으로 검사 → 첫 히트가 시각적 최상단
-    for (let i = displayCards.length - 1; i >= 0; i--) {
-      const el = cardRefs.current.get(i);
-      if (!el || selectedIndices.includes(i)) continue;
-
-      const rect = el.getBoundingClientRect();
-      const inX = clickX >= rect.left - containerRect.left && clickX <= rect.right - containerRect.left;
-      const inY = clickY >= rect.top - containerRect.top && clickY <= rect.bottom - containerRect.top;
-
-      if (inX && inY) {
-        onCardSelect(i);
-        return;
-      }
-    }
-  }, [displayCards.length, selectedIndices, onCardSelect]);
-
   return (
     <div
       ref={containerRef}
-      className="relative w-full flex items-center justify-center min-h-[160px] md:min-h-[280px] h-full cursor-pointer"
-      onClick={handleContainerClick}
+      className="relative w-full flex items-center justify-center min-h-[160px] md:min-h-[280px] h-full"
     >
       {containerWidth > 0 && displayCards.map((card, index) => {
         const isSelected = selectedIndices.includes(index);
         const totalCards = displayCards.length;
         const half = totalCards / 2;
-        // 아크 각도: 카드 수에 따라 조절 (많으면 총 각도 넓게, 개별 각도는 ��게)
-        const maxArc = Math.min(totalCards * 0.9, 40); // ��대 40도 범위 (겹침 방지)
+        const maxArc = Math.min(totalCards * 0.9, 40);
         const angle = isSpread ? (index - half) * (maxArc / totalCards) : 0;
         const xOffset = isSpread ? (index - half) * layout.overlap : (index - half) * 1.5;
         const yOffset = isSpread
@@ -123,7 +97,6 @@ export function CardDeck({ cards, isSpread, selectedIndices, onCardSelect }: Car
         return (
           <motion.div
             key={card.id}
-            ref={(el) => { if (el) cardRefs.current.set(index, el); }}
             initial={{ x: 0, y: 50, rotate: 0, opacity: 0 }}
             animate={{
               x: xOffset,
@@ -138,8 +111,9 @@ export function CardDeck({ cards, isSpread, selectedIndices, onCardSelect }: Car
               damping: 18,
               delay: isSpread ? index * 0.015 : 0,
             }}
-            className="absolute pointer-events-none"
+            className="absolute cursor-pointer"
             style={{ zIndex: isSelected ? 0 : hoveredIndex === index ? 200 : index }}
+            onClick={() => { if (!isSelected) onCardSelect(index); }}
             onPointerEnter={() => setHoveredIndex(index)}
             onPointerLeave={() => setHoveredIndex(null)}
           >


### PR DESCRIPTION
## Summary
카드 스프레드 후 간헐적으로 카드를 클릭/터치해도 선택되지 않던 문제 수정.

**근본 원인**: `pointer-events-none` + `getBoundingClientRect()` 좌표 기반 히트 테스트
- 카드에 `rotate` 변환 적용 시 AABB(축 정렬 경계 상자)와 시각적 영역 불일치
- Framer Motion spring 애니메이션 진행 중 좌표 부정확
- `onPointerEnter/Leave` 비작동으로 hover z-index 부스트 비활성화

**수정**:
- `pointer-events-none` 제거 → 각 카드에 직접 `onClick` 핸들러
- 좌표 기반 히트 테스트(`handleContainerClick`) 완전 제거
- 코드 31줄 삭감 (159줄 → 134줄)

## Test plan
- [ ] 카드 스프레드 후 좌측/중앙/우측 카드 모두 선택 가능
- [ ] 모바일 터치로 카드 선택 가능
- [ ] 이미 선택된 카드 재클릭 시 무시
- [ ] hover 시 카드가 앞으로 올라오는 효과 작동

🤖 Generated with [Claude Code](https://claude.com/claude-code)