### PR TITLE
fix: 신점 최종 결과 JSON 원문 노출 버그 수정

### DIFF
--- a/src/app/shinjeom/session/page.tsx
+++ b/src/app/shinjeom/session/page.tsx
@@ -107,12 +107,14 @@ export default function ShinjeomSessionPage() {
       const decoder = new TextDecoder();
       let sseBuffer = "";
       let fullText = "";
+      const isFinalTurn = newTurn >= MAX_TURNS;
 
       // 스트리밍 메시지를 위한 임시 ID
       const msgId = crypto.randomUUID();
       addChatMessage({
         id: msgId, role: "character",
-        content: "", mood: "mystical", timestamp: new Date(),
+        content: isFinalTurn ? "신점 결과를 준비하고 있어요..." : "",
+        mood: "mystical", timestamp: new Date(),
       });
 
       while (true) {
@@ -136,14 +138,21 @@ export default function ShinjeomSessionPage() {
             }
             if (data.chunk) {
               fullText += data.chunk;
-              useShinjeomSessionStore.setState((state) => ({
-                chatMessages: state.chatMessages.map((m) =>
-                  m.id === msgId ? { ...m, content: fullText } : m
-                ),
-              }));
+              // 최종 턴에서는 JSON이 오므로 채팅에 표시하지 않음
+              if (!isFinalTurn) {
+                useShinjeomSessionStore.setState((state) => ({
+                  chatMessages: state.chatMessages.map((m) =>
+                    m.id === msgId ? { ...m, content: fullText } : m
+                  ),
+                }));
+              }
             }
             if (data.done) {
               if (data.isFinal && data.result) {
+                // 최종 결과 → 대기 메시지 제거 후 결과 화면 전환
+                useShinjeomSessionStore.setState((state) => ({
+                  chatMessages: state.chatMessages.filter((m) => m.id !== msgId),
+                }));
                 setReadingResult(data.result);
                 setPhase("result");
                 setMood("smile");


### PR DESCRIPTION
## Summary
- 신점 3회차(최종 턴) 스트리밍 시 AI가 JSON 형식으로 응답하는데, 청크가 실시간으로 채팅 버블에 표시되어 **raw JSON이 사용자에게 그대로 노출**되는 버그 수정
- 최종 턴에서는 "신점 결과를 준비하고 있어요..." 대기 메시지만 표시
- 결과 파싱 완료 시 대기 메시지 제거 후 결과 화면으로 전환

## 로컬 검증 (CI 불가 — GitHub Actions 무료 한도 소진)
- [x] `pnpm type-check` 통과
- [x] `pnpm lint` 통과
- [x] `pnpm build` 통과 (23/23 pages)

## Test plan
- [ ] 신점 3회 대화 완료 시 채팅에 JSON 텍스트가 보이지 않는지 확인
- [ ] 최종 턴 중 "신점 결과를 준비하고 있어요..." 대기 메시지 표시 확인
- [ ] 결과 화면 전환 후 정상적으로 종합 신점/상세 해석/조언 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)