### PR TITLE
fix: 카드 미선택 상태에서 리딩 진행되는 race condition 수정

### DIFF
--- a/src/app/tarot/session/page.tsx
+++ b/src/app/tarot/session/page.tsx
@@ -37,7 +37,9 @@ export default function TarotSessionPage() {
   const [selectedIndices, setSelectedIndices] = useState<number[]>([]);
   const [revealedPositions, setRevealedPositions] = useState<number[]>([]);
   const [readingError, setReadingError] = useState(false);
-  const [pendingConfirm, setPendingConfirm] = useState(false);
+  const [pendingConfirm, _setPendingConfirm] = useState(false);
+  const pendingConfirmRef = useRef(false);
+  const setPendingConfirm = (v: boolean) => { pendingConfirmRef.current = v; _setPendingConfirm(v); };
   const [confirmEachCard, setConfirmEachCard] = useState(() => {
     if (typeof window !== "undefined") {
       return localStorage.getItem("arcana-confirm-each-card") !== "false";
@@ -97,9 +99,9 @@ export default function TarotSessionPage() {
   }, [topic]);
 
   const handleCardSelect = useCallback((index: number) => {
-    // 항상 fresh 스토어 상태를 읽어 stale closure 방지
+    // 항상 fresh 상태를 읽어 stale closure 방지
     const { selectedCards: currentCards, requiredCards: required } = useSessionStore.getState();
-    if (currentCards.length >= required || pendingConfirm) return;
+    if (currentCards.length >= required || pendingConfirmRef.current) return;
 
     const card = shuffledDeck[index];
     const isReversed = Math.random() > 0.5;
@@ -114,7 +116,8 @@ export default function TarotSessionPage() {
     const isLast = currentCount >= required;
 
     if (isLast && !confirmEachCard) {
-      // 확인 모드 OFF + 마지막 카드 → 자동으로 리딩 시작
+      // 확인 모드 OFF + 마지막 카드 → 자동으로 리딩 시작 (즉시 잠금으로 중복 방지)
+      setPendingConfirm(true);
       setTimeout(() => {
         const allCards = useSessionStore.getState().selectedCards;
         startReading(allCards);
@@ -133,7 +136,7 @@ export default function TarotSessionPage() {
       }, 500);
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [shuffledDeck, pendingConfirm, confirmEachCard, selectCard, setMood, addChatMessage]);
+  }, [shuffledDeck, confirmEachCard, selectCard, setMood, addChatMessage]);
 
   /** 확인 → 마지막 카드면 리딩 시작, 아니면 다음 카드 선택 계속 */
   const handleConfirmCard = useCallback(() => {


### PR DESCRIPTION
## Summary
빠른 연속 클릭 시 React useState 배칭으로 `pendingConfirm` 가드가 뚫려 카드를 다 선택하지 않았는데 리딩으로 넘어가는 문제 수정.

### 원인
- `pendingConfirm`이 useState로 관리 → 빠른 클릭 시 이전 렌더의 `false` 참조 (stale closure)
- `confirmEachCard=false` 자동 진행 경로에서 잠금 없이 startReading 호출

### 수정
- `pendingConfirmRef` (useRef) 도입: handleCardSelect에서 동기적 ref 값으로 가드
- `setPendingConfirm` 래퍼 함수: ref + state 동시 업데이트
- 자동 진행 시에도 `setPendingConfirm(true)` 즉시 호출

## Test plan
- [ ] 7장 스프레드: 빠르게 연속 클릭해도 7장 완료 전 리딩 미시작
- [ ] 확인 모드 ON: 매 카드 확인 → 다 선택 후 리딩 시작
- [ ] 확인 모드 OFF: 마지막 카드 자동 진행 정상

🤖 Generated with [Claude Code](https://claude.com/claude-code)