### PR TITLE
fix: sessions topic 제약에 신점 토픽 추가

### DIFF
--- a/supabase/migrations/008_shinjeom.sql
+++ b/supabase/migrations/008_shinjeom.sql
@@ -1,3 +1,15 @@
+-- sessions.topic 제약 확장: 신점 토픽 추가
+ALTER TABLE sessions DROP CONSTRAINT IF EXISTS sessions_topic_check;
+ALTER TABLE sessions ADD CONSTRAINT sessions_topic_check
+  CHECK (topic IN (
+    'love', 'love-single', 'love-couple', 'finance', 'career', 'health', 'general',
+    'fortune-3y', 'fortune-5y', 'fortune-full',
+    'saju-general', 'saju-love-single', 'saju-love-couple',
+    'saju-career', 'saju-health', 'saju-personality',
+    'saju-compatibility', 'saju-auspicious-date',
+    'shinjeom-general', 'shinjeom-love', 'shinjeom-wealth', 'shinjeom-health'
+  ));
+
 -- 신점 메시지 히스토리 테이블
 CREATE TABLE IF NOT EXISTS shinjeom_messages (
   id uuid DEFAULT gen_random_uuid() PRIMARY KEY,


### PR DESCRIPTION
## Summary
sessions_topic_check 제약에 신점 토픽이 누락되어 세션 생성 실패.
Supabase SQL Editor에서 제약 업데이트 필요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)