### PR TITLE
feat: 선호 상담사 자동 선택 기능 (C+A 혼합)

### DIFF
--- a/src/app/saju/page.tsx
+++ b/src/app/saju/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useState, useEffect } from "react";
-import { useRouter } from "next/navigation";
+import { useState, useEffect, Suspense } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
 import Image from "next/image";
 import { Icon } from "@/components/common/Icon";
 import { motion, AnimatePresence } from "framer-motion";
@@ -11,27 +11,59 @@ import { CharacterCard } from "@/components/character/CharacterCard";
 import { DialogueBox } from "@/components/chat/DialogueBox";
 import { ParticleOverlay } from "@/components/effects/ParticleOverlay";
 import { UserInfoForm } from "@/components/common/UserInfoForm";
-import { getCharactersByGender } from "@/data/characters";
+import { getCharactersByGender, getCharacterById } from "@/data/characters";
 import { CharacterConfig, GenderFilter } from "@/types/character";
 import { useGenderStore } from "@/hooks/useGenderStore";
 import { ChatMessage, SajuTimeRange, Topic } from "@/types/session";
 import { UserInfo } from "@/types/user-info";
 import { sajuTimeOptions, sajuAreaOptions } from "@/data/saju/categories";
+import { useFavoriteCharacter } from "@/hooks/useFavoriteCharacter";
 
 type PageStep = "character-select" | "info-input" | "saju-select";
 
-export default function SajuPage() {
+function SajuPageContent() {
   const router = useRouter();
+  const searchParams = useSearchParams();
   const { setTopic, setTimeRange, setIncludeMonthly, setCharacterId, setUserInfo, setPhase } = useSajuSessionStore();
   const { genderFilter, setGenderFilter } = useGenderStore();
   const sajuCharacters = getCharactersByGender(genderFilter);
 
-  const [step, setStep] = useState<PageStep>("character-select");
-  const [selectedCharacter, setSelectedCharacter] = useState<CharacterConfig | null>(null);
-  const [dialogueMessages, setDialogueMessages] = useState<ChatMessage[]>([]);
+  const preselectedCharId = searchParams.get("character");
+  const preselectedChar = preselectedCharId ? getCharacterById(preselectedCharId) ?? null : null;
+
+  const [step, setStep] = useState<PageStep>(() => preselectedChar ? "info-input" : "character-select");
+  const [selectedCharacter, setSelectedCharacter] = useState<CharacterConfig | null>(() => preselectedChar);
+  const [dialogueMessages, setDialogueMessages] = useState<ChatMessage[]>(() =>
+    preselectedChar ? [{
+      id: crypto.randomUUID(), role: "character" as const,
+      content: preselectedChar.greeting, mood: "smile", timestamp: new Date(),
+    }] : []
+  );
   const [selectedTime, setSelectedTime] = useState<SajuTimeRange | null>(null);
   const [selectedArea, setSelectedArea] = useState<Topic | null>(null);
   const [monthlyToggle, setMonthlyToggle] = useState(false);
+
+  // URL 파라미터로 캐릭터가 프리셀렉트된 경우 스토어에 반영
+  useEffect(() => {
+    if (preselectedChar) {
+      setCharacterId(preselectedChar.id);
+    }
+  }, [preselectedChar, setCharacterId]);
+
+  // 선호 상담사 fallback: URL 파라미터 없이 직접 접속한 경우 자동 선택
+  const { favoriteCharacter } = useFavoriteCharacter(!!preselectedChar);
+  useEffect(() => {
+    if (favoriteCharacter && !selectedCharacter) {
+      setSelectedCharacter(favoriteCharacter);
+      setCharacterId(favoriteCharacter.id);
+      setDialogueMessages([{
+        id: crypto.randomUUID(), role: "character",
+        content: favoriteCharacter.greeting, mood: "smile", timestamp: new Date(),
+      }]);
+      setStep("info-input");
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [favoriteCharacter]);
 
   // 스텝 전환 시 스크롤 최상단 초기화 (3중 보정: 즉시 + rAF + rAF)
   useEffect(() => {
@@ -238,5 +270,17 @@ export default function SajuPage() {
         ) : null}
       </AnimatePresence>
     </div>
+  );
+}
+
+export default function SajuPage() {
+  return (
+    <Suspense fallback={
+      <div className="min-h-screen flex items-center justify-center">
+        <div className="w-8 h-8 border-2 border-arcana-purple/30 border-t-arcana-purple rounded-full animate-spin" />
+      </div>
+    }>
+      <SajuPageContent />
+    </Suspense>
   );
 }

--- a/src/app/shinjeom/page.tsx
+++ b/src/app/shinjeom/page.tsx
@@ -1,17 +1,18 @@
 "use client";
 
-import { useState, useEffect } from "react";
-import { useRouter } from "next/navigation";
+import { useState, useEffect, Suspense } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
 import Image from "next/image";
 import { motion, AnimatePresence } from "framer-motion";
 import { useShinjeomSessionStore } from "@/hooks/useShinjeomSession";
 import { CharacterCard } from "@/components/character/CharacterCard";
 import { ParticleOverlay } from "@/components/effects/ParticleOverlay";
-import { getCharactersByGender } from "@/data/characters";
+import { getCharactersByGender, getCharacterById } from "@/data/characters";
 import { CharacterConfig } from "@/types/character";
 import { useGenderStore } from "@/hooks/useGenderStore";
 import { Topic } from "@/types/session";
 import { Icon } from "@/components/common/Icon";
+import { useFavoriteCharacter } from "@/hooks/useFavoriteCharacter";
 
 const topics: { id: Topic; label: string; iconId: string; desc: string }[] = [
   { id: "shinjeom-general", label: "신수 (종합운)", iconId: "shinjeom-general", desc: "전반적인 운세와 앞날의 길흉" },
@@ -24,21 +25,43 @@ const topics: { id: Topic; label: string; iconId: string; desc: string }[] = [
 
 type PageStep = "character-select" | "topic-select";
 
-export default function ShinjeomPage() {
+function ShinjeomPageContent() {
   const router = useRouter();
+  const searchParams = useSearchParams();
   const { setCharacterId, setTopic, setPhase } = useShinjeomSessionStore();
   const { genderFilter, setGenderFilter } = useGenderStore();
   const characters = getCharactersByGender(genderFilter);
 
+  const preselectedCharId = searchParams.get("character");
+  const preselectedChar = preselectedCharId ? getCharacterById(preselectedCharId) ?? null : null;
+
   const reset = useShinjeomSessionStore.getState().reset;
-  const [step, setStep] = useState<PageStep>("character-select");
-  const [selectedCharacter, setSelectedCharacter] = useState<CharacterConfig | null>(null);
+  const [step, setStep] = useState<PageStep>(() => preselectedChar ? "topic-select" : "character-select");
+  const [selectedCharacter, setSelectedCharacter] = useState<CharacterConfig | null>(() => preselectedChar);
 
   // 페이지 진입 시 이전 세션 초기화
   useEffect(() => {
     reset();
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  // URL 파라미터로 캐릭터가 프리셀렉트된 경우 스토어에 반영
+  useEffect(() => {
+    if (preselectedChar) {
+      setCharacterId(preselectedChar.id);
+    }
+  }, [preselectedChar, setCharacterId]);
+
+  // 선호 상담사 fallback: URL 파라미터 없이 직접 접속한 경우 자동 선택
+  const { favoriteCharacter } = useFavoriteCharacter(!!preselectedChar);
+  useEffect(() => {
+    if (favoriteCharacter && !selectedCharacter) {
+      setSelectedCharacter(favoriteCharacter);
+      setCharacterId(favoriteCharacter.id);
+      setStep("topic-select");
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [favoriteCharacter]);
 
   // 스텝 전환 시 스크롤 최상단 초기화 (3중 보정: 즉시 + rAF + rAF)
   useEffect(() => {
@@ -159,5 +182,17 @@ export default function ShinjeomPage() {
         )}
       </AnimatePresence>
     </div>
+  );
+}
+
+export default function ShinjeomPage() {
+  return (
+    <Suspense fallback={
+      <div className="min-h-screen flex items-center justify-center">
+        <div className="w-8 h-8 border-2 border-arcana-purple/30 border-t-arcana-purple rounded-full animate-spin" />
+      </div>
+    }>
+      <ShinjeomPageContent />
+    </Suspense>
   );
 }

--- a/src/app/tarot/page.tsx
+++ b/src/app/tarot/page.tsx
@@ -13,6 +13,7 @@ import { ParticleOverlay } from "@/components/effects/ParticleOverlay";
 import { UserInfoForm } from "@/components/common/UserInfoForm";
 import { UserInfo } from "@/types/user-info";
 import { getCharactersByGender, getCharacterById } from "@/data/characters";
+import { useFavoriteCharacter } from "@/hooks/useFavoriteCharacter";
 import { spreads } from "@/data/spreads";
 import { CharacterConfig, GenderFilter } from "@/types/character";
 import { useGenderStore } from "@/hooks/useGenderStore";
@@ -129,6 +130,24 @@ function TarotPageContent() {
       setCharacterId(preselectedChar.id);
     }
   }, [preselectedChar, setCharacterId]);
+
+  // 선호 상담사 fallback: URL 파라미터 없이 직접 접속한 경우 자동 선택
+  const { favoriteCharacter } = useFavoriteCharacter(!!preselectedChar);
+  useEffect(() => {
+    if (favoriteCharacter && !selectedCharacter) {
+      setSelectedCharacter(favoriteCharacter);
+      setCharacterId(favoriteCharacter.id);
+      setDialogueMessages([{
+        id: crypto.randomUUID(),
+        role: "character",
+        content: favoriteCharacter.greeting,
+        mood: "smile",
+        timestamp: new Date(),
+      }]);
+      setStep("topic-select");
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [favoriteCharacter]);
 
   // 스텝 전환 시 스크롤 최상단 초기화 (3중 보정: 즉시 + rAF + rAF)
   useEffect(() => {

--- a/src/hooks/useFavoriteCharacter.ts
+++ b/src/hooks/useFavoriteCharacter.ts
@@ -1,0 +1,48 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { createClient } from "@/lib/supabase/client";
+import { getCharacterById } from "@/data/characters";
+import type { CharacterConfig } from "@/types/character";
+
+/**
+ * 로그인한 사용자의 선호 상담사를 Supabase에서 조회한다.
+ * skip=true이면 즉시 null 반환 (URL 파라미터로 이미 캐릭터가 선택된 경우).
+ */
+export function useFavoriteCharacter(skip: boolean): {
+  favoriteCharacter: CharacterConfig | null;
+  loading: boolean;
+} {
+  const [favoriteCharacter, setFavoriteCharacter] = useState<CharacterConfig | null>(null);
+  const [loading, setLoading] = useState(!skip);
+
+  useEffect(() => {
+    if (skip) {
+      setLoading(false);
+      return;
+    }
+    let cancelled = false;
+    const supabase = createClient();
+    (async () => {
+      try {
+        const { data: { user } } = await supabase.auth.getUser();
+        if (!user || cancelled) { setLoading(false); return; }
+        const { data } = await supabase
+          .from("profiles")
+          .select("favorite_character_id")
+          .eq("id", user.id)
+          .single();
+        if (cancelled) return;
+        if (data?.favorite_character_id) {
+          const char = getCharacterById(data.favorite_character_id);
+          if (char) setFavoriteCharacter(char);
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [skip]);
+
+  return { favoriteCharacter, loading };
+}


### PR DESCRIPTION
## Summary

- `useFavoriteCharacter` 훅 신규 추가: 로그인 사용자의 선호 상담사를 Supabase에서 조회. URL 파라미터로 이미 캐릭터가 선택된 경우 `skip=true`로 fetch 생략
- 사주·신점 페이지에 `?character=xxx` URL 파라미터 지원 추가 (`useSearchParams` + `Suspense` 래퍼)
- 타로·사주·신점 전체에 선호 상담사 `useEffect` fallback 추가: 홈 등 파라미터 없이 직접 접속 시에도 자동 선택 동작

## 동작 흐름

1. **캐릭터 상세 → 서비스 진입** (`?character=xxx` 경로): 타로는 기존부터 지원, 사주·신점도 동일 패턴 적용 → character-select 스킵
2. **홈 CTA 등 직접 진입** (파라미터 없음): 마운트 후 Supabase 조회 → 선호 상담사 자동 선택 → 다음 단계 이동
3. **비로그인 또는 선호 상담사 미설정**: 기존과 동일하게 character-select 화면 표시
4. **상담사 변경**: 각 서비스의 기존 뒤로가기 버튼("← 다른 상담사 선택")으로 character-select 복귀 가능

## Test plan

- [ ] 마이페이지에서 선호 상담사 설정 후 홈에서 `/tarot` 진입 → character-select 스킵 확인
- [ ] 마이페이지에서 선호 상담사 설정 후 홈에서 `/saju` 진입 → character-select 스킵 확인
- [ ] 마이페이지에서 선호 상담사 설정 후 홈에서 `/shinjeom` 진입 → character-select 스킵 확인
- [ ] 캐릭터 상세 페이지 → "사주 보기" / "신점 보기" → character-select 스킵 확인
- [ ] 비로그인 상태 → character-select 정상 표시
- [ ] 선호 상담사 미설정 → character-select 정상 표시
- [ ] "← 다른 상담사 선택" 버튼으로 character-select 복귀 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)