### PR TITLE
fix: AI 응답 토큰 가중치 조정

### DIFF
--- a/src/app/api/saju/reading/route.ts
+++ b/src/app/api/saju/reading/route.ts
@@ -78,8 +78,8 @@ export async function POST(request: NextRequest) {
       async start(controller) {
         let fullResponse = "";
         try {
-          // 월별 상세 포함 여부에 따라 max_tokens 조정
-          const sajuMaxTokens = includeMonthly ? 6000 : 4000;
+          // 월별 상세 포함 여부에 따라 max_tokens 조정 (월별 12개월 상세 보장)
+          const sajuMaxTokens = includeMonthly ? 8000 : 4000;
           for await (const chunk of grokProvider.streamReading(systemPrompt, readingPrompt, sajuMaxTokens)) {
             fullResponse += chunk;
             controller.enqueue(encoder.encode(`data: ${JSON.stringify({ chunk })}\n\n`));

--- a/src/app/api/shinjeom/message/route.ts
+++ b/src/app/api/shinjeom/message/route.ts
@@ -40,8 +40,8 @@ export async function POST(request: NextRequest) {
       async start(controller) {
         let fullResponse = "";
         try {
-          // 중간 대화는 짧게, 최종 결과는 길게
-          const shinjeomMaxTokens = isFinalTurn ? 3000 : 1000;
+          // 중간 대화는 짧게, 최종 결과는 길게 (JSON 3필드 풍부한 내용 보장)
+          const shinjeomMaxTokens = isFinalTurn ? 4000 : 1000;
           for await (const chunk of aiProvider.streamReading(systemPrompt, userPrompt, shinjeomMaxTokens)) {
             fullResponse += chunk;
             controller.enqueue(encoder.encode(`data: ${JSON.stringify({ chunk })}\n\n`));

--- a/src/app/api/tarot/reading/route.ts
+++ b/src/app/api/tarot/reading/route.ts
@@ -65,9 +65,9 @@ export async function POST(request: NextRequest) {
       async start(controller) {
         let fullResponse = "";
         try {
-          // 카드 수에 따라 max_tokens 조정 (비용 최적화)
+          // 카드 수에 따라 max_tokens 조정 (JSON 구조 오버헤드 감안)
           const cardCount = cards.length;
-          const maxTokens = cardCount <= 3 ? 2000 : cardCount <= 7 ? 4000 : 6000;
+          const maxTokens = cardCount <= 1 ? 2000 : cardCount <= 3 ? 3000 : cardCount <= 7 ? 4000 : 6000;
           for await (const chunk of grokProvider.streamReading(systemPrompt, readingPrompt + userInfoPrompt, maxTokens)) {
             fullResponse += chunk;
             controller.enqueue(encoder.encode(`data: ${JSON.stringify({ chunk })}\n\n`));


### PR DESCRIPTION
## Summary
- JSON 형식 응답에서 구조 오버헤드(~200토큰)로 콘텐츠가 잘리는 문제 방지
- 타로 3장: 2,000 → **3,000** (원카드 2,000 유지)
- 신점 최종 결과: 3,000 → **4,000** (JSON 3필드 풍부한 내용 보장)
- 사주 월별 상세: 6,000 → **8,000** (12개월 상세 분석 보장)

## 로컬 검증 (CI 불가)
- [x] `pnpm type-check` 통과
- [x] `pnpm lint` 통과
- [x] `pnpm build` 통과

## Test plan
- [ ] 타로 3장 스프레드 결과가 잘리지 않는지 확인
- [ ] 신점 최종 결과 3개 섹션 모두 풍부하게 출력되는지 확인
- [ ] 사주 월별 상세 포함 시 12개월 모두 출력되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)