### PR TITLE
fix: 리딩 결과 텍스트 깨짐 근본 수정

### DIFF
--- a/src/components/common/ReadingText.tsx
+++ b/src/components/common/ReadingText.tsx
@@ -7,14 +7,58 @@ interface ReadingTextProps {
 
 /** AI 리딩 텍스트를 단락별로 분리하여 렌더링 */
 export function ReadingText({ text, className = "" }: ReadingTextProps) {
-  // 리터럴 \\n이 남아있을 경우 실제 줄바꿈으로 변환
-  const normalized = text.replace(/\\n/g, "\n");
+  // 1. 리터럴 이스케이프 시퀀스를 실제 문자로 변환
+  let normalized = text
+    .replace(/\\n/g, "\n")
+    .replace(/\\r/g, "")
+    .replace(/\\t/g, " ")
+    .replace(/\\"/g, '"');
 
-  // 빈 줄(\n\n) 기준으로 단락 분리
+  // 2. JSON 잔여물 정리 (AI가 JSON 키를 텍스트에 포함시킨 경우)
+  normalized = normalized
+    .replace(/"(cardInterpretations|cardId|position|interpretation|overallReading|advice|isReversed)":\s*/g, "")
+    .replace(/^\s*[{}\[\]]\s*$/gm, "")
+    .replace(/^["']+|["']+$/gm, "")
+    .replace(/,\s*$/gm, "");
+
+  // 3. 연속 마침표/느낌표/물음표 뒤에 줄바꿈이 없으면 단락 분리 힌트 추가
+  //    (AI가 줄바꿈 없이 긴 텍스트를 반환하는 경우 대응)
+  normalized = normalized.replace(/([.!?。])\s{2,}/g, "$1\n\n");
+
+  // 4. 빈 줄(\n\n) 기준으로 단락 분리
   const paragraphs = normalized
     .split(/\n{2,}/)
     .map((p) => p.trim())
     .filter(Boolean);
+
+  // 5. 단락이 1개인데 너무 길면 (200자 이상) 문장 단위로 분리 시도
+  if (paragraphs.length === 1 && paragraphs[0].length > 200) {
+    const sentences = paragraphs[0].split(/(?<=[.!?。])\s+/);
+    const chunks: string[] = [];
+    let current = "";
+
+    for (const sentence of sentences) {
+      if (current.length + sentence.length > 150 && current.length > 0) {
+        chunks.push(current.trim());
+        current = sentence;
+      } else {
+        current += (current ? " " : "") + sentence;
+      }
+    }
+    if (current.trim()) chunks.push(current.trim());
+
+    if (chunks.length > 1) {
+      return (
+        <div className={`space-y-3 ${className}`}>
+          {chunks.map((chunk, i) => (
+            <p key={i} className="text-arcana-text reading-text">
+              {chunk}
+            </p>
+          ))}
+        </div>
+      );
+    }
+  }
 
   if (paragraphs.length === 0) return null;
 

--- a/src/services/core/text-cleaner.ts
+++ b/src/services/core/text-cleaner.ts
@@ -12,7 +12,6 @@ export function cleanReadingText(text: string): string {
     .replace(/\\r/g, "")
     .replace(/\\t/g, " ")
     .replace(/\\"/g, '"')
-    .replace(/\\/g, "")
     // 줄 정리
     .replace(/^["']+|["']+$/gm, "")
     .replace(/,\s*$/gm, "")


### PR DESCRIPTION
## Summary
AI 응답 형식에 관계없이 리딩 결과가 항상 깔끔하게 표시되도록 ReadingText 강건화.

### 처리 케이스
| AI 응답 형식 | 기존 | 수정 후 |
|------------|------|--------|
| `\n\n` 이스케이프 줄바꿈 | 단락 분리 ✅ | ✅ |
| 실제 줄바꿈 (`\n\n`) | 단락 분리 ✅ | ✅ |
| **줄바꿈 없이 한 덩어리** | **뭉침** ❌ | **문장 단위 자동 분리** ✅ |
| **JSON 잔여물 포함** | **깨짐** ❌ | **자동 정리** ✅ |
| 연속 공백으로 구분 | 뭉침 ❌ | 단락 분리 ✅ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)