### PR TITLE
fix: AI API 전체 실패 케이스 완전 처리 (5건)

### DIFF
--- a/src/app/api/daily-card/route.ts
+++ b/src/app/api/daily-card/route.ts
@@ -86,7 +86,13 @@ export async function POST(request: NextRequest) {
 
     return NextResponse.json({ cardId: card.id, isReversed, interpretation, keywords });
   } catch (error) {
-    console.error("Daily card error:", error);
-    return NextResponse.json({ error: "Failed to generate daily card" }, { status: 500 });
+    const errMsg = error instanceof Error ? error.message : String(error);
+    console.error("Daily card error:", errMsg);
+    const userMessage = errMsg.includes("API_KEY") || errMsg.includes("auth")
+      ? "AI 서비스 설정에 문제가 있습니다."
+      : errMsg.includes("rate limit") || errMsg.includes("429")
+      ? "요청이 많아 잠시 후 다시 시도해주세요."
+      : "일일 카드 생성에 실패했습니다. 잠시 후 다시 시도해주세요.";
+    return NextResponse.json({ error: userMessage }, { status: 500 });
   }
 }

--- a/src/services/core/fallback-provider.ts
+++ b/src/services/core/fallback-provider.ts
@@ -1,5 +1,5 @@
 import { AIProvider } from "@/types/service";
-import { GrokProvider, RateLimitError } from "./grok-provider";
+import { GrokProvider, RateLimitError, AuthError } from "./grok-provider";
 import { ClaudeProvider } from "./claude-provider";
 
 /**
@@ -7,14 +7,16 @@ import { ClaudeProvider } from "./claude-provider";
  *
  * - Grok 정상: Grok 사용
  * - Grok 장애 (500 등): Claude 전환 + 5분 쿨다운
- * - Grok Rate Limit (429): Claude 전환 + Retry-After 헤더 기반 쿨다운 (기본 30초)
+ * - Grok Rate Limit (429): Claude 전환 + Retry-After 기반 쿨다운 (기본 30초)
+ * - Grok 인증 실패 (401/403): Claude 전환 + 30분 쿨다운 (재시도 불가 에러)
  */
 export class FallbackProvider implements AIProvider {
   private grok: GrokProvider;
   private claude: ClaudeProvider | null = null;
   private grokDown = false;
   private grokDownUntil = 0;
-  private static readonly COOLDOWN_MS = 5 * 60 * 1000; // 5분
+  private static readonly COOLDOWN_MS = 5 * 60 * 1000; // 5분 (서버 에러)
+  private static readonly AUTH_COOLDOWN_MS = 30 * 60 * 1000; // 30분 (인증 에러, 재시도 불가)
 
   constructor() {
     this.grok = new GrokProvider();
@@ -36,11 +38,12 @@ export class FallbackProvider implements AIProvider {
     return false;
   }
 
-  private markGrokDown(cooldownMs?: number): void {
+  private markGrokDown(cooldownMs?: number, reason?: string): void {
     this.grokDown = true;
     const duration = cooldownMs ?? FallbackProvider.COOLDOWN_MS;
     this.grokDownUntil = Date.now() + duration;
-    console.warn(`[FallbackProvider] Grok API 사용 불가 → Claude로 전환 (${Math.round(duration / 1000)}초 후 Grok 재시도)`);
+    const reasonText = reason || "에러";
+    console.warn(`[FallbackProvider] Grok ${reasonText} → Claude 전환 (${Math.round(duration / 1000)}초 후 Grok 재시도)`);
   }
 
   private hasClaude(): boolean {
@@ -54,15 +57,24 @@ export class FallbackProvider implements AIProvider {
       } catch (e) {
         console.error("[FallbackProvider] Grok generateReading 실패:", e);
         if (this.hasClaude()) {
-          const cooldown = e instanceof RateLimitError ? e.retryAfterMs : undefined;
-          this.markGrokDown(cooldown);
+          const cooldown = e instanceof AuthError ? FallbackProvider.AUTH_COOLDOWN_MS
+            : e instanceof RateLimitError ? e.retryAfterMs : undefined;
+          const reason = e instanceof AuthError ? "인증 실패 (401/403)"
+            : e instanceof RateLimitError ? "Rate Limit (429)"
+            : "서버 에러/네트워크";
+          this.markGrokDown(cooldown, reason);
         } else {
           throw e;
         }
       }
     }
     console.log("[FallbackProvider] Claude API로 generateReading 실행");
-    return this.getClaude().generateReading(systemPrompt, userPrompt);
+    try {
+      return await this.getClaude().generateReading(systemPrompt, userPrompt);
+    } catch (claudeError) {
+      console.error("[FallbackProvider] Claude generateReading도 실패:", claudeError);
+      throw new Error("AI 서비스가 일시적으로 사용할 수 없습니다. 잠시 후 다시 시도해주세요.");
+    }
   }
 
   async *streamReading(systemPrompt: string, userPrompt: string): AsyncGenerator<string, void, unknown> {
@@ -73,14 +85,23 @@ export class FallbackProvider implements AIProvider {
       } catch (e) {
         console.error("[FallbackProvider] Grok streamReading 실패:", e);
         if (this.hasClaude()) {
-          const cooldown = e instanceof RateLimitError ? e.retryAfterMs : undefined;
-          this.markGrokDown(cooldown);
+          const cooldown = e instanceof AuthError ? FallbackProvider.AUTH_COOLDOWN_MS
+            : e instanceof RateLimitError ? e.retryAfterMs : undefined;
+          const reason = e instanceof AuthError ? "인증 실패 (401/403)"
+            : e instanceof RateLimitError ? "Rate Limit (429)"
+            : "서버 에러/네트워크";
+          this.markGrokDown(cooldown, reason);
         } else {
           throw e;
         }
       }
     }
     console.log("[FallbackProvider] Claude API로 streamReading 실행");
-    yield* this.getClaude().streamReading(systemPrompt, userPrompt);
+    try {
+      yield* this.getClaude().streamReading(systemPrompt, userPrompt);
+    } catch (claudeError) {
+      console.error("[FallbackProvider] Claude streamReading도 실패:", claudeError);
+      throw new Error("AI 서비스가 일시적으로 사용할 수 없습니다. 잠시 후 다시 시도해주세요.");
+    }
   }
 }

--- a/src/services/core/grok-provider.ts
+++ b/src/services/core/grok-provider.ts
@@ -1,12 +1,20 @@
 import { AIProvider } from "@/types/service";
 
-/** Grok API Rate Limit (429) 전용 에러 — Fallback Provider에서 짧은 쿨다운 적용 */
+/** Grok API Rate Limit (429) — Retry-After 기반 짧은 쿨다운 */
 export class RateLimitError extends Error {
   retryAfterMs: number;
   constructor(retryAfter: number) {
     super(`Grok API rate limit (429) — retry after ${retryAfter}ms`);
     this.name = "RateLimitError";
     this.retryAfterMs = retryAfter;
+  }
+}
+
+/** API 인증 실패 (401/403) — 재시도 불가, 장기 쿨다운 적용 */
+export class AuthError extends Error {
+  constructor(status: number, detail: string) {
+    super(`Grok API auth error (${status}): ${detail}`);
+    this.name = "AuthError";
   }
 }
 
@@ -50,6 +58,10 @@ export class GrokProvider implements AIProvider {
         }),
         signal: controller.signal,
       });
+      if (response.status === 401 || response.status === 403) {
+        const error = await response.text();
+        throw new AuthError(response.status, error);
+      }
       if (response.status === 429) {
         const retryAfter = parseInt(response.headers.get("retry-after") || "30", 10) * 1000;
         throw new RateLimitError(retryAfter);
@@ -78,6 +90,10 @@ export class GrokProvider implements AIProvider {
         }),
         signal: controller.signal,
       });
+      if (response.status === 401 || response.status === 403) {
+        const error = await response.text();
+        throw new AuthError(response.status, error);
+      }
       if (response.status === 429) {
         const retryAfter = parseInt(response.headers.get("retry-after") || "30", 10) * 1000;
         throw new RateLimitError(retryAfter);


### PR DESCRIPTION
## Summary
AI API 호출의 모든 실패 케이스를 분석하여 미처리 5건을 수정.

### 실패 케이스 매트릭스 (수정 후)
| 케이스 | 쿨다운 | 동작 |
|--------|--------|------|
| 429 Rate Limit | Retry-After (기본 30초) | Claude 전환 |
| 500 서버 에러 | 5분 | Claude 전환 |
| **401/403 인증 실패** | **30분** (신규) | Claude 전환, 재시도 무의미 |
| DNS/네트워크 | 5분 | Claude 전환 |
| **Grok + Claude 둘 다 실패** | — | **명확한 에러 메시지** (신규) |
| **Daily Card 에러** | — | **원인별 메시지 분류** (신규) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)