### PR TITLE
fix: 세션 페이지 scrollIntoView 윈도우 스크롤 누수 수정

### DIFF
--- a/src/app/saju/session/page.tsx
+++ b/src/app/saju/session/page.tsx
@@ -30,7 +30,7 @@ export default function SajuSessionPage() {
 
   const character = characterId ? getCharacterById(characterId) : null;
   const [readingError, setReadingError] = useState(false);
-  const resultBottomRef = useRef<HTMLDivElement>(null);
+  const resultContainerRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     if (!topic || !character || !userInfo || !timeRange) { router.push("/saju"); return; }
@@ -108,7 +108,11 @@ export default function SajuSessionPage() {
   };
 
   useEffect(() => {
-    if (phase === "result") resultBottomRef.current?.scrollIntoView({ behavior: "smooth" });
+    // 결과 스트리밍 시 컨테이너 내부만 하단 스크롤 (윈도우 스크롤 방��)
+    if (phase === "result") {
+      const container = resultContainerRef.current;
+      if (container) container.scrollTop = container.scrollHeight;
+    }
   }, [chatMessages, phase]);
 
   const birthYear = userInfo ? parseInt(userInfo.birthDate.split("-")[0]) : 2000;
@@ -143,7 +147,7 @@ export default function SajuSessionPage() {
           {phase === "result" && readingResult && sajuData ? (
             <motion.div initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }}
               className="w-full flex-1 flex flex-col overflow-hidden py-4">
-              <div className="space-y-4 md:space-y-5 flex-1 overflow-y-auto pr-2">
+              <div ref={resultContainerRef} className="space-y-4 md:space-y-5 flex-1 overflow-y-auto pr-2">
                 <SajuChart pillars={sajuData.pillars} dayMaster={sajuData.dayMaster}
                   dayMasterElement={sajuData.dayMasterElement} isStrong={sajuData.isStrong} yongsin={sajuData.yongsin} />
                 <OhaengGraph elements={sajuData.elements} yongsinElement={sajuData.yongsin.element} />
@@ -179,7 +183,6 @@ export default function SajuSessionPage() {
                     <ReadingText text={readingResult.advice} />
                   </div>
                 )}
-                <div ref={resultBottomRef} />
               </div>
 
               <div className="flex gap-3 pt-5 flex-shrink-0">

--- a/src/app/shinjeom/session/page.tsx
+++ b/src/app/shinjeom/session/page.tsx
@@ -23,7 +23,6 @@ export default function ShinjeomSessionPage() {
   const character = characterId ? getCharacterById(characterId) : null;
   const [inputText, setInputText] = useState("");
   const [sessionCreated, setSessionCreated] = useState(false);
-  const messagesEndRef = useRef<HTMLDivElement>(null);
 
   // 세션 생성
   useEffect(() => {
@@ -52,12 +51,16 @@ export default function ShinjeomSessionPage() {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [topic]);
 
-  // 새 메시지 추가 시에만 스크롤 (스트리밍 청크 업데이트 시에는 스크롤 안 함)
+  // 새 메시지 추가 시에만 컨테이너 내부 스크롤 (윈도우 스크롤 방지)
+  const chatContainerRef = useRef<HTMLDivElement>(null);
   const messageCountRef = useRef(0);
   useEffect(() => {
     if (chatMessages.length !== messageCountRef.current) {
       messageCountRef.current = chatMessages.length;
-      messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
+      const container = chatContainerRef.current;
+      if (container) {
+        container.scrollTop = container.scrollHeight;
+      }
     }
   }, [chatMessages.length]);
 
@@ -226,7 +229,7 @@ export default function ShinjeomSessionPage() {
           ) : (
             /* 대화 */
             <>
-              <div className="flex-1 overflow-y-auto py-3 space-y-3">
+              <div ref={chatContainerRef} className="flex-1 overflow-y-auto py-3 space-y-3">
                 <AnimatePresence>
                   {chatMessages.map((msg) => (
                     <motion.div
@@ -255,7 +258,6 @@ export default function ShinjeomSessionPage() {
                     </div>
                   </div>
                 )}
-                <div ref={messagesEndRef} />
               </div>
 
               {/* 입력 */}

--- a/src/app/tarot/session/page.tsx
+++ b/src/app/tarot/session/page.tsx
@@ -46,7 +46,7 @@ export default function TarotSessionPage() {
     }
     return false;
   });
-  const resultBottomRef = useRef<HTMLDivElement>(null);
+  const resultContainerRef = useRef<HTMLDivElement>(null);
 
   const toggleConfirmMode = () => {
     setConfirmEachCard((prev) => {
@@ -353,9 +353,11 @@ export default function TarotSessionPage() {
     setLoading(false);
   };
 
+  // 결과 스트리밍 시 컨테이너 내부만 하단 스크롤 (윈도우 스크롤 방지)
   useEffect(() => {
     if (phase === "result") {
-      resultBottomRef.current?.scrollIntoView({ behavior: "smooth" });
+      const container = resultContainerRef.current;
+      if (container) container.scrollTop = container.scrollHeight;
     }
   }, [chatMessages, phase]);
 
@@ -518,7 +520,7 @@ export default function TarotSessionPage() {
                 className="w-full flex-1 flex flex-col overflow-hidden py-4"
               >
                 {/* 리딩 결과만 표시 (캐릭터 대사 제외) */}
-                <div className="space-y-4 md:space-y-5 flex-1 overflow-y-auto pr-2">
+                <div ref={resultContainerRef} className="space-y-4 md:space-y-5 flex-1 overflow-y-auto pr-2">
                   {/* 카드별 해석 */}
                   {readingResult.cardInterpretations?.map((interp, i) => {
                     const card = selectedCards.find(c => c.card.id === interp.cardId);
@@ -559,7 +561,6 @@ export default function TarotSessionPage() {
                     </div>
                   )}
 
-                  <div ref={resultBottomRef} />
                 </div>
 
                 {/* 액션 버튼 */}


### PR DESCRIPTION
## Summary
- 신점/타로/사주 세션 페이지에서 `scrollIntoView({ behavior: "smooth" })`가 내부 overflow 컨테이너뿐 아니라 **윈도우 전체를 하단으로 스크롤**하는 버그 수정
- 컨테이너 ref의 `scrollTop = scrollHeight`로 교체하여 **내부 스크롤만 이동**
- 모바일에서 신점 답변 시/결과 도출 시 화면이 맨아래로 이동하던 현상 해결

## 변경 파일
- `src/app/shinjeom/session/page.tsx` — messagesEndRef → chatContainerRef.scrollTop
- `src/app/tarot/session/page.tsx` — resultBottomRef → resultContainerRef.scrollTop
- `src/app/saju/session/page.tsx` — resultBottomRef → resultContainerRef.scrollTop

## 로컬 검증 (CI 불가 — GitHub Actions 무료 한도 소진)
- [x] `pnpm type-check` 통과
- [x] `pnpm lint` 통과
- [x] `pnpm build` 통과 (23/23 pages)

## Test plan
- [ ] 모바일 신점: 고민 입력 → 답변 시 화면이 대화 영역 내에서만 스크롤되는지 확인
- [ ] 모바일 타로: 리딩 결과 스트리밍 시 결과 컨테이너 내에서만 스크롤되는지 확인
- [ ] 모바일 사주: 결과 스트리밍 시 동일 확인
- [ ] 페이지 간 이동 시 스크롤 최상단 유지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)