### PR TITLE
fix: 폰트 MZ 감성 전환 — serif 과다 사용 제거

### DIFF
--- a/src/app/saju/page.tsx
+++ b/src/app/saju/page.tsx
@@ -98,13 +98,13 @@ export default function SajuPage() {
           <motion.div key="char-select" initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }}
             className="max-w-4xl mx-auto px-4 py-8 relative z-20">
             <div className="text-center mb-8">
-              <h2 className="text-xl md:text-2xl lg:text-3xl font-serif font-bold mb-2">사주 상담사를 선택해주세요</h2>
+              <h2 className="text-xl md:text-2xl lg:text-3xl font-display font-bold mb-2">사주 상담사를 선택해주세요</h2>
               <p className="text-arcana-muted text-sm md:text-base">사주명리학 전문 상담을 받아보세요</p>
             </div>
             <div className="flex justify-center gap-2 mb-6">
               {(["all", "female", "male"] as GenderFilter[]).map((f) => (
                 <button key={f} onClick={() => setGenderFilter(f)}
-                  className={`px-4 py-1.5 rounded-full text-xs font-serif font-bold border transition-colors ${
+                  className={`px-4 py-1.5 rounded-full text-xs font-display font-bold border transition-colors ${
                     genderFilter === f
                       ? "border-arcana-purple bg-arcana-purple/20 text-arcana-purple"
                       : "border-arcana-border text-arcana-muted hover:border-arcana-purple"
@@ -159,7 +159,7 @@ export default function SajuPage() {
               <div className="mb-5">
                 <div className="flex items-center gap-2 mb-2">
                   <Icon id="ui-hourglass" size={20} />
-                  <h3 className="font-serif font-bold text-sm md:text-base text-arcana-purple">시간단위</h3>
+                  <h3 className="font-sans font-bold text-sm md:text-base text-arcana-purple">시간단위</h3>
                 </div>
                 <div className="flex flex-wrap gap-2">
                   {sajuTimeOptions.map((opt) => (
@@ -167,7 +167,7 @@ export default function SajuPage() {
                       setSelectedTime(opt.id);
                       if (!opt.allowMonthly) setMonthlyToggle(false);
                     }}
-                      className={`flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-serif font-bold border transition-all ${
+                      className={`flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-display font-bold border transition-all ${
                         selectedTime === opt.id
                           ? "border-arcana-purple bg-arcana-purple/20 text-arcana-purple shadow-sm shadow-arcana-purple/20"
                           : "border-arcana-border text-arcana-muted hover:border-arcana-purple/60 bg-arcana-card/50"
@@ -191,7 +191,7 @@ export default function SajuPage() {
                       className={`w-9 h-5 rounded-full transition-colors relative ${monthlyToggle ? "bg-arcana-purple" : "bg-arcana-border"}`}>
                       <div className={`absolute top-0.5 w-4 h-4 bg-white rounded-full shadow transition-transform ${monthlyToggle ? "translate-x-4" : "translate-x-0.5"}`} />
                     </div>
-                    <span className="text-xs font-serif text-arcana-muted group-hover:text-arcana-text transition-colors">
+                    <span className="text-xs font-sans text-arcana-muted group-hover:text-arcana-text transition-colors">
                       월별 상세 포함
                     </span>
                   </label>
@@ -202,7 +202,7 @@ export default function SajuPage() {
               <div className="mb-6">
                 <div className="flex items-center gap-2 mb-2">
                   <Icon id="saju-general" size={20} />
-                  <h3 className="font-serif font-bold text-sm md:text-base text-arcana-purple">분석영역</h3>
+                  <h3 className="font-sans font-bold text-sm md:text-base text-arcana-purple">분석영역</h3>
                 </div>
                 <div className="grid grid-cols-2 gap-2">
                   {sajuAreaOptions.map((opt) => (
@@ -214,7 +214,7 @@ export default function SajuPage() {
                       }`}>
                       <Icon id={opt.icon} size={22} className="flex-shrink-0" />
                       <div className="min-w-0">
-                        <p className={`text-xs md:text-sm font-serif font-bold truncate ${selectedArea === opt.id ? "text-arcana-purple" : "text-arcana-text"}`}>
+                        <p className={`text-xs md:text-sm font-display font-bold truncate ${selectedArea === opt.id ? "text-arcana-purple" : "text-arcana-text"}`}>
                           {opt.label}
                         </p>
                         <p className="text-arcana-muted text-xs truncate">{opt.desc}</p>
@@ -226,7 +226,7 @@ export default function SajuPage() {
 
               {/* 시작 버튼 */}
               <button onClick={handleStart} disabled={!canStart}
-                className={`w-full py-3 rounded-full font-serif font-bold text-sm transition-all ${
+                className={`w-full py-3 rounded-full font-sans font-bold text-sm transition-all ${
                   canStart
                     ? "bg-gradient-to-r from-arcana-purple to-arcana-indigo text-white shadow-lg shadow-arcana-purple/30 hover:opacity-90"
                     : "bg-arcana-surface/50 text-arcana-muted border border-arcana-border cursor-not-allowed"

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -59,7 +59,7 @@ export default function SettingsPage() {
           ← 홈으로
         </Link>
 
-        <h1 className="text-2xl md:text-3xl font-serif font-bold text-arcana-purple mt-4 mb-8 drop-shadow-md">
+        <h1 className="text-2xl md:text-3xl font-display font-bold text-arcana-purple mt-4 mb-8 drop-shadow-md">
           설정
         </h1>
 
@@ -67,7 +67,7 @@ export default function SettingsPage() {
 
           {/* 테마 */}
           <section className="bg-arcana-card/70 backdrop-blur-sm border border-arcana-border rounded-2xl p-5">
-            <h2 className="font-serif font-bold text-base md:text-lg text-arcana-text mb-1">테마</h2>
+            <h2 className="font-sans font-bold text-base md:text-lg text-arcana-text mb-1">테마</h2>
             <p className="text-arcana-muted text-xs mb-4">현재: {mode === "auto" ? `자동 (${themes[activeTheme].nameKo})` : themes[activeTheme].nameKo}</p>
             <div className="grid grid-cols-4 gap-2">
               {themeOptions.map((t) => (
@@ -81,7 +81,7 @@ export default function SettingsPage() {
                   }`}
                 >
                   <span className="text-lg">{t.icon}</span>
-                  <span className="font-serif text-xs leading-tight text-center">{t.label}</span>
+                  <span className="font-sans text-xs leading-tight text-center">{t.label}</span>
                 </button>
               ))}
             </div>
@@ -89,7 +89,7 @@ export default function SettingsPage() {
 
           {/* 카드 스킨 */}
           <section className="bg-arcana-card/70 backdrop-blur-sm border border-arcana-border rounded-2xl p-5">
-            <h2 className="font-serif font-bold text-base md:text-lg text-arcana-text mb-1">카드 스킨</h2>
+            <h2 className="font-sans font-bold text-base md:text-lg text-arcana-text mb-1">카드 스킨</h2>
             <p className="text-arcana-muted text-xs mb-4">현재: {cardSkins.find((s) => s.id === selectedSkinId)?.nameKo || "기본"}</p>
             <div className="grid grid-cols-2 md:grid-cols-3 gap-3">
               {cardSkins.map((skin) => (
@@ -107,7 +107,7 @@ export default function SettingsPage() {
                       className="w-4 h-4 rounded-full border border-white/20"
                       style={{ background: `linear-gradient(135deg, ${skin.palette.primary}, ${skin.palette.secondary})` }}
                     />
-                    <span className="font-serif font-bold text-xs text-arcana-text">{skin.nameKo}</span>
+                    <span className="font-sans font-bold text-xs text-arcana-text">{skin.nameKo}</span>
                   </div>
                   <p className="text-arcana-muted text-xs leading-relaxed">{skin.description}</p>
                 </button>
@@ -117,14 +117,14 @@ export default function SettingsPage() {
 
           {/* 상담사 성별 필터 */}
           <section className="bg-arcana-card/70 backdrop-blur-sm border border-arcana-border rounded-2xl p-5">
-            <h2 className="font-serif font-bold text-base md:text-lg text-arcana-text mb-1">기본 상담사 필터</h2>
+            <h2 className="font-sans font-bold text-base md:text-lg text-arcana-text mb-1">기본 상담사 필터</h2>
             <p className="text-arcana-muted text-xs mb-4">캐릭터 선택 시 기본 필터</p>
             <div className="flex gap-2">
               {genderOptions.map((opt) => (
                 <button
                   key={opt.id}
                   onClick={() => setGenderFilter(opt.id)}
-                  className={`flex-1 py-2.5 rounded-full text-sm font-serif font-bold transition-all ${
+                  className={`flex-1 py-2.5 rounded-full text-sm font-display font-bold transition-all ${
                     genderFilter === opt.id
                       ? "bg-gradient-to-r from-arcana-purple to-arcana-indigo text-white shadow-lg shadow-arcana-purple/20"
                       : "bg-arcana-card/50 border border-arcana-border text-arcana-muted hover:border-arcana-purple"
@@ -138,14 +138,14 @@ export default function SettingsPage() {
 
           {/* 카드 선택 */}
           <section className="bg-arcana-card/70 backdrop-blur-sm border border-arcana-border rounded-2xl p-5">
-            <h2 className="font-serif font-bold text-base md:text-lg text-arcana-text mb-1">카드 선택 방식</h2>
+            <h2 className="font-sans font-bold text-base md:text-lg text-arcana-text mb-1">카드 선택 방식</h2>
             <p className="text-arcana-muted text-xs mb-4">타로 카드 선택 시 동작</p>
             <button
               onClick={toggleConfirmMode}
               className="w-full flex items-center justify-between p-3 rounded-xl border border-arcana-border/50 hover:border-arcana-border transition-colors"
             >
               <div>
-                <span className="text-arcana-text text-sm font-serif">카드 확인 모드</span>
+                <span className="text-arcana-text text-sm font-sans">카드 확인 모드</span>
                 <p className="text-arcana-muted text-xs mt-0.5">
                   {confirmEachCard ? "매 카드 선택 시 확인 요청" : "확인 없이 바로 선택 (기본)"}
                 </p>
@@ -162,14 +162,14 @@ export default function SettingsPage() {
 
           {/* 저장된 개인정보 */}
           <section className="bg-arcana-card/70 backdrop-blur-sm border border-arcana-border rounded-2xl p-5">
-            <h2 className="font-serif font-bold text-base md:text-lg text-arcana-text mb-1">저장된 개인정보</h2>
+            <h2 className="font-sans font-bold text-base md:text-lg text-arcana-text mb-1">저장된 개인정보</h2>
             <p className="text-arcana-muted text-xs mb-4">브라우저에 저장된 정보 관리</p>
             {hasSavedInfo ? (
               <div className="flex items-center justify-between">
                 <span className="text-arcana-text text-sm">개인정보 저장됨</span>
                 <button
                   onClick={clearSavedInfo}
-                  className="px-4 py-1.5 rounded-full border border-red-500/30 text-red-400 text-xs font-serif hover:bg-red-500/10 transition-colors"
+                  className="px-4 py-1.5 rounded-full border border-red-500/30 text-red-400 text-xs font-sans hover:bg-red-500/10 transition-colors"
                 >
                   삭제
                 </button>

--- a/src/app/shinjeom/page.tsx
+++ b/src/app/shinjeom/page.tsx
@@ -83,7 +83,7 @@ export default function ShinjeomPage() {
             exit={{ opacity: 0, x: -50 }}
             className="relative z-20 max-w-4xl mx-auto px-4 py-8"
           >
-            <h2 className="text-xl md:text-2xl lg:text-3xl font-serif font-bold text-center mb-2 drop-shadow-md">
+            <h2 className="text-xl md:text-2xl lg:text-3xl font-display font-bold text-center mb-2 drop-shadow-md">
               신점 상담사를 선택하세요
             </h2>
             <p className="text-arcana-muted text-sm text-center mb-6">영적 상담을 도와줄 캐릭터를 골라주세요</p>
@@ -93,7 +93,7 @@ export default function ShinjeomPage() {
                 <button
                   key={g}
                   onClick={() => setGenderFilter(g)}
-                  className={`px-4 py-1.5 rounded-full text-xs font-serif font-bold transition-all ${
+                  className={`px-4 py-1.5 rounded-full text-xs font-display font-bold transition-all ${
                     genderFilter === g
                       ? "bg-arcana-purple/20 text-arcana-purple border border-arcana-purple"
                       : "border border-arcana-border text-arcana-muted hover:border-arcana-purple"
@@ -131,7 +131,7 @@ export default function ShinjeomPage() {
               ← 다른 상담사 선택
             </button>
 
-            <h3 className="font-serif font-bold text-lg mb-2 drop-shadow-md">어떤 점을 봐드릴까요?</h3>
+            <h3 className="font-display font-bold text-lg mb-2 drop-shadow-md">어떤 점을 봐드릴까요?</h3>
             <p className="text-arcana-muted text-xs mb-6">상담 주제를 선택하면 대화가 시작됩니다</p>
 
             <div className="grid grid-cols-1 gap-3">
@@ -148,7 +148,7 @@ export default function ShinjeomPage() {
                   <div className="flex items-center gap-3">
                     <Icon id={t.iconId} size={28} />
                     <div>
-                      <h4 className="font-serif font-bold text-sm">{t.label}</h4>
+                      <h4 className="font-sans font-bold text-sm">{t.label}</h4>
                       <p className="text-arcana-muted text-xs mt-0.5">{t.desc}</p>
                     </div>
                   </div>

--- a/src/app/tarot/page.tsx
+++ b/src/app/tarot/page.tsx
@@ -223,7 +223,7 @@ function TarotPageContent() {
             className="max-w-4xl mx-auto px-4 py-8 relative z-20"
           >
             <div className="text-center mb-8">
-              <h2 className="text-xl md:text-2xl lg:text-3xl font-serif font-bold mb-2 drop-shadow-md">상담사를 선택해주세요</h2>
+              <h2 className="text-xl md:text-2xl lg:text-3xl font-display font-bold mb-2 drop-shadow-md">상담사를 선택해주세요</h2>
               <p className="text-arcana-muted text-sm md:text-base drop-shadow-sm">각 상담사마다 다른 스타일의 리딩을 제공합니다</p>
             </div>
 
@@ -233,7 +233,7 @@ function TarotPageContent() {
                 <button
                   key={f}
                   onClick={() => setGenderFilter(f)}
-                  className={`px-4 py-1.5 rounded-full text-xs font-serif font-bold border transition-colors ${
+                  className={`px-4 py-1.5 rounded-full text-xs font-display font-bold border transition-colors ${
                     genderFilter === f
                       ? "border-arcana-purple bg-arcana-purple/20 text-arcana-purple"
                       : "border-arcana-border text-arcana-muted hover:border-arcana-purple"
@@ -294,7 +294,7 @@ function TarotPageContent() {
               >
                 ← 다른 상담사 선택
               </button>
-              <h3 className="font-serif font-bold text-base md:text-lg mb-4 drop-shadow-md">어떤 이야기를 들려주실 건가요?</h3>
+              <h3 className="font-sans font-bold text-base md:text-lg mb-4 drop-shadow-md">어떤 이야기를 들려주실 건가요?</h3>
               <div className="grid grid-cols-1 gap-2 md:gap-3">
                 {topics.map((topic, index) => (
                   <motion.button
@@ -308,7 +308,7 @@ function TarotPageContent() {
                   >
                     <Icon id={topic.iconId} size={24} />
                     <div>
-                      <h4 className="font-serif font-bold text-sm group-hover:text-arcana-purple transition-colors">{topic.label}</h4>
+                      <h4 className="font-sans font-bold text-sm group-hover:text-arcana-purple transition-colors">{topic.label}</h4>
                       <p className="text-arcana-muted text-xs md:text-sm mt-0.5">{topic.desc}</p>
                     </div>
                   </motion.button>
@@ -345,7 +345,7 @@ function TarotPageContent() {
               <button onClick={handleBack} className="self-start mb-4 text-arcana-muted text-sm hover:text-arcana-purple transition-colors">
                 ← 주제 다시 선택
               </button>
-              <h3 className="font-serif font-bold text-base md:text-lg mb-2 drop-shadow-md">카드 리딩 방식을 선택해주세요</h3>
+              <h3 className="font-sans font-bold text-base md:text-lg mb-2 drop-shadow-md">카드 리딩 방식을 선택해주세요</h3>
               <p className="text-arcana-muted text-xs mb-4">카드 수가 많을수록 더 깊이 있는 해석을 받을 수 있어요</p>
 
               <div className="grid grid-cols-1 gap-3">
@@ -363,10 +363,10 @@ function TarotPageContent() {
                       <Icon id={opt.iconId} size={28} />
                       <div className="flex-1">
                         <div className="flex items-center gap-2">
-                          <h4 className="font-serif font-bold text-sm group-hover:text-arcana-purple transition-colors">{opt.label}</h4>
+                          <h4 className="font-sans font-bold text-sm group-hover:text-arcana-purple transition-colors">{opt.label}</h4>
                           <span className="text-arcana-gold text-[10px] font-bold bg-arcana-gold/10 px-2 py-0.5 rounded-full">{opt.cards}장</span>
                         </div>
-                        <p className="text-arcana-purple text-xs font-serif mt-0.5">{opt.desc}</p>
+                        <p className="text-arcana-purple text-xs font-sans mt-0.5">{opt.desc}</p>
                       </div>
                     </div>
                     <p className="text-arcana-muted text-xs leading-relaxed">{opt.detail}</p>
@@ -378,7 +378,7 @@ function TarotPageContent() {
               <button
                 type="button"
                 onClick={handleOpenUserInfo}
-                className="mt-4 w-full py-2.5 rounded-full border border-arcana-border text-arcana-muted text-xs font-serif hover:border-arcana-purple hover:text-arcana-purple transition-colors"
+                className="mt-4 w-full py-2.5 rounded-full border border-arcana-border text-arcana-muted text-xs font-sans hover:border-arcana-purple hover:text-arcana-purple transition-colors"
               >
                 <span className="inline-flex items-center gap-1"><Icon id="ui-info" size={14} /> 개인정보 입력하고 더 정확한 리딩 받기 (선택)</span>
               </button>

--- a/src/components/character/CharacterCard.tsx
+++ b/src/components/character/CharacterCard.tsx
@@ -39,7 +39,7 @@ export function CharacterCard({ character, isSelected, onClick, index }: Charact
         <div className="absolute top-0 bottom-0 right-0 w-1/5 bg-gradient-to-l from-arcana-card/50 to-transparent" />
       </div>
 
-      <h3 className="font-serif font-bold text-sm md:text-base group-hover:text-arcana-purple transition-colors">
+      <h3 className="font-sans font-bold text-sm md:text-base group-hover:text-arcana-purple transition-colors">
         {character.name}
       </h3>
       <p className="text-arcana-muted text-[11px] mt-0.5">{character.nameJp}</p>

--- a/src/components/home/BottomCTA.tsx
+++ b/src/components/home/BottomCTA.tsx
@@ -14,14 +14,14 @@ export function BottomCTA() {
 
       <div className="max-w-2xl mx-auto text-center relative z-10">
         <ScrollReveal>
-          <h2 className="text-xl md:text-2xl font-serif font-bold mb-4 text-white">
+          <h2 className="text-xl md:text-2xl font-display font-bold mb-4 text-white">
             지금 바로 첫 번째 상담을 시작해보세요
           </h2>
           <p className="text-white/70 text-sm md:text-base mb-8">
             로그인 없이도 바로 이용 가능합니다
           </p>
           <Link href="/tarot"
-            className="inline-block px-10 py-4 rounded-full bg-white text-arcana-purple font-serif font-bold text-sm hover:bg-white/90 transition-colors shadow-xl shadow-arcana-purple/30">
+            className="inline-block px-10 py-4 rounded-full bg-white text-arcana-purple font-sans font-bold text-sm hover:bg-white/90 transition-colors shadow-xl shadow-arcana-purple/30">
             상담 시작하기
           </Link>
 

--- a/src/components/home/CharacterGallery.tsx
+++ b/src/components/home/CharacterGallery.tsx
@@ -16,7 +16,7 @@ export function CharacterGallery() {
     <section className="py-16 md:py-24 px-4">
       <div className="max-w-6xl mx-auto">
         <ScrollReveal className="text-center mb-8">
-          <h2 className="text-xl md:text-2xl font-serif font-bold mb-3">당신의 상담사를 만나보세요</h2>
+          <h2 className="text-xl md:text-2xl font-display font-bold mb-3">당신의 상담사를 만나보세요</h2>
           <p className="text-arcana-muted text-sm md:text-base max-w-lg mx-auto">
             각 상담사만의 특별한 리딩 스타일로 카드의 메시지를 전합니다
           </p>
@@ -43,10 +43,10 @@ export function CharacterGallery() {
                     <div className="absolute bottom-0 left-0 right-0 h-1/3 bg-gradient-to-t from-arcana-card to-transparent" />
                   </div>
                   <div className="p-3">
-                    <h3 className="font-serif font-bold text-sm">{char.name}</h3>
-                    <p className="text-arcana-muted text-[10px] mt-0.5">{char.nameJp}</p>
+                    <h3 className="font-sans font-bold text-sm">{char.name}</h3>
+                    <p className="text-arcana-muted text-xs mt-0.5">{char.nameJp}</p>
                     <div className="mt-1.5 inline-block px-2 py-0.5 bg-arcana-purple/10 border border-arcana-purple/30 rounded-full">
-                      <span className="text-arcana-purple text-[9px] font-serif">{char.speciality}</span>
+                      <span className="text-arcana-purple text-xs font-sans">{char.speciality}</span>
                     </div>
                   </div>
                 </motion.div>

--- a/src/components/home/DailyCard.tsx
+++ b/src/components/home/DailyCard.tsx
@@ -74,7 +74,7 @@ export function DailyCard() {
     <section id="daily-card" className="py-16 md:py-24 px-4">
       <div className="max-w-4xl mx-auto">
         <ScrollReveal className="text-center mb-8">
-          <h2 className="text-xl md:text-2xl font-serif font-bold mb-2">오늘의 카드</h2>
+          <h2 className="text-xl md:text-2xl font-display font-bold mb-2">오늘의 카드</h2>
           <p className="text-arcana-muted text-sm">{new Date().toLocaleDateString("ko-KR", { year: "numeric", month: "long", day: "numeric", weekday: "long" })}</p>
         </ScrollReveal>
 
@@ -82,7 +82,7 @@ export function DailyCard() {
         <div className="flex gap-2 mb-8 overflow-x-auto pb-2 scrollbar-hide justify-start md:justify-center md:flex-wrap">
           {characters.map((char) => (
             <button key={char.id} type="button" onClick={() => setActiveTab(char.id)}
-              className={`flex items-center gap-2 px-4 py-2 rounded-full text-xs font-serif transition-all ${
+              className={`flex items-center gap-2 px-4 py-2 rounded-full text-xs font-sans transition-all ${
                 activeTab === char.id
                   ? "bg-arcana-purple text-white shadow-lg shadow-arcana-purple/30"
                   : "bg-arcana-card/70 text-arcana-muted hover:text-arcana-text border border-arcana-border"
@@ -150,13 +150,13 @@ export function DailyCard() {
                   className="space-y-4"
                 >
                   <div>
-                    <h3 className="font-serif font-bold text-lg">{currentCard.nameKo}</h3>
+                    <h3 className="font-display font-bold text-lg">{currentCard.nameKo}</h3>
                     <p className="text-arcana-muted text-xs">{currentCard.name} {currentData.isReversed ? "(역방향)" : "(정방향)"}</p>
                   </div>
 
                   <div className="flex flex-wrap gap-2">
                     {currentData.keywords.map((kw) => (
-                      <span key={kw} className="px-2 py-0.5 text-[10px] rounded-full bg-arcana-purple/10 text-arcana-purple border border-arcana-purple/20">
+                      <span key={kw} className="px-2 py-0.5 text-xs rounded-full bg-arcana-purple/10 text-arcana-purple border border-arcana-purple/20">
                         {kw}
                       </span>
                     ))}
@@ -165,7 +165,7 @@ export function DailyCard() {
                   <div className="bg-arcana-card/70 backdrop-blur-sm border border-arcana-border rounded-xl p-4">
                     <div className="flex items-center gap-2 mb-2">
                       <div className="px-2 py-0.5 bg-gradient-to-r from-arcana-purple to-arcana-indigo rounded-full">
-                        <span className="text-white text-[10px] font-serif font-bold">
+                        <span className="text-white text-xs font-display font-bold">
                           {characters.find((c) => c.id === activeTab)?.name}
                         </span>
                       </div>
@@ -174,13 +174,13 @@ export function DailyCard() {
                   </div>
 
                   <button onClick={handleShare} type="button"
-                    className="px-4 py-2 text-xs rounded-full border border-arcana-purple text-arcana-purple font-serif font-bold hover:bg-arcana-purple/10 transition-colors">
+                    className="px-4 py-2 text-xs rounded-full border border-arcana-purple text-arcana-purple font-display font-bold hover:bg-arcana-purple/10 transition-colors">
                     공유하기
                   </button>
                 </motion.div>
               ) : currentData && !isFlipped ? (
                 <div className="flex flex-col items-center md:items-start justify-center h-full">
-                  <p className="text-arcana-muted text-sm font-serif">카드를 탭하여 오늘의 운세를 확인해보세요</p>
+                  <p className="text-arcana-muted text-sm font-sans">카드를 탭하여 오늘의 운세를 확인해보세요</p>
                 </div>
               ) : loading === activeTab ? (
                 <div className="space-y-3">

--- a/src/components/home/FAQ.tsx
+++ b/src/components/home/FAQ.tsx
@@ -16,7 +16,7 @@ function FAQItem({ question, answer, index }: { question: string; answer: string
         className="w-full bg-arcana-card/70 backdrop-blur-sm border border-arcana-border rounded-xl p-4 md:p-5 text-left hover:border-arcana-purple/50 transition-colors"
       >
         <div className="flex items-center justify-between gap-4">
-          <h3 className="font-serif font-bold text-sm md:text-base">{question}</h3>
+          <h3 className="font-sans font-bold text-sm md:text-base">{question}</h3>
           <motion.span
             animate={{ rotate: isOpen ? 180 : 0 }}
             transition={{ duration: 0.2 }}
@@ -50,7 +50,7 @@ export function FAQ() {
     <section className="py-16 md:py-24 px-4">
       <div className="max-w-3xl mx-auto">
         <ScrollReveal className="text-center mb-12">
-          <h2 className="text-xl md:text-2xl font-serif font-bold mb-3">자주 묻는 질문</h2>
+          <h2 className="text-xl md:text-2xl font-display font-bold mb-3">자주 묻는 질문</h2>
         </ScrollReveal>
 
         <div className="space-y-3">

--- a/src/components/home/GenderFilter.tsx
+++ b/src/components/home/GenderFilter.tsx
@@ -12,7 +12,7 @@ export function GenderFilterToggle() {
         <button
           key={f}
           onClick={() => setGenderFilter(f)}
-          className={`px-4 py-1.5 rounded-full text-xs font-serif font-bold border transition-colors ${
+          className={`px-4 py-1.5 rounded-full text-xs font-display font-bold border transition-colors ${
             genderFilter === f
               ? "border-arcana-purple bg-arcana-purple/20 text-arcana-purple"
               : "border-arcana-border text-arcana-muted hover:border-arcana-purple"

--- a/src/components/home/HeroSection.tsx
+++ b/src/components/home/HeroSection.tsx
@@ -42,7 +42,7 @@ export function HeroSection() {
           transition={{ duration: 0.8, delay: 0.3, ease: "easeOut" }}
           className="w-full md:w-[50%] flex flex-col items-center md:items-start justify-center px-4 md:px-12"
         >
-          <h1 className="text-3xl sm:text-4xl md:text-5xl font-serif font-bold mb-4 text-center md:text-left leading-tight">
+          <h1 className="text-3xl sm:text-4xl md:text-5xl font-display font-bold mb-4 text-center md:text-left leading-tight">
             <span className="bg-gradient-to-r from-arcana-purple via-arcana-indigo to-arcana-gold bg-clip-text text-transparent">
               카드가 속삭이는
             </span>
@@ -54,11 +54,11 @@ export function HeroSection() {
           </p>
           <div className="flex flex-col sm:flex-row gap-3">
             <Link href="/tarot"
-              className="px-8 py-3 rounded-full bg-gradient-to-r from-arcana-purple to-arcana-indigo text-white font-serif font-bold text-sm hover:opacity-90 transition-opacity shadow-lg shadow-arcana-purple/20 text-center">
+              className="px-8 py-3 rounded-full bg-gradient-to-r from-arcana-purple to-arcana-indigo text-white font-sans font-bold text-sm hover:opacity-90 transition-opacity shadow-lg shadow-arcana-purple/20 text-center">
               타로 상담 시작하기
             </Link>
             <button onClick={scrollToDaily} type="button"
-              className="px-8 py-3 rounded-full border border-arcana-purple text-arcana-purple font-serif font-bold text-sm hover:bg-arcana-purple/10 transition-colors text-center">
+              className="px-8 py-3 rounded-full border border-arcana-purple text-arcana-purple font-sans font-bold text-sm hover:bg-arcana-purple/10 transition-colors text-center">
               오늘의 카드 뽑기
             </button>
           </div>

--- a/src/components/home/ReviewCarousel.tsx
+++ b/src/components/home/ReviewCarousel.tsx
@@ -22,7 +22,7 @@ export function ReviewCarousel() {
     <section className="py-16 md:py-24 px-4">
       <div className="max-w-3xl mx-auto">
         <ScrollReveal className="text-center mb-12">
-          <h2 className="text-xl md:text-2xl font-serif font-bold mb-3">상담 후기</h2>
+          <h2 className="text-xl md:text-2xl font-display font-bold mb-3">상담 후기</h2>
           <p className="text-arcana-muted text-sm md:text-base">실제 사용자들의 리딩 경험</p>
         </ScrollReveal>
 
@@ -61,7 +61,7 @@ export function ReviewCarousel() {
                     </div>
                     <span className="text-arcana-muted text-sm">{reviews[current].name}</span>
                   </div>
-                  <span className="text-[10px] px-2 py-0.5 rounded-full bg-arcana-purple/10 text-arcana-purple">{reviews[current].topic}</span>
+                  <span className="text-xs px-2 py-0.5 rounded-full bg-arcana-purple/10 text-arcana-purple">{reviews[current].topic}</span>
                 </div>
               </motion.div>
             </AnimatePresence>

--- a/src/components/home/ServiceFlow.tsx
+++ b/src/components/home/ServiceFlow.tsx
@@ -15,7 +15,7 @@ export function ServiceFlow() {
     <section className="py-16 md:py-24 px-4 bg-arcana-surface/30">
       <div className="max-w-5xl mx-auto">
         <ScrollReveal className="text-center mb-12">
-          <h2 className="text-xl md:text-2xl font-serif font-bold mb-3">이렇게 진행됩니다</h2>
+          <h2 className="text-xl md:text-2xl font-display font-bold mb-3">이렇게 진행됩니다</h2>
           <p className="text-arcana-muted text-sm md:text-base">간단한 4단계로 타로 상담을 받아보세요</p>
         </ScrollReveal>
 
@@ -29,8 +29,8 @@ export function ServiceFlow() {
                   <Icon id={step.iconId} size={24} />
                 </div>
                 <div>
-                  <span className="text-arcana-purple text-xs font-serif font-bold">STEP {step.num}</span>
-                  <h3 className="font-serif font-bold text-sm mt-1">{step.title}</h3>
+                  <span className="text-arcana-purple text-xs font-display font-bold">STEP {step.num}</span>
+                  <h3 className="font-sans font-bold text-sm mt-1">{step.title}</h3>
                   <p className="text-arcana-muted text-xs mt-1 leading-relaxed">{step.desc}</p>
                 </div>
               </div>

--- a/src/components/home/SkinGallery.tsx
+++ b/src/components/home/SkinGallery.tsx
@@ -34,7 +34,7 @@ export function SkinGallery() {
       <div className="max-w-5xl mx-auto">
         {/* 섹션 헤더 */}
         <ScrollReveal className="text-center mb-10">
-          <h2 className="text-xl md:text-2xl font-serif font-bold mb-3">나만의 카드 디자인</h2>
+          <h2 className="text-xl md:text-2xl font-display font-bold mb-3">나만의 카드 디자인</h2>
           <p className="text-arcana-muted text-sm md:text-base max-w-lg mx-auto">
             취향에 맞는 카드 스킨을 선택해보세요
           </p>
@@ -62,7 +62,7 @@ export function SkinGallery() {
             animate={{ opacity: 1, y: 0 }}
             exit={{ opacity: 0, y: 20 }}
             transition={{ duration: 0.25 }}
-            className="fixed bottom-8 left-1/2 -translate-x-1/2 z-50 px-5 py-3 rounded-full bg-arcana-gold text-[#08081a] text-sm font-serif font-bold shadow-xl whitespace-nowrap pointer-events-none"
+            className="fixed bottom-8 left-1/2 -translate-x-1/2 z-50 px-5 py-3 rounded-full bg-arcana-gold text-[#08081a] text-sm font-display font-bold shadow-xl whitespace-nowrap pointer-events-none"
           >
             ✨ {toastName} 스킨이 적용되었습니다
           </motion.div>

--- a/src/components/home/StatsCounter.tsx
+++ b/src/components/home/StatsCounter.tsx
@@ -27,7 +27,7 @@ function AnimatedNumber({ value, suffix }: { value: number; suffix: string }) {
   }, [isInView, value]);
 
   return (
-    <span ref={ref} className="text-3xl md:text-4xl font-serif font-bold text-arcana-purple">
+    <span ref={ref} className="text-3xl md:text-4xl font-display font-bold text-arcana-purple">
       {display.toLocaleString()}{suffix}
     </span>
   );


### PR DESCRIPTION
## Summary
- **font-serif(Noto Serif KR) 24~30곳 과다 사용** → 딱딱한 격식적 느낌 제거
- 제목: `font-display` (Gothic A1 — 모던/임팩트, 기존 로딩만 되고 미사용이었던 폰트 활용)
- 버튼/CTA: `font-sans` (깔끔한 현대적 UI)
- 마이크로텍스트: `text-[9px]/text-[10px]` → `text-xs` 통일
- 15개 파일 동시 변경

## 로컬 검증 (CI 불가)
- [x] `pnpm type-check` 통과
- [x] `pnpm lint` 통과
- [x] `pnpm build` 통과

## Test plan
- [ ] 홈 페이지 전체 섹션 폰트 자연스러움 확인
- [ ] 타로/사주/신점 페이지 제목/버튼 폰트 확인
- [ ] 캐릭터 카드 이름/설명 가독성 확인
- [ ] 설정 페이지 라벨 가독성 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)