### PR TITLE
fix: Claude fallback max_tokens 8000으로 통일

### DIFF
--- a/src/services/core/claude-provider.ts
+++ b/src/services/core/claude-provider.ts
@@ -34,7 +34,7 @@ export class ClaudeProvider implements AIProvider {
         },
         body: JSON.stringify({
           model: this.model,
-          max_tokens: 4096,
+          max_tokens: 8000,
           system: systemPrompt,
           messages: [{ role: "user", content: userPrompt }],
         }),
@@ -63,7 +63,7 @@ export class ClaudeProvider implements AIProvider {
         },
         body: JSON.stringify({
           model: this.model,
-          max_tokens: 4096,
+          max_tokens: 8000,
           stream: true,
           system: systemPrompt,
           messages: [{ role: "user", content: userPrompt }],


### PR DESCRIPTION
## Summary
Grok(8000)과 Claude fallback(4096)의 max_tokens 불일치 수정.

사주 월별 상세, 장기 분석 등에서 Claude fallback 시 응답 잘림 방지.

🤖 Generated with [Claude Code](https://claude.com/claude-code)