### PR TITLE
feat: 마이페이지 선호 상담사 설정 기능

### DIFF
--- a/src/app/api/profile/favorite-character/route.ts
+++ b/src/app/api/profile/favorite-character/route.ts
@@ -1,0 +1,28 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { getCharacterById } from "@/data/characters";
+
+export async function POST(request: NextRequest) {
+  try {
+    const { characterId } = (await request.json()) as { characterId: string | null };
+
+    // characterId가 있으면 유효한 캐릭터인지 검증
+    if (characterId !== null && !getCharacterById(characterId)) {
+      return NextResponse.json({ error: "Invalid character" }, { status: 400 });
+    }
+
+    const supabase = await createClient();
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+    const { error } = await supabase
+      .from("profiles")
+      .update({ favorite_character_id: characterId })
+      .eq("id", user.id);
+
+    if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+    return NextResponse.json({ success: true });
+  } catch {
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/src/app/mypage/FavoriteCharacterSelector.tsx
+++ b/src/app/mypage/FavoriteCharacterSelector.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { motion, AnimatePresence } from "framer-motion";
+import { CharacterCard } from "@/components/character/CharacterCard";
+import { characters } from "@/data/characters";
+
+interface FavoriteCharacterSelectorProps {
+  currentCharacterId?: string | null;
+  currentCharacterName?: string | null;
+}
+
+export function FavoriteCharacterSelector({ currentCharacterId, currentCharacterName }: FavoriteCharacterSelectorProps) {
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+  const [isPending, startTransition] = useTransition();
+
+  const handleSelect = async (characterId: string | null) => {
+    const res = await fetch("/api/profile/favorite-character", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ characterId }),
+    });
+    if (!res.ok) return;
+    setOpen(false);
+    startTransition(() => router.refresh());
+  };
+
+  return (
+    <>
+      {/* 선호 상담사 카드 (클릭 가능) */}
+      <button
+        onClick={() => setOpen(true)}
+        disabled={isPending}
+        className="bg-arcana-card/70 backdrop-blur-sm border border-arcana-border rounded-2xl p-4 text-center w-full hover:border-arcana-purple/50 transition-colors group"
+      >
+        <p className={`text-sm font-sans font-bold truncate transition-colors ${currentCharacterName ? "text-arcana-indigo" : "text-arcana-muted"}`}>
+          {isPending ? "저장 중..." : (currentCharacterName ?? "미설정")}
+        </p>
+        <p className="text-arcana-muted text-xs mt-1 group-hover:text-arcana-purple/70 transition-colors">
+          선호 상담사 {currentCharacterName ? "변경" : "설정"}
+        </p>
+      </button>
+
+      {/* 모달 */}
+      <AnimatePresence>
+        {open && (
+          <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/70 backdrop-blur-sm"
+            onClick={() => setOpen(false)}
+          >
+            <motion.div
+              initial={{ opacity: 0, scale: 0.95, y: 20 }}
+              animate={{ opacity: 1, scale: 1, y: 0 }}
+              exit={{ opacity: 0, scale: 0.95, y: 20 }}
+              className="bg-arcana-surface border border-arcana-border rounded-2xl p-6 w-full max-w-lg max-h-[80dvh] overflow-y-auto"
+              onClick={(e) => e.stopPropagation()}
+            >
+              <div className="flex items-center justify-between mb-4">
+                <h3 className="font-sans font-bold text-base">선호 상담사 선택</h3>
+                <button onClick={() => setOpen(false)} className="text-arcana-muted hover:text-arcana-text text-xl leading-none">✕</button>
+              </div>
+
+              <div className="grid grid-cols-3 gap-3 mb-4">
+                {characters.map((char, index) => (
+                  <CharacterCard
+                    key={char.id}
+                    character={char}
+                    isSelected={char.id === currentCharacterId}
+                    onClick={() => handleSelect(char.id)}
+                    index={index}
+                  />
+                ))}
+              </div>
+
+              {currentCharacterId && (
+                <button
+                  onClick={() => handleSelect(null)}
+                  className="w-full py-2 rounded-full text-xs text-arcana-muted border border-arcana-border hover:border-arcana-purple/50 hover:text-arcana-text transition-colors"
+                >
+                  선호 상담사 해제
+                </button>
+              )}
+            </motion.div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </>
+  );
+}

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -5,6 +5,7 @@ import { createClient } from "@/lib/supabase/server";
 import { characters } from "@/data/characters";
 import { DeckManager } from "@/services/tarot/deck-manager";
 import { LogoutButton } from "./LogoutButton";
+import { FavoriteCharacterSelector } from "./FavoriteCharacterSelector";
 
 /** readings는 1:1 관계(unique session_id)이므로 PostgREST가 단일 객체로 반환 */
 interface ReadingData {
@@ -229,12 +230,10 @@ export default async function MyPage() {
             </p>
             <p className="text-arcana-muted text-xs mt-1">자주 뽑은 카드</p>
           </div>
-          <div className="bg-arcana-card/70 backdrop-blur-sm border border-arcana-border rounded-2xl p-4 text-center">
-            <p className="text-sm font-serif font-bold text-arcana-indigo truncate">
-              {favoriteCharName ?? "미설정"}
-            </p>
-            <p className="text-arcana-muted text-xs mt-1">선호 상담사</p>
-          </div>
+          <FavoriteCharacterSelector
+            currentCharacterId={profile?.favorite_character_id}
+            currentCharacterName={favoriteCharName}
+          />
           <div className="bg-arcana-card/70 backdrop-blur-sm border border-arcana-border rounded-2xl p-4 text-center">
             <p className="text-sm font-serif font-bold text-arcana-text truncate">
               {lastReadingDate ? formatRelativeDate(lastReadingDate) : "없음"}


### PR DESCRIPTION
## Summary

- 마이페이지 "선호 상담사" 카드가 클릭 가능해지고, 12개 캐릭터 그리드 모달로 설정 가능
- `POST /api/profile/favorite-character` API로 `profiles.favorite_character_id` 업데이트
- 선택 즉시 저장 후 페이지 자동 갱신, 해제 기능 제공

## Test plan

- [ ] 로그인 후 마이페이지 → "선호 상담사 설정" 카드 클릭 → 모달 열림 확인
- [ ] 캐릭터 선택 → 모달 닫히고 카드에 이름 업데이트 확인
- [ ] 새로고침 후 선택 유지 확인
- [ ] "선호 상담사 해제" 클릭 → "미설정" 복귀 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)