### PR TITLE
fix: 조디악 휠 1하우스/12하우스 카드 좌표 겹침 수정

### DIFF
--- a/src/data/spreads/index.ts
+++ b/src/data/spreads/index.ts
@@ -96,7 +96,7 @@ export const spreads: Record<SpreadType, SpreadDefinition> = {
     type: "zodiac", name: "Zodiac Wheel Spread", nameKo: "조디악 휠",
     description: "점성술 12하우스에 카드를 배치하여 인생 전반을 종합 분석합니다.",
     positions: [
-      { index: 0, label: "1st House — Self", labelKo: "1하우스 — 자아", x: 50, y: 5 },
+      { index: 0, label: "1st House — Self", labelKo: "1하우스 — 자아", x: 50, y: 2 },
       { index: 1, label: "2nd House — Finance", labelKo: "2하우스 — 재정", x: 73, y: 12 },
       { index: 2, label: "3rd House — Communication", labelKo: "3하우스 — 소통", x: 90, y: 30 },
       { index: 3, label: "4th House — Home", labelKo: "4하우스 — 가정", x: 95, y: 55 },
@@ -107,7 +107,7 @@ export const spreads: Record<SpreadType, SpreadDefinition> = {
       { index: 8, label: "9th House — Philosophy", labelKo: "9하우스 — 철학/여행", x: 5, y: 55 },
       { index: 9, label: "10th House — Career", labelKo: "10하우스 — 커리어", x: 10, y: 30 },
       { index: 10, label: "11th House — Community", labelKo: "11하우스 — 우정/커뮤니티", x: 27, y: 12 },
-      { index: 11, label: "12th House — Spirituality", labelKo: "12하우스 — 영성/카르마", x: 50, y: 5 },
+      { index: 11, label: "12th House — Spirituality", labelKo: "12하우스 — 영성/카르마", x: 30, y: 5 },
     ],
   },
   "tree-of-life": {


### PR DESCRIPTION
## Summary
조디악 휠(12장) 스프레드에서 1하우스(index:0)와 12하우스(index:11)가 동일 좌표 `(50, 5)`로 정의되어 카드가 겹침.

카드 뒤집기 연출 시 12시 방향 카드가 먼저 뒤집혔다가 원래대로 돌아가는 것처럼 보이는 현상.

### 수정
- 1하우스: `(50, 5)` → `(50, 2)` (12시 정상단)
- 12하우스: `(50, 5)` → `(30, 5)` (11시 방향으로 분리)

## Test plan
- [ ] 조디악 휠 스프레드: 12장 카드가 모두 개별 위치에 표시
- [ ] 카드 뒤집기 연출 시 겹침 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)