### PR TITLE
fix: 페이지 네비게이션 스크롤 초기화 버그 수정

### DIFF
--- a/e2e/navigation.spec.ts
+++ b/e2e/navigation.spec.ts
@@ -132,7 +132,7 @@ test.describe("네비게이션 — 모바일 Header", () => {
     await page.waitForURL("**/settings");
   });
 
-  test("MobileNav 4탭 표시 + 클릭", async ({ page }) => {
+  test("MobileNav 5탭 표시 + 클릭", async ({ page }) => {
     await page.setViewportSize({ width: 390, height: 844 });
     await page.goto("/");
     await page.waitForLoadState("networkidle");
@@ -143,5 +143,79 @@ test.describe("네비게이션 — 모바일 Header", () => {
       await tarotTab.click();
       await page.waitForURL("**/tarot");
     }
+  });
+});
+
+test.describe("네비게이션 — 페이지 이동 후 스크롤 최상단 초기화", () => {
+  test("MobileNav 탭 클릭 후 scrollY === 0 (모바일)", async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.goto("/");
+    await page.waitForLoadState("networkidle");
+
+    // 홈에서 아래로 스크롤
+    await page.evaluate(() => window.scrollTo(0, 500));
+    await page.waitForTimeout(100);
+    const scrollBefore = await page.evaluate(() => window.scrollY);
+    expect(scrollBefore).toBeGreaterThan(0);
+
+    // 타로 탭 클릭 → 스크롤 최상단 확인
+    const tarotTab = page.locator("nav a[href='/tarot']").last();
+    await tarotTab.click();
+    await page.waitForURL("**/tarot");
+    await page.waitForTimeout(500); // AnimatePresence 전환 대기
+    const scrollAfterTarot = await page.evaluate(() => window.scrollY);
+    expect(scrollAfterTarot).toBe(0);
+
+    // 사주 탭 클릭 → 스크롤 최상단 확인
+    const sajuTab = page.locator("nav a[href='/saju']").last();
+    await sajuTab.click();
+    await page.waitForURL("**/saju");
+    await page.waitForTimeout(500);
+    const scrollAfterSaju = await page.evaluate(() => window.scrollY);
+    expect(scrollAfterSaju).toBe(0);
+
+    // 신점 탭 클릭 → 스크롤 최상단 확인
+    const shinjeomTab = page.locator("nav a[href='/shinjeom']").last();
+    await shinjeomTab.click();
+    await page.waitForURL("**/shinjeom");
+    await page.waitForTimeout(500);
+    const scrollAfterShinjeom = await page.evaluate(() => window.scrollY);
+    expect(scrollAfterShinjeom).toBe(0);
+  });
+
+  test("Header 데스크탑 링크 클릭 후 scrollY === 0", async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 800 });
+    await page.goto("/");
+    await page.waitForLoadState("networkidle");
+
+    // 홈에서 아래로 스크롤
+    await page.evaluate(() => window.scrollTo(0, 800));
+    await page.waitForTimeout(100);
+
+    // 타로 링크 클릭
+    const tarotLink = page.locator("nav a[href='/tarot']").first();
+    await tarotLink.click();
+    await page.waitForURL("**/tarot");
+    await page.waitForTimeout(500);
+    const scrollAfter = await page.evaluate(() => window.scrollY);
+    expect(scrollAfter).toBe(0);
+  });
+
+  test("페이지 내 스크롤 후 다른 페이지 이동 시 초기화", async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.goto("/tarot");
+    await page.waitForLoadState("networkidle");
+
+    // 타로 페이지에서 아래로 스크롤 (캐릭터 그리드 영역)
+    await page.evaluate(() => window.scrollTo(0, 300));
+    await page.waitForTimeout(100);
+
+    // 홈으로 이동
+    const homeTab = page.locator("nav a[href='/']").last();
+    await homeTab.click();
+    await page.waitForURL(/\/$/);
+    await page.waitForTimeout(500);
+    const scrollAfter = await page.evaluate(() => window.scrollY);
+    expect(scrollAfter).toBe(0);
   });
 });

--- a/src/app/saju/page.tsx
+++ b/src/app/saju/page.tsx
@@ -32,11 +32,18 @@ export default function SajuPage() {
   const [selectedArea, setSelectedArea] = useState<Topic | null>(null);
   const [monthlyToggle, setMonthlyToggle] = useState(false);
 
-  // 스텝 전환 시 스크롤 최상단 초기화
+  // 스텝 전환 시 스크롤 최상단 초기화 (3중 보정: 즉시 + rAF + rAF)
   useEffect(() => {
-    window.scrollTo(0, 0);
-    document.querySelectorAll("[class*='overflow-y-auto'], [class*='overflow-auto']")
-      .forEach((el) => { el.scrollTop = 0; });
+    const resetScroll = () => {
+      window.scrollTo({ top: 0, left: 0, behavior: "instant" });
+      document.querySelectorAll("[class*='overflow-y-auto'], [class*='overflow-auto']")
+        .forEach((el) => { el.scrollTop = 0; });
+    };
+    resetScroll();
+    requestAnimationFrame(() => {
+      resetScroll();
+      requestAnimationFrame(resetScroll);
+    });
   }, [step]);
 
   const handleCharacterSelect = (character: CharacterConfig) => {

--- a/src/app/shinjeom/page.tsx
+++ b/src/app/shinjeom/page.tsx
@@ -37,8 +37,18 @@ export default function ShinjeomPage() {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  // 스텝 전환 시 스크롤 최상단 초기화 (3중 보정: 즉시 + rAF + rAF)
   useEffect(() => {
-    window.scrollTo(0, 0);
+    const resetScroll = () => {
+      window.scrollTo({ top: 0, left: 0, behavior: "instant" });
+      document.querySelectorAll("[class*='overflow-y-auto'], [class*='overflow-auto']")
+        .forEach((el) => { el.scrollTop = 0; });
+    };
+    resetScroll();
+    requestAnimationFrame(() => {
+      resetScroll();
+      requestAnimationFrame(resetScroll);
+    });
   }, [step]);
 
   const handleCharacterSelect = (character: CharacterConfig) => {

--- a/src/app/tarot/page.tsx
+++ b/src/app/tarot/page.tsx
@@ -128,11 +128,18 @@ function TarotPageContent() {
     }
   }, [preselectedChar, setCharacterId]);
 
-  // 스텝 전환 시 스크롤 최상단 초기화
+  // 스텝 전환 시 스크롤 최상단 초기화 (3중 보정: 즉시 + rAF + rAF)
   useEffect(() => {
-    window.scrollTo(0, 0);
-    document.querySelectorAll("[class*='overflow-y-auto'], [class*='overflow-auto']")
-      .forEach((el) => { el.scrollTop = 0; });
+    const resetScroll = () => {
+      window.scrollTo({ top: 0, left: 0, behavior: "instant" });
+      document.querySelectorAll("[class*='overflow-y-auto'], [class*='overflow-auto']")
+        .forEach((el) => { el.scrollTop = 0; });
+    };
+    resetScroll();
+    requestAnimationFrame(() => {
+      resetScroll();
+      requestAnimationFrame(resetScroll);
+    });
   }, [step]);
 
   const handleCharacterSelect = (character: CharacterConfig) => {

--- a/src/components/layout/FocusReset.tsx
+++ b/src/components/layout/FocusReset.tsx
@@ -3,24 +3,33 @@
 import { useEffect } from "react";
 import { usePathname, useSearchParams } from "next/navigation";
 
-/** 페이지 전환 시 포커스 해제 + 모든 스크롤 최상단 초기화 */
+/** 페이지 전환 시 포커스 해제 + 모든 스크롤 최상단 초기화 (3중 보정) */
 export function FocusReset() {
   const pathname = usePathname();
   const searchParams = useSearchParams();
 
   useEffect(() => {
-    // 포커스 해제
-    if (document.activeElement instanceof HTMLElement) {
-      document.activeElement.blur();
-    }
+    const resetScroll = () => {
+      // 포커스 해제
+      if (document.activeElement instanceof HTMLElement) {
+        document.activeElement.blur();
+      }
 
-    // 메인 윈도우 스크롤 초기화
-    window.scrollTo(0, 0);
+      // 메인 윈도우 스크롤 초기화 (instant로 즉각 이동)
+      window.scrollTo({ top: 0, left: 0, behavior: "instant" });
 
-    // 내부 overflow 스크롤 컨테이너도 초기화
-    const scrollables = document.querySelectorAll("[class*='overflow-y-auto'], [class*='overflow-auto'], [class*='overflow-y-scroll']");
-    scrollables.forEach((el) => {
-      el.scrollTop = 0;
+      // 내부 overflow 스크롤 컨테이너도 초기화
+      document.querySelectorAll("[class*='overflow-y-auto'], [class*='overflow-auto'], [class*='overflow-y-scroll']")
+        .forEach((el) => { el.scrollTop = 0; });
+    };
+
+    // 즉시 1회
+    resetScroll();
+    // 다음 프레임: 렌더 후 레이아웃 시프트 보정
+    requestAnimationFrame(() => {
+      resetScroll();
+      // 한 프레임 더: AnimatePresence 애니메이션 완료 후 최종 보정
+      requestAnimationFrame(resetScroll);
     });
   }, [pathname, searchParams]);
 


### PR DESCRIPTION
## Summary
- FocusReset + 각 페이지 step 전환 스크롤 리셋을 3중 rAF 보정으로 강화
- 기존 1회 `window.scrollTo(0,0)`은 AnimatePresence 레이아웃 시프트 이후 브라우저가 스크롤 위치를 재계산하면서 하단으로 밀리는 근본 원인 해결
- `behavior:"instant"` + `requestAnimationFrame` 3중 호출(즉시/rAF/rAF)로 확실히 상단 고정
- E2E 스크롤 검증 테스트 3건 추가 (기존 0건 → 3건)

## 변경 파일
- `src/components/layout/FocusReset.tsx` — 3중 rAF 보정 + behavior:instant
- `src/app/tarot/page.tsx` — step 전환 스크롤 리셋 강화
- `src/app/saju/page.tsx` — 동일
- `src/app/shinjeom/page.tsx` — 동일 + overflow 컨테이너 리셋 추가
- `e2e/navigation.spec.ts` — 스크롤 초기화 검증 3개 테스트 추가

## Test plan
- [x] `pnpm type-check` 통과
- [x] `pnpm lint` 통과
- [x] `pnpm build` 통과 (23/23 pages)
- [ ] CI E2E 테스트 통과
- [ ] 수동 검증: MobileNav에서 타로/사주/신점 이동 시 스크롤 최상단 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)