### PR TITLE
fix: n8n Spec Tracker Polling 방식 변경

### DIFF
--- a/n8n/README.md
+++ b/n8n/README.md
@@ -36,22 +36,13 @@ n8n 대시보드 → Workflows → Import from File → 아래 JSON 파일 선�
 - `workflow-quality-monitor.json` — 일일 리딩 품질 모니터링
 - `workflow-weekly-report.json` — 주간 운영 리포트
 
-### 4. GitHub Webhook 설정
-
-`workflow-spec-tracker.json` import 후 n8n이 생성하는 Webhook URL을 GitHub에 등록:
-
-1. GitHub → Repository Settings → Webhooks → Add webhook
-2. Payload URL: n8n이 제공하는 Webhook URL
-3. Content type: `application/json`
-4. Events: "Issues" 선택
-5. Active 체크 → Add webhook
-
 ## 워크플로우 설명
 
 ### 1. Spec Tracker (`workflow-spec-tracker.json`)
-- **트리거**: GitHub Issue에 `spec` 라벨이 붙을 때
-- **동작**: Issue 본문을 파싱 → GitHub Actions `workflow_dispatch` 트리거 → Issue에 "구현 시작" 코멘트
-- **용도**: SuperGrok에서 확정한 스펙 → Claude CLI 자동 구현 연결
+- **트리거**: 5분마다 폴링 (localhost 환경 대응, Webhook/ngrok 불필요)
+- **동작**: `spec` 라벨 + `open` 상태 Issue 조회 → 미처리 Issue에 `in-progress` 라벨 추가 + 구현 안내 코멘트
+- **용도**: SuperGrok에서 확정한 스펙 → Claude CLI 구현 알림
+- **중복 방지**: `in-progress` 라벨이 이미 붙은 Issue는 건너뜀
 
 ### 2. Quality Monitor (`workflow-quality-monitor.json`)
 - **트리거**: 매일 오전 9시 (KST)

--- a/n8n/workflow-spec-tracker.json
+++ b/n8n/workflow-spec-tracker.json
@@ -1,68 +1,108 @@
 {
-  "name": "ArcanaInsight — Spec Tracker",
+  "name": "ArcanaInsight — Spec Tracker (Polling)",
   "nodes": [
     {
       "parameters": {
-        "httpMethod": "POST",
-        "path": "arcana-spec",
-        "responseMode": "responseNode"
+        "rule": {
+          "interval": [{ "field": "cronExpression", "expression": "*/5 * * * *" }]
+        }
       },
-      "id": "webhook-trigger",
-      "name": "GitHub Webhook",
-      "type": "n8n-nodes-base.webhook",
-      "typeVersion": 2,
+      "id": "cron-poll",
+      "name": "5분마다 폴링",
+      "type": "n8n-nodes-base.scheduleTrigger",
+      "typeVersion": 1.2,
       "position": [250, 300]
     },
     {
       "parameters": {
+        "method": "GET",
+        "url": "https://api.github.com/repos/xzawed/ArcanaInsight/issues",
+        "authentication": "genericCredentialType",
+        "genericAuthType": "httpHeaderAuth",
+        "sendQuery": true,
+        "queryParameters": {
+          "parameters": [
+            { "name": "labels", "value": "spec" },
+            { "name": "state", "value": "open" },
+            { "name": "sort", "value": "created" },
+            { "name": "direction", "value": "desc" },
+            { "name": "per_page", "value": "5" }
+          ]
+        }
+      },
+      "id": "fetch-issues",
+      "name": "GitHub: spec Issue 조회",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [470, 300],
+      "credentials": {
+        "httpHeaderAuth": { "id": "github-pat", "name": "GitHub PAT" }
+      }
+    },
+    {
+      "parameters": {
         "conditions": {
-          "options": { "caseSensitive": true },
           "combinator": "and",
           "conditions": [
             {
-              "leftValue": "={{ $json.action }}",
-              "rightValue": "labeled",
-              "operator": { "type": "string", "operation": "equals" }
-            },
+              "leftValue": "={{ $json.length }}",
+              "rightValue": "0",
+              "operator": { "type": "number", "operation": "gt" }
+            }
+          ]
+        }
+      },
+      "id": "check-exists",
+      "name": "Issue 존재 여부",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2,
+      "position": [690, 300]
+    },
+    {
+      "parameters": {
+        "fieldToSplitOut": "={{ $json }}",
+        "options": {}
+      },
+      "id": "split-issues",
+      "name": "Issue별 분리",
+      "type": "n8n-nodes-base.splitOut",
+      "typeVersion": 1,
+      "position": [910, 300]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "combinator": "and",
+          "conditions": [
             {
-              "leftValue": "={{ $json.label?.name }}",
-              "rightValue": "spec",
+              "leftValue": "={{ $json.labels?.some(l => l.name === 'in-progress') }}",
+              "rightValue": "false",
               "operator": { "type": "string", "operation": "equals" }
             }
           ]
         }
       },
-      "id": "filter-spec",
-      "name": "Filter: spec 라벨만",
+      "id": "filter-new",
+      "name": "미처리 Issue만",
       "type": "n8n-nodes-base.if",
       "typeVersion": 2,
-      "position": [470, 300]
+      "position": [1130, 300]
     },
     {
       "parameters": {
         "method": "POST",
-        "url": "=https://api.github.com/repos/{{ $json.repository.full_name }}/dispatches",
+        "url": "=https://api.github.com/repos/xzawed/ArcanaInsight/issues/{{ $json.number }}/labels",
         "authentication": "genericCredentialType",
         "genericAuthType": "httpHeaderAuth",
         "sendBody": true,
-        "bodyParameters": {
-          "parameters": [
-            {
-              "name": "event_type",
-              "value": "spec-implementation"
-            },
-            {
-              "name": "client_payload",
-              "value": "={{ JSON.stringify({ issue_number: $json.issue.number, title: $json.issue.title, body: $json.issue.body }) }}"
-            }
-          ]
-        }
+        "specifyBody": "json",
+        "jsonBody": "={ \"labels\": [\"in-progress\"] }"
       },
-      "id": "trigger-implementation",
-      "name": "GitHub: Dispatch 트리거",
+      "id": "mark-progress",
+      "name": "GitHub: in-progress 라벨 추가",
       "type": "n8n-nodes-base.httpRequest",
       "typeVersion": 4.2,
-      "position": [690, 200],
+      "position": [1350, 200],
       "credentials": {
         "httpHeaderAuth": { "id": "github-pat", "name": "GitHub PAT" }
       }
@@ -70,50 +110,35 @@
     {
       "parameters": {
         "method": "POST",
-        "url": "=https://api.github.com/repos/{{ $json.repository.full_name }}/issues/{{ $json.issue.number }}/comments",
+        "url": "=https://api.github.com/repos/xzawed/ArcanaInsight/issues/{{ $json.number }}/comments",
         "authentication": "genericCredentialType",
         "genericAuthType": "httpHeaderAuth",
         "sendBody": true,
-        "bodyParameters": {
-          "parameters": [
-            {
-              "name": "body",
-              "value": "🤖 **자동 구현 트리거됨**\\n\\n이 스펙이 Claude CLI 구현 파이프라인에 전달되었습니다.\\n진행 상황은 [Actions 탭](../../actions)에서 확인하세요."
-            }
-          ]
-        }
+        "specifyBody": "json",
+        "jsonBody": "={ \"body\": \"🤖 **Spec 감지됨 — 구현 대기 중**\\n\\n이 스펙이 감지되었습니다. Claude CLI에서 구현을 시작해주세요:\\n\\n```\\nGitHub Issue #{{ $json.number }} 내용대로 구현해줘\\n```\\n\\n---\\n*n8n Spec Tracker에 의해 자동 생성된 코멘트입니다.*\" }"
       },
       "id": "comment-issue",
       "name": "GitHub: Issue 코멘트",
       "type": "n8n-nodes-base.httpRequest",
       "typeVersion": 4.2,
-      "position": [690, 400],
+      "position": [1350, 400],
       "credentials": {
         "httpHeaderAuth": { "id": "github-pat", "name": "GitHub PAT" }
       }
-    },
-    {
-      "parameters": {
-        "options": {}
-      },
-      "id": "respond-ok",
-      "name": "Respond OK",
-      "type": "n8n-nodes-base.respondToWebhook",
-      "typeVersion": 1.1,
-      "position": [910, 300]
     }
   ],
   "connections": {
-    "GitHub Webhook": { "main": [[{ "node": "Filter: spec 라벨만", "type": "main", "index": 0 }]] },
-    "Filter: spec 라벨만": {
+    "5분마다 폴링": { "main": [[{ "node": "GitHub: spec Issue 조회", "type": "main", "index": 0 }]] },
+    "GitHub: spec Issue 조회": { "main": [[{ "node": "Issue 존재 여부", "type": "main", "index": 0 }]] },
+    "Issue 존재 여부": { "main": [[{ "node": "Issue별 분리", "type": "main", "index": 0 }]] },
+    "Issue별 분리": { "main": [[{ "node": "미처리 Issue만", "type": "main", "index": 0 }]] },
+    "미처리 Issue만": {
       "main": [
         [
-          { "node": "GitHub: Dispatch 트리거", "type": "main", "index": 0 },
+          { "node": "GitHub: in-progress 라벨 추가", "type": "main", "index": 0 },
           { "node": "GitHub: Issue 코멘트", "type": "main", "index": 0 }
         ]
       ]
-    },
-    "GitHub: Dispatch 트리거": { "main": [[{ "node": "Respond OK", "type": "main", "index": 0 }]] },
-    "GitHub: Issue 코멘트": { "main": [[{ "node": "Respond OK", "type": "main", "index": 0 }]] }
+    }
   }
 }


### PR DESCRIPTION
## Summary
localhost에서 GitHub Webhook이 도달 불가하므로 Polling 방식으로 변경.

- 5분마다 GitHub API 폴링 → spec 라벨 open Issue 감지
- in-progress 라벨로 중복 처리 방지
- Webhook/ngrok 설정 불필요

🤖 Generated with [Claude Code](https://claude.com/claude-code)