### PR TITLE
feat: Grok API 장애 시 Claude API 자동 fallback

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -7,5 +7,8 @@ NEXT_PUBLIC_SUPABASE_URL=your_supabase_project_url
 NEXT_PUBLIC_SUPABASE_ANON_KEY=your_supabase_anon_key
 SUPABASE_SERVICE_ROLE_KEY=your_supabase_service_role_key
 
+# Claude API (Anthropic) — Grok API 장애 시 자동 fallback
+ANTHROPIC_API_KEY=your_anthropic_api_key
+
 # Site
 NEXT_PUBLIC_SITE_URL=http://localhost:3000

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -238,8 +238,8 @@ supabase/migrations/            # DB 마이그레이션 파일 (번호 순서 �
 ## 핵심 아키텍처 패턴
 
 - **DivinationService 인터페이스**: 모든 운세 서비스는 이 인터페이스를 구현. 새 서비스 추가 = 구현체 + 프롬프트 + API 라우트 + 페이지
-- **AIProvider 추상화**: Grok API를 직접 호출하지 않고 인터페이스 통해 호출. 모델 교체 용이
-- **SSE 스트리밍**: `/api/tarot/reading`, `/api/saju/reading`에서 Grok 응답을 SSE로 클라이언트에 스트리밍
+- **AIProvider 추상화 + Fallback**: `FallbackProvider`가 Grok API 우선 호출 → 실패 시 Claude API로 자동 전환 (5분 쿨다운). `ANTHROPIC_API_KEY` 미설정 시 Grok 단독 사용
+- **SSE 스트리밍**: `/api/tarot/reading`, `/api/saju/reading`, `/api/daily-card`에서 AI 응답을 SSE로 클라이언트에 스트리밍
 - **Tailwind v4**: CSS `@theme` 블록(`globals.css`)에서 커스텀 컬러 정의 (`arcana-*` 계열)
 - **Path alias**: `@/*` → `./src/*` (tsconfig.json)
 - **동적 테마**: `useTheme.ts`에서 사용자 로컬 시간/계절 기반으로 7종 테마 자동 감지
@@ -296,8 +296,9 @@ pnpm test:e2e:ui      # Playwright UI 모드 (시각적 디버깅)
 ## 환경 변수
 
 ```
-GROK_API_KEY=               # xAI Grok API 키
+GROK_API_KEY=               # xAI Grok API 키 (1순위 AI)
 GROK_MODEL=grok-3           # 텍스트 생성 모델
+ANTHROPIC_API_KEY=          # Anthropic Claude API 키 (Grok 장애 시 자동 fallback)
 NEXT_PUBLIC_SUPABASE_URL=   # Supabase 프로젝트 URL
 NEXT_PUBLIC_SUPABASE_ANON_KEY= # Supabase 익명 키
 SUPABASE_SERVICE_ROLE_KEY=  # Supabase 서비스 키 (서버 전용)

--- a/src/app/api/daily-card/route.ts
+++ b/src/app/api/daily-card/route.ts
@@ -1,10 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
-import { GrokProvider } from "@/services/core/grok-provider";
+import { FallbackProvider } from "@/services/core/fallback-provider";
 import { DeckManager } from "@/services/tarot/deck-manager";
 import { getCharacterById } from "@/data/characters";
 
-const grokProvider = new GrokProvider();
+const grokProvider = new FallbackProvider();
 const deckManager = new DeckManager();
 
 function hashDateSeed(date: string, characterId: string): number {

--- a/src/app/api/saju/reading/route.ts
+++ b/src/app/api/saju/reading/route.ts
@@ -1,12 +1,12 @@
 import { NextRequest } from "next/server";
 import { SajuService } from "@/services/saju/saju-service";
-import { GrokProvider } from "@/services/core/grok-provider";
+import { FallbackProvider } from "@/services/core/fallback-provider";
 import { calculateSaju } from "@/services/saju/saju-calculator";
 import { Topic, SajuTimeRange } from "@/types/session";
 import { sajuTimeOptions } from "@/data/saju/categories";
 
 const sajuService = new SajuService();
-const grokProvider = new GrokProvider();
+const grokProvider = new FallbackProvider();
 
 const VALID_TOPICS: Topic[] = [
   "saju-general", "saju-love-single", "saju-love-couple",

--- a/src/app/api/tarot/reading/route.ts
+++ b/src/app/api/tarot/reading/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest } from "next/server";
 import { TarotService } from "@/services/tarot/tarot-service";
-import { GrokProvider } from "@/services/core/grok-provider";
+import { FallbackProvider } from "@/services/core/fallback-provider";
 import { DeckManager } from "@/services/tarot/deck-manager";
 import { SpreadResolver } from "@/services/tarot/spread-resolver";
 import { Topic } from "@/types/session";
@@ -8,7 +8,7 @@ import { SelectedCard } from "@/types/card";
 import { buildUserInfoPrompt } from "@/services/core/prompt-builder";
 
 const tarotService = new TarotService();
-const grokProvider = new GrokProvider();
+const grokProvider = new FallbackProvider();
 const deckManager = new DeckManager();
 const spreadResolver = new SpreadResolver();
 

--- a/src/services/core/claude-provider.ts
+++ b/src/services/core/claude-provider.ts
@@ -1,0 +1,102 @@
+import { AIProvider } from "@/types/service";
+
+/**
+ * Claude API (Anthropic) — Grok API 장애 시 fallback provider
+ * OpenAI 호환 API가 아니므로 Anthropic Messages API 사용
+ */
+export class ClaudeProvider implements AIProvider {
+  private _apiKey: string | null = null;
+  private baseUrl = "https://api.anthropic.com/v1";
+  private model = "claude-sonnet-4-20250514";
+  private static readonly TIMEOUT_MS = 60_000;
+
+  private get apiKey(): string {
+    if (!this._apiKey) {
+      const key = process.env.ANTHROPIC_API_KEY;
+      if (!key) {
+        throw new Error("ANTHROPIC_API_KEY 환경변수가 설정되지 않았습니다.");
+      }
+      this._apiKey = key;
+    }
+    return this._apiKey;
+  }
+
+  async generateReading(systemPrompt: string, userPrompt: string): Promise<string> {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), ClaudeProvider.TIMEOUT_MS);
+    try {
+      const response = await fetch(`${this.baseUrl}/messages`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "x-api-key": this.apiKey,
+          "anthropic-version": "2023-06-01",
+        },
+        body: JSON.stringify({
+          model: this.model,
+          max_tokens: 4096,
+          system: systemPrompt,
+          messages: [{ role: "user", content: userPrompt }],
+        }),
+        signal: controller.signal,
+      });
+      if (!response.ok) { const error = await response.text(); throw new Error(`Claude API error (${response.status}): ${error}`); }
+      const data = await response.json();
+      const content = data.content?.[0]?.text;
+      if (!content) throw new Error("Claude API가 빈 응답을 반환했습니다.");
+      return content;
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+
+  async *streamReading(systemPrompt: string, userPrompt: string): AsyncGenerator<string, void, unknown> {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), ClaudeProvider.TIMEOUT_MS);
+    try {
+      const response = await fetch(`${this.baseUrl}/messages`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "x-api-key": this.apiKey,
+          "anthropic-version": "2023-06-01",
+        },
+        body: JSON.stringify({
+          model: this.model,
+          max_tokens: 4096,
+          stream: true,
+          system: systemPrompt,
+          messages: [{ role: "user", content: userPrompt }],
+        }),
+        signal: controller.signal,
+      });
+      if (!response.ok) { const error = await response.text(); throw new Error(`Claude API error (${response.status}): ${error}`); }
+      if (!response.body) throw new Error("Response body is null");
+      const reader = response.body.getReader();
+      const decoder = new TextDecoder();
+      let buffer = "";
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, { stream: true });
+        const lines = buffer.split("\n");
+        buffer = lines.pop() || "";
+        for (const line of lines) {
+          const trimmed = line.trim();
+          if (!trimmed || !trimmed.startsWith("data: ")) continue;
+          const data = trimmed.slice(6);
+          if (data === "[DONE]") return;
+          try {
+            const parsed = JSON.parse(data);
+            // Anthropic SSE: content_block_delta 이벤트에서 텍스트 추출
+            if (parsed.type === "content_block_delta" && parsed.delta?.text) {
+              yield parsed.delta.text;
+            }
+          } catch { /* 파싱 실패 무시 */ }
+        }
+      }
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+}

--- a/src/services/core/fallback-provider.ts
+++ b/src/services/core/fallback-provider.ts
@@ -1,0 +1,83 @@
+import { AIProvider } from "@/types/service";
+import { GrokProvider } from "./grok-provider";
+import { ClaudeProvider } from "./claude-provider";
+
+/**
+ * Fallback AI Provider — Grok API 우선, 실패 시 Claude API로 자동 전환
+ *
+ * 헬스체크 결과를 캐시하여 반복 실패를 방지:
+ * - Grok 정상: Grok 사용
+ * - Grok 장애: Claude로 전환 + 5분간 Grok 스킵 (불필요한 타임아웃 방지)
+ */
+export class FallbackProvider implements AIProvider {
+  private grok: GrokProvider;
+  private claude: ClaudeProvider | null = null;
+  private grokDown = false;
+  private grokDownUntil = 0;
+  private static readonly COOLDOWN_MS = 5 * 60 * 1000; // 5분
+
+  constructor() {
+    this.grok = new GrokProvider();
+  }
+
+  private getClaude(): ClaudeProvider {
+    if (!this.claude) {
+      this.claude = new ClaudeProvider();
+    }
+    return this.claude;
+  }
+
+  private isGrokAvailable(): boolean {
+    if (!this.grokDown) return true;
+    if (Date.now() > this.grokDownUntil) {
+      this.grokDown = false;
+      return true;
+    }
+    return false;
+  }
+
+  private markGrokDown(): void {
+    this.grokDown = true;
+    this.grokDownUntil = Date.now() + FallbackProvider.COOLDOWN_MS;
+    console.warn(`[FallbackProvider] Grok API 장애 감지 → Claude로 전환 (${new Date(this.grokDownUntil).toLocaleTimeString()}까지)`);
+  }
+
+  private hasClaude(): boolean {
+    return !!process.env.ANTHROPIC_API_KEY;
+  }
+
+  async generateReading(systemPrompt: string, userPrompt: string): Promise<string> {
+    if (this.isGrokAvailable()) {
+      try {
+        return await this.grok.generateReading(systemPrompt, userPrompt);
+      } catch (e) {
+        console.error("[FallbackProvider] Grok generateReading 실패:", e);
+        if (this.hasClaude()) {
+          this.markGrokDown();
+        } else {
+          throw e; // Claude 없으면 원래 에러 그대로 전파
+        }
+      }
+    }
+    console.log("[FallbackProvider] Claude API로 generateReading 실행");
+    return this.getClaude().generateReading(systemPrompt, userPrompt);
+  }
+
+  async *streamReading(systemPrompt: string, userPrompt: string): AsyncGenerator<string, void, unknown> {
+    if (this.isGrokAvailable()) {
+      try {
+        yield* this.grok.streamReading(systemPrompt, userPrompt);
+        return;
+      } catch (e) {
+        console.error("[FallbackProvider] Grok streamReading 실패:", e);
+        if (this.hasClaude()) {
+          this.markGrokDown();
+        } else {
+          throw e;
+        }
+      }
+    }
+    console.log("[FallbackProvider] Claude API로 streamReading 실행");
+    yield* this.getClaude().streamReading(systemPrompt, userPrompt);
+  }
+}


### PR DESCRIPTION
## Summary
Grok API가 장애이거나 응답하지 않을 때 Claude API(Anthropic)로 자동 전환하는 FallbackProvider 구현.

### 동작 방식
```
API 요청 도착
  └→ FallbackProvider
       ├→ Grok API 정상 → Grok 사용
       └→ Grok API 실패 → Claude API 자동 전환 (5분간 Grok 스킵)
            └→ 5분 후 Grok 재시도 → 정상이면 Grok 복귀
```

### 안전장치
- `ANTHROPIC_API_KEY` 미설정 시 기존 Grok 단독 동작 유지 (fallback 없음)
- 5분 쿨다운으로 Grok 장애 시 불필요한 타임아웃 반복 방지
- 3개 API 라우트 전체 적용 (tarot/saju/daily-card)

### 필요한 설정
Railway 환경변수에 `ANTHROPIC_API_KEY` 추가

## Test plan
- [ ] `pnpm type-check` + `pnpm lint` 통과
- [ ] ANTHROPIC_API_KEY 없이 기존 동작 유지 확인
- [ ] Grok API 정상 시 Grok 사용 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)