### PR TITLE
docs: 문서-코드 동기화 + 코드 품질 최적화

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,7 +113,7 @@ src/
 │   ├── effects/                # ParticleOverlay (배경 파티클), ScrollReveal (스크롤 페이드인)
 │   ├── home/                   # HeroSection, CharacterGallery, ServiceFlow, DailyCard,
 │   │                           # GenderFilter, SkinGallery, ReviewCarousel, StatsCounter, FAQ, BottomCTA
-│   ├── layout/                 # Header (스크롤/드롭다운), Footer, MobileNav (4탭), ThemeProvider, FocusReset
+│   ├── layout/                 # Header (스크롤/드롭다운), Footer, MobileNav (5탭), ThemeProvider, FocusReset
 │   ├── common/                 # UserInfoForm (개인정보 입력), PrivacyConsentModal (동의), ReadingText (단락 분리 렌더링)
 │   ├── saju/                   # SajuChart, OhaengGraph, DaeunTimeline
 │   ├── skin/                   # SkinSelector
@@ -180,7 +180,7 @@ scripts/                        # 유틸리티 스크립트
 ├── regenerate-all-nukki.mjs    # 전체 캐릭터 누끼 재생성
 └── upload-skin-images.ts       # 생성된 스킨 이미지를 Supabase Storage에 업로드
 
-e2e/                            # Playwright E2E 테스트 (18개 파일, 121개 테스트, 3개 디바이스)
+e2e/                            # Playwright E2E 테스트 (19개 파일, 116개 테스트, 3개 디바이스)
 ├── home.spec.ts                # 홈 페이지 섹션 검증
 ├── tarot-flow.spec.ts          # 타로 풀 플로우
 ├── saju-flow.spec.ts           # 사주 풀 플로우
@@ -206,7 +206,9 @@ supabase/migrations/            # DB 마이그레이션 파일 (번호 순서 �
 ├── 004_user_info.sql           # 사용자 정보 (생년월일, 성별, 혈액형 등)
 ├── 005_session_character_and_topics.sql # sessions 테이블 캐릭터/토픽 확장
 ├── 006_saju_readings.sql       # saju_readings 테이블 (사주 서비스)
-└── 007_skin_selection.sql      # 스킨 선택 관련 컬럼
+├── 007_skin_selection.sql      # 스��� 선택 관련 컬럼
+├── 008_shinjeom.sql            # 신점 테이블 (shinjeom_messages, shinjeom_readings)
+└── 009_shinjeom_topics_expand.sql # 신점 직장/이직 + 택일 토픽 확장
 ```
 
 ## 캐릭터 시스템

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ ArcanaInsight는 일본 애니메이션 스타일의 캐릭터와 상담하듯 �
 | 상태관리 | Zustand v5 |
 | 패키지 매니저 | pnpm 10.33 |
 | 호스팅 | Railway (GitHub Actions 자동 배포) |
-| E2E 테스트 | Playwright — 18개 파일, 121개 테스트 (Desktop · Android · iOS) |
+| E2E 테스트 | Playwright — 19개 파일, 116개 테스트 (Desktop · Android · iOS) |
 
 ---
 

--- a/e2e/responsive.spec.ts
+++ b/e2e/responsive.spec.ts
@@ -26,9 +26,9 @@ test.describe("반응형 레이아웃", () => {
     await page.goto("/");
     await page.waitForLoadState("networkidle");
 
-    // 최소 4개의 네비 아이템 (홈/타로/사주/MY)
-    const navItems = page.locator("nav a, nav button").filter({ hasText: /홈|타로|사주|MY/ });
-    expect(await navItems.count()).toBeGreaterThanOrEqual(3);
+    // 최소 5개의 네비 아이템 (홈/타로/사주/신점/MY)
+    const navItems = page.locator("nav a, nav button").filter({ hasText: /홈|타로|사주|신점|MY/ });
+    expect(await navItems.count()).toBeGreaterThanOrEqual(4);
   });
 
   test("캐릭터 상세 — 데스크탑 좌우 50:50 분할", async ({ page }) => {

--- a/src/services/core/fallback-provider.ts
+++ b/src/services/core/fallback-provider.ts
@@ -68,7 +68,7 @@ export class FallbackProvider implements AIProvider {
         }
       }
     }
-    console.log("[FallbackProvider] Claude API로 generateReading 실행");
+    console.debug("[FallbackProvider] Claude API로 generateReading 실행");
     try {
       return await this.getClaude().generateReading(systemPrompt, userPrompt, maxTokens);
     } catch (claudeError) {
@@ -96,7 +96,7 @@ export class FallbackProvider implements AIProvider {
         }
       }
     }
-    console.log("[FallbackProvider] Claude API로 streamReading 실행");
+    console.debug("[FallbackProvider] Claude API로 streamReading 실행");
     try {
       yield* this.getClaude().streamReading(systemPrompt, userPrompt, maxTokens);
     } catch (claudeError) {


### PR DESCRIPTION
## Summary
- CLAUDE.md: MobileNav 4탭→5탭, E2E 19개 파일/116개 테스트, 마이그레이션 008·009 목록 추가
- README.md: E2E 19개 파일/116개 테스트
- e2e/responsive.spec.ts: 네비 아이템 코멘트 5개로 수정 + assertion 강화
- fallback-provider.ts: `console.log` → `console.debug` (프로덕션 로그 레벨 구분)

## 로컬 검증 (CI 불가)
- [x] `pnpm type-check` 통과
- [x] `pnpm lint` 통과
- [x] `pnpm build` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)