### PR TITLE
fix: 신점 대화 중 스크롤 포커스 고정 문제

### DIFF
--- a/src/app/shinjeom/session/page.tsx
+++ b/src/app/shinjeom/session/page.tsx
@@ -52,10 +52,14 @@ export default function ShinjeomSessionPage() {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [topic]);
 
-  // 자동 스크롤
+  // 새 메시지 추가 시에만 스크롤 (스트리밍 청크 업데이트 시에는 스크롤 안 함)
+  const messageCountRef = useRef(0);
   useEffect(() => {
-    messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
-  }, [chatMessages]);
+    if (chatMessages.length !== messageCountRef.current) {
+      messageCountRef.current = chatMessages.length;
+      messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
+    }
+  }, [chatMessages.length]);
 
   const handleSend = async () => {
     const message = inputText.trim();


### PR DESCRIPTION
## Summary
신점 리딩 중 SSE 스트리밍 청크마다 scrollIntoView가 호출되어 글을 읽을 수 없는 문제.

메시지 개수(length)가 변할 때만 스크롤하도록 변경.

🤖 Generated with [Claude Code](https://claude.com/claude-code)