### PR TITLE
feat: Grok API 429 Rate Limit 전용 처리

### DIFF
--- a/src/services/core/fallback-provider.ts
+++ b/src/services/core/fallback-provider.ts
@@ -1,13 +1,13 @@
 import { AIProvider } from "@/types/service";
-import { GrokProvider } from "./grok-provider";
+import { GrokProvider, RateLimitError } from "./grok-provider";
 import { ClaudeProvider } from "./claude-provider";
 
 /**
  * Fallback AI Provider — Grok API 우선, 실패 시 Claude API로 자동 전환
  *
- * 헬스체크 결과를 캐시하여 반복 실패를 방지:
  * - Grok 정상: Grok 사용
- * - Grok 장애: Claude로 전환 + 5분간 Grok 스킵 (불필요한 타임아웃 방지)
+ * - Grok 장애 (500 등): Claude 전환 + 5분 쿨다운
+ * - Grok Rate Limit (429): Claude 전환 + Retry-After 헤더 기반 쿨다운 (기본 30초)
  */
 export class FallbackProvider implements AIProvider {
   private grok: GrokProvider;
@@ -36,10 +36,11 @@ export class FallbackProvider implements AIProvider {
     return false;
   }
 
-  private markGrokDown(): void {
+  private markGrokDown(cooldownMs?: number): void {
     this.grokDown = true;
-    this.grokDownUntil = Date.now() + FallbackProvider.COOLDOWN_MS;
-    console.warn(`[FallbackProvider] Grok API 장애 감지 → Claude로 전환 (${new Date(this.grokDownUntil).toLocaleTimeString()}까지)`);
+    const duration = cooldownMs ?? FallbackProvider.COOLDOWN_MS;
+    this.grokDownUntil = Date.now() + duration;
+    console.warn(`[FallbackProvider] Grok API 사용 불가 → Claude로 전환 (${Math.round(duration / 1000)}초 후 Grok 재시도)`);
   }
 
   private hasClaude(): boolean {
@@ -53,9 +54,10 @@ export class FallbackProvider implements AIProvider {
       } catch (e) {
         console.error("[FallbackProvider] Grok generateReading 실패:", e);
         if (this.hasClaude()) {
-          this.markGrokDown();
+          const cooldown = e instanceof RateLimitError ? e.retryAfterMs : undefined;
+          this.markGrokDown(cooldown);
         } else {
-          throw e; // Claude 없으면 원래 에러 그대로 전파
+          throw e;
         }
       }
     }
@@ -71,7 +73,8 @@ export class FallbackProvider implements AIProvider {
       } catch (e) {
         console.error("[FallbackProvider] Grok streamReading 실패:", e);
         if (this.hasClaude()) {
-          this.markGrokDown();
+          const cooldown = e instanceof RateLimitError ? e.retryAfterMs : undefined;
+          this.markGrokDown(cooldown);
         } else {
           throw e;
         }

--- a/src/services/core/grok-provider.ts
+++ b/src/services/core/grok-provider.ts
@@ -1,5 +1,15 @@
 import { AIProvider } from "@/types/service";
 
+/** Grok API Rate Limit (429) 전용 에러 — Fallback Provider에서 짧은 쿨다운 적용 */
+export class RateLimitError extends Error {
+  retryAfterMs: number;
+  constructor(retryAfter: number) {
+    super(`Grok API rate limit (429) — retry after ${retryAfter}ms`);
+    this.name = "RateLimitError";
+    this.retryAfterMs = retryAfter;
+  }
+}
+
 export class GrokProvider implements AIProvider {
   private _apiKey: string | null = null;
   private _model: string | null = null;
@@ -40,6 +50,10 @@ export class GrokProvider implements AIProvider {
         }),
         signal: controller.signal,
       });
+      if (response.status === 429) {
+        const retryAfter = parseInt(response.headers.get("retry-after") || "30", 10) * 1000;
+        throw new RateLimitError(retryAfter);
+      }
       if (!response.ok) { const error = await response.text(); throw new Error(`Grok API error (${response.status}): ${error}`); }
       const data = await response.json();
       const content = data.choices?.[0]?.message?.content;
@@ -64,6 +78,10 @@ export class GrokProvider implements AIProvider {
         }),
         signal: controller.signal,
       });
+      if (response.status === 429) {
+        const retryAfter = parseInt(response.headers.get("retry-after") || "30", 10) * 1000;
+        throw new RateLimitError(retryAfter);
+      }
       if (!response.ok) { const error = await response.text(); throw new Error(`Grok API error (${response.status}): ${error}`); }
       if (!response.body) throw new Error("Response body is null");
       const reader = response.body.getReader();


### PR DESCRIPTION
## Summary
Grok API 한도 소진(429) 시 Retry-After 헤더 기반으로 정확한 쿨다운을 적용.

### 동작 방식
```
Grok API 호출
  ├→ 200 정상 → Grok 사용
  ├→ 429 Rate Limit → Claude 전환 + Retry-After 기반 쿨다운 (기본 30초)
  └→ 500 등 장애 → Claude 전환 + 5분 쿨다운
       └→ 쿨다운 후 Grok 재시도
```

### 변경 전 vs 후
| 시나리오 | 변경 전 | 변경 후 |
|---------|--------|--------|
| 429 Rate Limit | 일반 에러 → 5분 쿨다운 | **Retry-After 기반 쿨다운 (기본 30초)** |
| 500 서버 에러 | 5분 쿨다운 | 5분 쿨다운 (동일) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)