### PR TITLE
fix: 5장+ 스프레드 리딩 결과 잘림 수정 — max_tokens 확대

### DIFF
--- a/src/services/core/grok-provider.ts
+++ b/src/services/core/grok-provider.ts
@@ -54,7 +54,7 @@ export class GrokProvider implements AIProvider {
         body: JSON.stringify({
           model: this.model,
           messages: [{ role: "system", content: systemPrompt }, { role: "user", content: userPrompt }],
-          temperature: 0.7, max_tokens: 2000,
+          temperature: 0.7, max_tokens: 8000,
         }),
         signal: controller.signal,
       });
@@ -86,7 +86,7 @@ export class GrokProvider implements AIProvider {
         body: JSON.stringify({
           model: this.model,
           messages: [{ role: "system", content: systemPrompt }, { role: "user", content: userPrompt }],
-          temperature: 0.7, max_tokens: 2000, stream: true,
+          temperature: 0.7, max_tokens: 8000, stream: true,
         }),
         signal: controller.signal,
       });


### PR DESCRIPTION
## Summary
Grok API max_tokens가 2,000으로 설정되어 5장 이상 스프레드에서 JSON 응답이 잘리던 문제.

| 스프레드 | 필요 토큰 | 기존 (2,000) | 수정 후 (8,000) |
|---------|---------|------------|--------------|
| 1카드 | ~500 | ✅ | ✅ |
| 3카드 | ~1,500 | ✅ | ✅ |
| 5카드 | ~2,500 | ❌ 잘림 | ✅ |
| 7카드 | ~3,500 | ❌ 잘림 | ✅ |
| 10카드 | ~5,000 | ❌ 잘림 | ✅ |
| 12카드 | ~6,000 | ❌ 잘림 | ✅ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)