### PR TITLE
fix: 신점 페이지 이전 대화 잔류 수정

### DIFF
--- a/src/app/shinjeom/page.tsx
+++ b/src/app/shinjeom/page.tsx
@@ -27,8 +27,15 @@ export default function ShinjeomPage() {
   const { genderFilter, setGenderFilter } = useGenderStore();
   const characters = getCharactersByGender(genderFilter);
 
+  const reset = useShinjeomSessionStore.getState().reset;
   const [step, setStep] = useState<PageStep>("character-select");
   const [selectedCharacter, setSelectedCharacter] = useState<CharacterConfig | null>(null);
+
+  // 페이지 진입 시 이전 세션 초기화
+  useEffect(() => {
+    reset();
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   useEffect(() => {
     window.scrollTo(0, 0);


### PR DESCRIPTION
## Summary
신점 페이지 재진입 시 이전 세션의 대화 내용이 그대로 남아있던 문제.
페이지 마운트 시 `reset()` 호출로 해결.

🤖 Generated with [Claude Code](https://claude.com/claude-code)