### PR TITLE
fix: 전체 타이포그래피 일관성 + 가독성 개선

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -174,9 +174,9 @@
 
 @layer components {
   .reading-text {
-    @apply text-[14px] sm:text-[15px] md:text-base lg:text-[17px];
-    @apply leading-[1.85] md:leading-[1.9];
-    @apply tracking-[0.01em];
+    @apply text-sm sm:text-base md:text-base lg:text-lg;
+    @apply leading-relaxed md:leading-loose;
+    @apply tracking-wide;
     @apply whitespace-pre-wrap;
     text-indent: 0.5em;
   }

--- a/src/app/saju/page.tsx
+++ b/src/app/saju/page.tsx
@@ -98,8 +98,8 @@ export default function SajuPage() {
           <motion.div key="char-select" initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }}
             className="max-w-4xl mx-auto px-4 py-8 relative z-20">
             <div className="text-center mb-8">
-              <h2 className="text-xl md:text-2xl font-serif font-bold mb-2">사주 상담사를 선택해주세요</h2>
-              <p className="text-arcana-muted">사주명리학 전문 상담을 받아보세요</p>
+              <h2 className="text-xl md:text-2xl lg:text-3xl font-serif font-bold mb-2">사주 상담사를 선택해주세요</h2>
+              <p className="text-arcana-muted text-sm md:text-base">사주명리학 전문 상담을 받아보세요</p>
             </div>
             <div className="flex justify-center gap-2 mb-6">
               {(["all", "female", "male"] as GenderFilter[]).map((f) => (
@@ -159,7 +159,7 @@ export default function SajuPage() {
               <div className="mb-5">
                 <div className="flex items-center gap-2 mb-2">
                   <Icon id="ui-hourglass" size={20} />
-                  <h3 className="font-serif font-bold text-sm text-arcana-purple">시간단위</h3>
+                  <h3 className="font-serif font-bold text-sm md:text-base text-arcana-purple">시간단위</h3>
                 </div>
                 <div className="flex flex-wrap gap-2">
                   {sajuTimeOptions.map((opt) => (
@@ -202,7 +202,7 @@ export default function SajuPage() {
               <div className="mb-6">
                 <div className="flex items-center gap-2 mb-2">
                   <Icon id="saju-general" size={20} />
-                  <h3 className="font-serif font-bold text-sm text-arcana-purple">분석영역</h3>
+                  <h3 className="font-serif font-bold text-sm md:text-base text-arcana-purple">분석영역</h3>
                 </div>
                 <div className="grid grid-cols-2 gap-2">
                   {sajuAreaOptions.map((opt) => (
@@ -214,10 +214,10 @@ export default function SajuPage() {
                       }`}>
                       <Icon id={opt.icon} size={22} className="flex-shrink-0" />
                       <div className="min-w-0">
-                        <p className={`text-xs font-serif font-bold truncate ${selectedArea === opt.id ? "text-arcana-purple" : "text-arcana-text"}`}>
+                        <p className={`text-xs md:text-sm font-serif font-bold truncate ${selectedArea === opt.id ? "text-arcana-purple" : "text-arcana-text"}`}>
                           {opt.label}
                         </p>
-                        <p className="text-arcana-muted text-[10px] truncate">{opt.desc}</p>
+                        <p className="text-arcana-muted text-xs truncate">{opt.desc}</p>
                       </div>
                     </button>
                   ))}

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -67,7 +67,7 @@ export default function SettingsPage() {
 
           {/* 테마 */}
           <section className="bg-arcana-card/70 backdrop-blur-sm border border-arcana-border rounded-2xl p-5">
-            <h2 className="font-serif font-bold text-base text-arcana-text mb-1">테마</h2>
+            <h2 className="font-serif font-bold text-base md:text-lg text-arcana-text mb-1">테마</h2>
             <p className="text-arcana-muted text-xs mb-4">현재: {mode === "auto" ? `자동 (${themes[activeTheme].nameKo})` : themes[activeTheme].nameKo}</p>
             <div className="grid grid-cols-4 gap-2">
               {themeOptions.map((t) => (
@@ -81,7 +81,7 @@ export default function SettingsPage() {
                   }`}
                 >
                   <span className="text-lg">{t.icon}</span>
-                  <span className="font-serif text-[10px] leading-tight text-center">{t.label}</span>
+                  <span className="font-serif text-xs leading-tight text-center">{t.label}</span>
                 </button>
               ))}
             </div>
@@ -89,7 +89,7 @@ export default function SettingsPage() {
 
           {/* 카드 스킨 */}
           <section className="bg-arcana-card/70 backdrop-blur-sm border border-arcana-border rounded-2xl p-5">
-            <h2 className="font-serif font-bold text-base text-arcana-text mb-1">카드 스킨</h2>
+            <h2 className="font-serif font-bold text-base md:text-lg text-arcana-text mb-1">카드 스킨</h2>
             <p className="text-arcana-muted text-xs mb-4">현재: {cardSkins.find((s) => s.id === selectedSkinId)?.nameKo || "기본"}</p>
             <div className="grid grid-cols-2 md:grid-cols-3 gap-3">
               {cardSkins.map((skin) => (
@@ -109,7 +109,7 @@ export default function SettingsPage() {
                     />
                     <span className="font-serif font-bold text-xs text-arcana-text">{skin.nameKo}</span>
                   </div>
-                  <p className="text-arcana-muted text-[10px] leading-relaxed">{skin.description}</p>
+                  <p className="text-arcana-muted text-xs leading-relaxed">{skin.description}</p>
                 </button>
               ))}
             </div>
@@ -117,7 +117,7 @@ export default function SettingsPage() {
 
           {/* 상담사 성별 필터 */}
           <section className="bg-arcana-card/70 backdrop-blur-sm border border-arcana-border rounded-2xl p-5">
-            <h2 className="font-serif font-bold text-base text-arcana-text mb-1">기본 상담사 필터</h2>
+            <h2 className="font-serif font-bold text-base md:text-lg text-arcana-text mb-1">기본 상담사 필터</h2>
             <p className="text-arcana-muted text-xs mb-4">캐릭터 선택 시 기본 필터</p>
             <div className="flex gap-2">
               {genderOptions.map((opt) => (
@@ -138,7 +138,7 @@ export default function SettingsPage() {
 
           {/* 카드 선택 */}
           <section className="bg-arcana-card/70 backdrop-blur-sm border border-arcana-border rounded-2xl p-5">
-            <h2 className="font-serif font-bold text-base text-arcana-text mb-1">카드 선택 방식</h2>
+            <h2 className="font-serif font-bold text-base md:text-lg text-arcana-text mb-1">카드 선택 방식</h2>
             <p className="text-arcana-muted text-xs mb-4">타로 카드 선택 시 동작</p>
             <button
               onClick={toggleConfirmMode}
@@ -146,7 +146,7 @@ export default function SettingsPage() {
             >
               <div>
                 <span className="text-arcana-text text-sm font-serif">카드 확인 모드</span>
-                <p className="text-arcana-muted text-[10px] mt-0.5">
+                <p className="text-arcana-muted text-xs mt-0.5">
                   {confirmEachCard ? "매 카드 선택 시 확인 요청" : "확인 없이 바로 선택 (기본)"}
                 </p>
               </div>
@@ -162,7 +162,7 @@ export default function SettingsPage() {
 
           {/* 저장된 개인정보 */}
           <section className="bg-arcana-card/70 backdrop-blur-sm border border-arcana-border rounded-2xl p-5">
-            <h2 className="font-serif font-bold text-base text-arcana-text mb-1">저장된 개인정보</h2>
+            <h2 className="font-serif font-bold text-base md:text-lg text-arcana-text mb-1">저장된 개인정보</h2>
             <p className="text-arcana-muted text-xs mb-4">브라우저에 저장된 정보 관리</p>
             {hasSavedInfo ? (
               <div className="flex items-center justify-between">

--- a/src/app/shinjeom/page.tsx
+++ b/src/app/shinjeom/page.tsx
@@ -83,7 +83,7 @@ export default function ShinjeomPage() {
             exit={{ opacity: 0, x: -50 }}
             className="relative z-20 max-w-4xl mx-auto px-4 py-8"
           >
-            <h2 className="text-2xl md:text-3xl font-serif font-bold text-center mb-2 drop-shadow-md">
+            <h2 className="text-xl md:text-2xl lg:text-3xl font-serif font-bold text-center mb-2 drop-shadow-md">
               신점 상담사를 선택하세요
             </h2>
             <p className="text-arcana-muted text-sm text-center mb-6">영적 상담을 도와줄 캐릭터를 골라주세요</p>

--- a/src/app/tarot/page.tsx
+++ b/src/app/tarot/page.tsx
@@ -223,8 +223,8 @@ function TarotPageContent() {
             className="max-w-4xl mx-auto px-4 py-8 relative z-20"
           >
             <div className="text-center mb-8">
-              <h2 className="text-xl md:text-2xl font-serif font-bold mb-2 drop-shadow-md">상담사를 선택해주세요</h2>
-              <p className="text-arcana-muted drop-shadow-sm">각 상담사마다 다른 스타일의 리딩을 제공합니다</p>
+              <h2 className="text-xl md:text-2xl lg:text-3xl font-serif font-bold mb-2 drop-shadow-md">상담사를 선택해주세요</h2>
+              <p className="text-arcana-muted text-sm md:text-base drop-shadow-sm">각 상담사마다 다른 스타일의 리딩을 제공합니다</p>
             </div>
 
             {/* 성별 필터 */}
@@ -309,7 +309,7 @@ function TarotPageContent() {
                     <Icon id={topic.iconId} size={24} />
                     <div>
                       <h4 className="font-serif font-bold text-sm group-hover:text-arcana-purple transition-colors">{topic.label}</h4>
-                      <p className="text-arcana-muted text-xs mt-0.5">{topic.desc}</p>
+                      <p className="text-arcana-muted text-xs md:text-sm mt-0.5">{topic.desc}</p>
                     </div>
                   </motion.button>
                 ))}

--- a/src/components/character/CharacterCard.tsx
+++ b/src/components/character/CharacterCard.tsx
@@ -39,11 +39,11 @@ export function CharacterCard({ character, isSelected, onClick, index }: Charact
         <div className="absolute top-0 bottom-0 right-0 w-1/5 bg-gradient-to-l from-arcana-card/50 to-transparent" />
       </div>
 
-      <h3 className="font-serif font-bold text-base group-hover:text-arcana-purple transition-colors">
+      <h3 className="font-serif font-bold text-sm md:text-base group-hover:text-arcana-purple transition-colors">
         {character.name}
       </h3>
-      <p className="text-arcana-muted text-xs mt-0.5">{character.nameJp}</p>
-      <p className="text-arcana-muted text-xs mt-2 line-clamp-2 leading-relaxed">
+      <p className="text-arcana-muted text-[11px] mt-0.5">{character.nameJp}</p>
+      <p className="text-arcana-muted text-xs md:text-sm mt-1.5 line-clamp-2 leading-relaxed">
         {character.personality}
       </p>
 

--- a/src/components/layout/MobileNav.tsx
+++ b/src/components/layout/MobileNav.tsx
@@ -38,7 +38,7 @@ export function MobileNav() {
               }`}
             >
               <Icon id={item.iconId} size={20} />
-              <span className={`text-[10px] font-sans leading-tight ${isActive ? "font-bold" : ""}`}>
+              <span className={`text-xs font-sans leading-tight ${isActive ? "font-bold" : ""}`}>
                 {item.label}
               </span>
             </span>


### PR DESCRIPTION
## Summary
전체 페이지 타이포그래피 감사 수행 후 일관성/가독성 문제 일괄 수정.

- MobileNav 라벨: `text-[10px]` → `text-xs` (접근성 최소 기준 충족)
- CharacterCard 성격 설명: 반응형 스케일 추가
- 서비스 3페이지 h2: `text-xl md:text-2xl lg:text-3xl` 통일
- 사주 분석영역: 라벨/설명 크기 상향 + Tailwind 표준 스케일
- 설정 페이지: 섹션 헤더 + 라벨 크기 개선
- ReadingText: 커스텀 px → Tailwind 표준 (`text-sm/base/lg`)

## 로컬 검증 (CI 불가)
- [x] `pnpm type-check` 통과
- [x] `pnpm lint` 통과
- [x] `pnpm build` 통과

## Test plan
- [ ] 모바일 MobileNav 라벨 가독성 확인
- [ ] 타로/사주/신점 제목 크기 통일 확인
- [ ] 설정 페이지 섹션 헤더 시각적 구분 확인
- [ ] 리딩 결과 텍스트 모바일~데스크탑 가독성 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)