### PR TITLE
docs: n8n Cloud 마이그레이션 가이드 준비

### DIFF
--- a/n8n/README.md
+++ b/n8n/README.md
@@ -53,3 +53,68 @@ n8n 대시보드 → Workflows → Import from File → 아래 JSON 파일 선�
 - **트리거**: 매주 금요일 오후 6시 (KST)
 - **동작**: Supabase에서 주간 통계 집계 → Grok API로 인사이트 생성 → GitHub Issue로 리포트
 - **용도**: 주간 운영 현황 자동 리포트
+
+### 4. [Cloud 전용] Spec Tracker Webhook (`workflow-spec-tracker-cloud.json`)
+- **트리거**: GitHub Webhook (Issue labeled 이벤트)
+- **동작**: Polling 버전과 동일하지만 실시간 감지 (5분 대기 없음)
+- **용도**: n8n Cloud 이전 후 사용
+
+---
+
+## n8n Cloud 마이그레이션 가이드
+
+현재 localhost Polling 방식에서 n8n Cloud로 이전할 때 참고.
+
+### 1. n8n Cloud 가입
+
+1. https://app.n8n.cloud 접속 → 가입
+2. 플랜 선택:
+   - **Starter** (€20/월) — 워크플로우 5개, 실행 2,500회/월 → ArcanaInsight에 충분
+   - **Pro** (€50/월) — 워크플로우 무제한, 실행 10,000회/월
+
+### 2. Credential 이전 체크리스트
+
+localhost에서 등록한 Credential을 Cloud에 새로 등록해야 합니다 (자동 이전 불가):
+
+| Credential | 이전 방법 |
+|-----------|---------|
+| **GitHub PAT** | Header Auth → Name: `Authorization`, Value: `token ghp_xxx` (동일) |
+| **Supabase DB** | Postgres → Host/DB/User/Password 동일, SSL ON |
+| **Grok API** | Header Auth → Name: `Authorization`, Value: `Bearer xai-xxx` (동일) |
+
+### 3. 워크플로우 이전
+
+1. localhost n8n에서 각 워크플로우 → `...` → **Export** → JSON 다운로드
+2. n8n Cloud에서 **Import** → JSON 업로드
+3. 각 노드의 Credential을 Cloud에서 새로 등록한 것으로 재연결
+4. **Spec Tracker만** Cloud 전용 Webhook 버전으로 교체:
+   - `workflow-spec-tracker.json` (Polling) → `workflow-spec-tracker-cloud.json` (Webhook) 사용
+
+### 4. GitHub Webhook 등록 (Cloud 전환 후)
+
+Spec Tracker를 Webhook 방식으로 전환하면 실시간 감지가 가능합니다:
+
+1. n8n Cloud에서 Spec Tracker (Webhook 버전) 활성화
+2. Webhook 노드의 **Production URL** 복사 (형태: `https://xxx.app.n8n.cloud/webhook/arcana-spec`)
+3. GitHub → Repository → **Settings** → **Webhooks** → **Add webhook**
+   - Payload URL: 복사한 Cloud Webhook URL
+   - Content type: `application/json`
+   - Events: **Let me select individual events** → **Issues** 체크
+   - Add webhook
+
+### 5. Polling → Webhook 전환 시 변경점
+
+| 항목 | Polling (현재) | Webhook (Cloud) |
+|------|-------------|----------------|
+| 감지 속도 | 최대 5분 지연 | 실시간 (수 초) |
+| API 호출 | 5분마다 GitHub API 호출 | Issue 이벤트 시에만 |
+| GitHub Rate Limit | 소모 (시간당 ~12회) | 소모 없음 |
+| 외부 URL 필요 | 불필요 | 필요 (Cloud 제공) |
+| 추가 설정 | 없음 | GitHub Webhook 등록 |
+
+### 6. 이전 후 정리
+
+- localhost n8n 종료
+- Quality Monitor, Weekly Report는 JSON 그대로 Import (변경 없음)
+- Spec Tracker만 Cloud 전용 버전으로 교체
+- GitHub Webhook 등록 후 Polling 워크플로우 비활성화

--- a/n8n/workflow-spec-tracker-cloud.json
+++ b/n8n/workflow-spec-tracker-cloud.json
@@ -1,0 +1,91 @@
+{
+  "name": "ArcanaInsight — Spec Tracker (Cloud Webhook)",
+  "nodes": [
+    {
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "arcana-spec",
+        "options": {}
+      },
+      "id": "webhook-trigger",
+      "name": "GitHub Webhook",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [250, 300]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": { "caseSensitive": true },
+          "combinator": "and",
+          "conditions": [
+            {
+              "leftValue": "={{ $json.body.action }}",
+              "rightValue": "labeled",
+              "operator": { "type": "string", "operation": "equals" }
+            },
+            {
+              "leftValue": "={{ $json.body.label?.name }}",
+              "rightValue": "spec",
+              "operator": { "type": "string", "operation": "equals" }
+            }
+          ]
+        }
+      },
+      "id": "filter-spec",
+      "name": "Filter: spec 라벨만",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2,
+      "position": [470, 300]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "=https://api.github.com/repos/xzawed/ArcanaInsight/issues/{{ $json.body.issue.number }}/labels",
+        "authentication": "genericCredentialType",
+        "genericAuthType": "httpHeaderAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={ \"labels\": [\"in-progress\"] }"
+      },
+      "id": "mark-progress",
+      "name": "GitHub: in-progress 라벨 추가",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [690, 200],
+      "credentials": {
+        "httpHeaderAuth": { "id": "github-pat", "name": "GitHub PAT" }
+      }
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "=https://api.github.com/repos/xzawed/ArcanaInsight/issues/{{ $json.body.issue.number }}/comments",
+        "authentication": "genericCredentialType",
+        "genericAuthType": "httpHeaderAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={ \"body\": \"🤖 **Spec 감지됨 — 구현 대기 중 (실시간)**\\n\\n이 스펙이 실시간으로 감지되었습니다. Claude CLI에서 구현을 시작해주세요:\\n\\n```\\nGitHub Issue #{{ $json.body.issue.number }} 내용대로 구현해줘\\n```\\n\\n---\\n*n8n Cloud Spec Tracker에 의해 자동 생성된 코멘트입니다.*\" }"
+      },
+      "id": "comment-issue",
+      "name": "GitHub: Issue 코멘트",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [690, 400],
+      "credentials": {
+        "httpHeaderAuth": { "id": "github-pat", "name": "GitHub PAT" }
+      }
+    }
+  ],
+  "connections": {
+    "GitHub Webhook": { "main": [[{ "node": "Filter: spec 라벨만", "type": "main", "index": 0 }]] },
+    "Filter: spec 라벨만": {
+      "main": [
+        [
+          { "node": "GitHub: in-progress 라벨 추가", "type": "main", "index": 0 },
+          { "node": "GitHub: Issue 코멘트", "type": "main", "index": 0 }
+        ]
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
추후 n8n Cloud 이전 시 필요한 가이드와 Cloud 전용 워크플로우를 미리 준비.

- n8n/README.md: Cloud 마이그레이션 섹션 추가
  - 가입/플랜 안내 (Starter €20/월 추천)
  - Credential 이전 체크리스트
  - Polling → Webhook 전환 절차 + 비교표
  - GitHub Webhook 등록 절차
- n8n/workflow-spec-tracker-cloud.json: Webhook 방식 Spec Tracker (미래용)

## Test plan
- [ ] 문서 내용 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)