### PR TITLE
fix: GitHub Actions 실행 시간 최적화 — 무료 분 소진 방지

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,8 +1,6 @@
 name: CI — Lint, Type Check & Build
 
 on:
-  push:
-    branches: [main]
   pull_request:
     branches: [main]
 

--- a/.github/workflows/qa-recheck.yml
+++ b/.github/workflows/qa-recheck.yml
@@ -4,13 +4,17 @@ name: QA Recheck — 수정 후 자동 재검증
 on:
   push:
     branches: [main]
+    # 문서만 변경된 경우 재검증 스킵
+    paths-ignore:
+      - '*.md'
+      - 'docs/**'
+      - 'n8n/**'
+      - '.github/ISSUE_TEMPLATE/**'
 
 jobs:
-  check-open-qa-issues:
-    name: QA Issue 확인
+  check-and-recheck:
+    name: QA Issue 확인 + 재검증
     runs-on: ubuntu-latest
-    outputs:
-      has_open_issues: ${{ steps.check.outputs.has_issues }}
     steps:
       - uses: actions/github-script@v7
         id: check
@@ -23,21 +27,14 @@ jobs:
               state: 'open',
             });
             const hasIssues = issues.some(i => i.title.startsWith('🚨 주간 QA 실패'));
-            core.setOutput('has_issues', hasIssues ? 'true' : 'false');
-
-  trigger-recheck:
-    name: 주간 QA 재실행 트리거
-    runs-on: ubuntu-latest
-    needs: check-open-qa-issues
-    if: needs.check-open-qa-issues.outputs.has_open_issues == 'true'
-    steps:
-      - uses: actions/github-script@v7
-        with:
-          script: |
+            if (!hasIssues) {
+              console.log('열린 QA 실패 Issue 없음 → 재검증 스킵');
+              return;
+            }
+            console.log('🔄 QA 실패 Issue 감지 → 주간 QA 자동 재실행');
             await github.rest.actions.createWorkflowDispatch({
               owner: context.repo.owner,
               repo: context.repo.repo,
               workflow_id: 'weekly-qa.yml',
               ref: 'main',
             });
-            console.log('🔄 QA 실패 Issue가 열려있어 주간 QA를 자동 재실행합니다.');

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -316,7 +316,7 @@ NEXT_PUBLIC_SITE_URL=       # 사이트 URL
 
 ### GitHub Actions (`.github/workflows/deploy.yml`)
 
-- **PR → main / push → main**: 3단계 순차 실행
+- **PR → main 시에만** 실행 (push 트리거 제거 — Actions 시간 절약):
   1. `lint-and-typecheck`: ESLint + TypeScript 타입 체크
   2. `build`: 프로덕션 빌드 (환경변수 주입)
   3. `e2e`: Playwright E2E 테스트 (Chromium + WebKit, 실패 시 리포트 아티팩트 업로드)
@@ -332,7 +332,8 @@ NEXT_PUBLIC_SITE_URL=       # 사이트 URL
 
 ### QA 자동 재검증 (`.github/workflows/qa-recheck.yml`)
 
-- QA 실패 Issue(`🚨 주간 QA 실패`)가 열려있는 상태에서 main에 push 시 자동으로 주간 QA 재실행
+- QA 실패 Issue(`🚨 주간 QA 실패`)가 열려있는 상태에서 main에 코드 push 시 자동으로 주간 QA 재실행
+- 문서만 변경된 push(*.md, docs/, n8n/)는 스킵 (Actions 시간 절약)
 - 재실행 → 전체 통과 시 → QA Issue 자동 닫힘 (완전 자동 루프)
 
 ### QA 프로세스 전체 흐름


### PR DESCRIPTION
## Summary
매 push마다 3개 워크플로우가 중복 실행되어 Actions 무료 시간이 급속 소진되는 문제 해결.

### 최적화 1: deploy.yml
- push 트리거 제거 → **PR 시에만 CI 실행** (50% 감소)

### 최적화 2: qa-recheck.yml
- 2개 job → 1개 job으로 통합 (runner 할당 절반)
- `paths-ignore`: 문서 변경(*.md, docs/, n8n/) 시 스킵

### 예상 효과
| 항목 | 변경 전 | 변경 후 |
|------|--------|--------|
| PR당 CI 실행 | 2회 (PR + push) | 1회 (PR만) |
| 문서 PR 시 qa-recheck | 실행 | 스킵 |

## Test plan
- [ ] PR 생성 시 CI 정상 실행
- [ ] main push 시 deploy.yml 미실행 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)