### PR TITLE
fix: 마이페이지 이력 미표시 수정

### DIFF
--- a/src/app/api/shinjeom/session/route.ts
+++ b/src/app/api/shinjeom/session/route.ts
@@ -11,10 +11,12 @@ export async function POST(request: NextRequest) {
     try {
       const { createClient } = await import("@/lib/supabase/server");
       const supabase = await createClient();
+      const { data: { user } } = await supabase.auth.getUser();
       const { data } = await supabase.from("sessions").insert({
         service_type: "shinjeom",
         topic,
         character_id: characterId,
+        user_id: user?.id || null,
         status: "in_progress",
       }).select("id").single();
       session = data;

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -277,7 +277,11 @@ export default async function MyPage() {
                 : overallText || null;
               const shareToken = reading?.share_token;
               const serviceLabel = session.service_type === "saju" ? "사주" : session.service_type === "shinjeom" ? "신점" : "타로";
-              const resultPath = session.service_type === "saju" ? `/saju/result/${shareToken}` : `/tarot/result/${shareToken}`;
+              const resultPath = session.service_type === "saju"
+                ? `/saju/result/${shareToken}`
+                : session.service_type === "shinjeom"
+                ? null
+                : `/tarot/result/${shareToken}`;
 
               const content = (
                 <>
@@ -309,7 +313,7 @@ export default async function MyPage() {
                 </>
               );
 
-              return shareToken ? (
+              return shareToken && resultPath ? (
                 <Link
                   key={session.id}
                   href={resultPath}


### PR DESCRIPTION
## 원인 분석

### 1. `saju_readings` 테이블 누락 (근본 원인)
- DB에 `saju_readings` 테이블이 없어서 마이페이지 쿼리(`saju_readings(...)` 조인) 자체가 실패
- 결과: 타로 포함 **모든 이력**이 표시되지 않음
- **Supabase 마이그레이션 직접 적용**으로 수정

### 2. `shinjeom_readings` / `shinjeom_messages` RLS 비활성화
- RLS 비활성화 상태 → 쿼리에서 빈 결과 반환
- **Supabase 마이그레이션으로 RLS + 정책 추가**

### 3. 신점 세션 API `user_id` 누락
- `shinjeom/session/route.ts`에서 `user_id`를 설정하지 않아 RLS 정책 `auth.uid() = user_id`에 걸림
- `auth.getUser()` 호출 추가

### 4. 마이페이지 신점 결과 링크 오류
- 신점 세션이 `/tarot/result/${shareToken}`으로 잘못 연결
- 신점은 별도 결과 페이지 없으므로 `resultPath = null` 처리

## Test plan

- [ ] 로그인 후 타로 상담 완료 → 마이페이지에서 이력 표시 확인
- [ ] 로그인 후 사주 상담 완료 → 마이페이지에서 이력 표시 확인
- [ ] 로그인 후 신점 상담 완료 → 마이페이지에서 이력 표시 확인
- [ ] 신점 이력 카드가 링크 없이 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)