### PR TITLE
fix: DB 저장 신뢰성 개선 + 설정에 선호 상담사 기능 추가

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -342,7 +342,7 @@ NEXT_PUBLIC_SITE_URL=       # 사이트 URL
 
 ## Git 브랜치 전략
 
-- `main`/`master`: 프로덕션 브랜치 (Railway 자동 배포 트리거)
+- `main`: 프로덕션 브랜치 (Railway 자동 배포 트리거)
 - `dev`: 개발 브랜치
 - `feature/*`: 기능 개발 브랜치
 - `fix/*`: 버그 수정 브랜치

--- a/src/app/api/saju/reading/route.ts
+++ b/src/app/api/saju/reading/route.ts
@@ -86,41 +86,45 @@ export async function POST(request: NextRequest) {
           }
           const result = sajuService.parseResult(fullResponse);
 
-          // 결과를 먼저 클라이언트에 전송 (DB 저장은 비동기 fire-and-forget)
+          // DB 저장 후 share_token 포함하여 done 이벤트 전송
+          if (supabase && sessionId) {
+            try {
+              const [readingRes] = await Promise.all([
+                supabase.from("saju_readings").insert({
+                  session_id: sessionId,
+                  birth_date: userInfo.birthDate,
+                  birth_hour: userInfo.birthHour,
+                  gender: userInfo.gender,
+                  birth_name: userInfo.name || null,
+                  pillars: sajuResult.pillars,
+                  day_master: sajuResult.dayMaster,
+                  day_master_element: sajuResult.dayMasterElement,
+                  is_strong: sajuResult.isStrong,
+                  elements: sajuResult.elements,
+                  ten_stars: sajuResult.tenStars,
+                  twelve_stages: sajuResult.twelveStages,
+                  interactions: sajuResult.interactions,
+                  yongsin: sajuResult.yongsin,
+                  major_fortunes: sajuResult.majorFortunes,
+                  yearly_fortune: sajuResult.yearlyFortune,
+                  overall_reading: result.overallReading,
+                  topic_reading: result.topicReading || "",
+                  advice: result.advice,
+                }).select("share_token").single(),
+                supabase.from("sessions").update({
+                  status: "completed", completed_at: new Date().toISOString(),
+                }).eq("id", sessionId),
+              ]);
+              result.shareToken = readingRes.data?.share_token ?? null;
+            } catch (e) {
+              console.error("사주 DB 저장 실패:", e);
+            }
+          }
           controller.enqueue(encoder.encode(`data: ${JSON.stringify({
             done: true,
             result,
             sajuData: sajuResult,
           })}\n\n`));
-
-          if (supabase && sessionId) {
-            Promise.all([
-              supabase.from("saju_readings").insert({
-                session_id: sessionId,
-                birth_date: userInfo.birthDate,
-                birth_hour: userInfo.birthHour,
-                gender: userInfo.gender,
-                birth_name: userInfo.name || null,
-                pillars: sajuResult.pillars,
-                day_master: sajuResult.dayMaster,
-                day_master_element: sajuResult.dayMasterElement,
-                is_strong: sajuResult.isStrong,
-                elements: sajuResult.elements,
-                ten_stars: sajuResult.tenStars,
-                twelve_stages: sajuResult.twelveStages,
-                interactions: sajuResult.interactions,
-                yongsin: sajuResult.yongsin,
-                major_fortunes: sajuResult.majorFortunes,
-                yearly_fortune: sajuResult.yearlyFortune,
-                overall_reading: result.overallReading,
-                topic_reading: result.topicReading || "",
-                advice: result.advice,
-              }),
-              supabase.from("sessions").update({
-                status: "completed", completed_at: new Date().toISOString(),
-              }).eq("id", sessionId),
-            ]).catch((e) => console.error("사주 DB 저장 실패:", e));
-          }
         } catch (e) {
           const errMsg = e instanceof Error ? e.message : String(e);
           console.error("사주 리딩 생성 실패:", errMsg);

--- a/src/app/api/shinjeom/message/route.ts
+++ b/src/app/api/shinjeom/message/route.ts
@@ -7,31 +7,32 @@ import { Topic, ChatMessage } from "@/types/session";
 const shinjeomService = new ShinjeomService();
 const aiProvider = new FallbackProvider();
 
-/** DB 저장 (fire-and-forget — 스트림을 블로킹하지 않음) */
+/** DB 저장 — 최종 턴에서 share_token 반환 */
 async function saveToDb(sessionId: string | null | undefined, params: {
   isFinalTurn: boolean;
-  result?: { overallReading: string; topicReading?: string; advice: string };
+  result?: { overallReading: string; topicReading?: string; advice: string; shareToken?: string | null };
   currentMessage?: string;
   fullResponse?: string;
   turnNumber?: number;
-}) {
-  if (!sessionId) return;
+}): Promise<string | null> {
+  if (!sessionId) return null;
   try {
     const { createClient } = await import("@/lib/supabase/server");
     const supabase = await createClient();
 
     if (params.isFinalTurn && params.result) {
-      await Promise.all([
+      const [readingRes] = await Promise.all([
         supabase.from("shinjeom_readings").insert({
           session_id: sessionId,
           overall_reading: params.result.overallReading,
           topic_reading: params.result.topicReading || "",
           advice: params.result.advice,
-        }),
+        }).select("share_token").single(),
         supabase.from("sessions").update({
           status: "completed", completed_at: new Date().toISOString(),
         }).eq("id", sessionId),
       ]);
+      return readingRes.data?.share_token ?? null;
     } else if (params.currentMessage && params.fullResponse && params.turnNumber) {
       await supabase.from("shinjeom_messages").insert([
         { session_id: sessionId, role: "user", content: params.currentMessage, message_index: (params.turnNumber - 1) * 2 },
@@ -39,6 +40,7 @@ async function saveToDb(sessionId: string | null | undefined, params: {
       ]);
     }
   } catch (e) { console.error("신점 DB 저장 실패:", e); }
+  return null;
 }
 
 export async function POST(request: NextRequest) {
@@ -75,13 +77,14 @@ export async function POST(request: NextRequest) {
           if (isFinalTurn) {
             const result = shinjeomService.parseResult(fullResponse);
 
-            // 결과를 먼저 클라이언트에 전송 (DB 저장은 비동기 fire-and-forget)
+            // DB 저장 후 share_token 포함하여 done 이벤트 전송
+            const shareToken = await saveToDb(sessionId, { isFinalTurn: true, result });
+            result.shareToken = shareToken;
             controller.enqueue(encoder.encode(`data: ${JSON.stringify({ done: true, isFinal: true, result })}\n\n`));
-            saveToDb(sessionId, { isFinalTurn: true, result });
           } else {
-            // 중간 대화 — 응답 먼저 전송, DB 저장은 비동기
+            // 중간 대화 — 응답 전송 후 DB 저장
             controller.enqueue(encoder.encode(`data: ${JSON.stringify({ done: true, isFinal: false, message: fullResponse })}\n\n`));
-            saveToDb(sessionId, { isFinalTurn: false, currentMessage, fullResponse, turnNumber });
+            await saveToDb(sessionId, { isFinalTurn: false, currentMessage, fullResponse, turnNumber });
           }
         } catch (e) {
           const errMsg = e instanceof Error ? e.message : String(e);

--- a/src/app/api/shinjeom/result/[id]/route.ts
+++ b/src/app/api/shinjeom/result/[id]/route.ts
@@ -1,0 +1,15 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+
+export async function GET(_request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  try {
+    const { id } = await params;
+    const supabase = await createClient();
+    const { data: reading, error } = await supabase
+      .from("shinjeom_readings").select("*").eq("share_token", id).single();
+    if (error || !reading) return NextResponse.json({ error: "Reading not found" }, { status: 404 });
+    return NextResponse.json({ reading });
+  } catch {
+    return NextResponse.json({ error: "Failed to fetch reading" }, { status: 500 });
+  }
+}

--- a/src/app/api/tarot/reading/route.ts
+++ b/src/app/api/tarot/reading/route.ts
@@ -74,26 +74,29 @@ export async function POST(request: NextRequest) {
           }
           const result = tarotService.parseResult(fullResponse);
 
-          // 결과를 먼저 클라이언트에 전송 (DB 저장은 비동기 병렬)
-          controller.enqueue(encoder.encode(`data: ${JSON.stringify({ done: true, result })}\n\n`));
-
-          // DB 저장 — fire-and-forget (스트림 블로킹 없음)
+          // DB 저장 후 share_token 포함하여 done 이벤트 전송
           if (supabase && sessionId) {
-            Promise.all([
-              supabase.from("readings").insert({
-                session_id: sessionId, card_interpretation: result.cardInterpretations,
-                overall_reading: result.overallReading, advice: result.advice,
-              }),
-              supabase.from("sessions").update({
-                status: "completed", completed_at: new Date().toISOString(),
-              }).eq("id", sessionId),
-              supabase.from("session_cards").insert(
-                cards.map((c: { cardId: string; position: number; isReversed: boolean }) => ({
-                  session_id: sessionId, card_id: c.cardId, position: c.position, is_reversed: c.isReversed,
-                }))
-              ),
-            ]).catch((e) => console.error("타로 DB 저장 실패:", e));
+            try {
+              const [readingRes] = await Promise.all([
+                supabase.from("readings").insert({
+                  session_id: sessionId, card_interpretation: result.cardInterpretations,
+                  overall_reading: result.overallReading, advice: result.advice,
+                }).select("share_token").single(),
+                supabase.from("sessions").update({
+                  status: "completed", completed_at: new Date().toISOString(),
+                }).eq("id", sessionId),
+                supabase.from("session_cards").insert(
+                  cards.map((c: { cardId: string; position: number; isReversed: boolean }) => ({
+                    session_id: sessionId, card_id: c.cardId, position: c.position, is_reversed: c.isReversed,
+                  }))
+                ),
+              ]);
+              result.shareToken = readingRes.data?.share_token ?? null;
+            } catch (e) {
+              console.error("타로 DB 저장 실패:", e);
+            }
           }
+          controller.enqueue(encoder.encode(`data: ${JSON.stringify({ done: true, result })}\n\n`));
         } catch (e) {
           const errMsg = e instanceof Error ? e.message : String(e);
           console.error("리딩 생성 실패:", errMsg);

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -277,7 +277,11 @@ export default async function MyPage() {
                 : overallText || null;
               const shareToken = reading?.share_token;
               const serviceLabel = session.service_type === "saju" ? "사주" : session.service_type === "shinjeom" ? "신점" : "타로";
-              const resultPath = session.service_type === "saju" ? `/saju/result/${shareToken}` : `/tarot/result/${shareToken}`;
+              const resultPath = session.service_type === "saju"
+                ? `/saju/result/${shareToken}`
+                : session.service_type === "shinjeom"
+                  ? `/shinjeom/result/${shareToken}`
+                  : `/tarot/result/${shareToken}`;
 
               const content = (
                 <>

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import Image from "next/image";
 import Link from "next/link";
 import { useThemeStore, themes, ThemeId } from "@/hooks/useTheme";
@@ -8,6 +8,8 @@ import { useSkinStore } from "@/hooks/useSkinStore";
 import { useGenderStore } from "@/hooks/useGenderStore";
 import { cardSkins } from "@/data/skins";
 import { GenderFilter } from "@/types/character";
+import { getCharactersByGender, getCharacterById } from "@/data/characters";
+import { createClient } from "@/lib/supabase/client";
 
 export default function SettingsPage() {
   const { mode, activeTheme, setMode } = useThemeStore();
@@ -22,6 +24,45 @@ export default function SettingsPage() {
     if (typeof window !== "undefined") return !!localStorage.getItem("arcana_user_info");
     return false;
   });
+
+  // 선호 상담사
+  const [userId, setUserId] = useState<string | null>(null);
+  const [favoriteCharacterId, setFavoriteCharacterId] = useState<string | null>(null);
+  const [isSavingFavorite, setIsSavingFavorite] = useState(false);
+
+  useEffect(() => {
+    const supabase = createClient();
+    supabase.auth.getUser().then(({ data: { user } }) => {
+      if (user) {
+        setUserId(user.id);
+        supabase.from("profiles").select("favorite_character_id").eq("id", user.id).single()
+          .then(({ data }) => setFavoriteCharacterId(data?.favorite_character_id ?? null));
+      } else {
+        const saved = localStorage.getItem("arcana-favorite-character");
+        if (saved) setFavoriteCharacterId(saved);
+      }
+    });
+  }, []);
+
+  const handleSelectFavorite = async (characterId: string) => {
+    const newValue = favoriteCharacterId === characterId ? null : characterId;
+    setFavoriteCharacterId(newValue);
+
+    if (userId) {
+      setIsSavingFavorite(true);
+      const supabase = createClient();
+      await supabase.from("profiles").update({ favorite_character_id: newValue }).eq("id", userId);
+      setIsSavingFavorite(false);
+    } else {
+      if (newValue) {
+        localStorage.setItem("arcana-favorite-character", newValue);
+      } else {
+        localStorage.removeItem("arcana-favorite-character");
+      }
+    }
+  };
+
+  const filteredCharacters = getCharactersByGender(genderFilter);
 
   const toggleConfirmMode = () => {
     const next = !confirmEachCard;
@@ -131,6 +172,49 @@ export default function SettingsPage() {
                   }`}
                 >
                   {opt.label}
+                </button>
+              ))}
+            </div>
+          </section>
+
+          {/* 선호 상담사 */}
+          <section className="bg-arcana-card/70 backdrop-blur-sm border border-arcana-border rounded-2xl p-5">
+            <h2 className="font-sans font-bold text-base md:text-lg text-arcana-text mb-1">선호 상담사</h2>
+            <p className="text-arcana-muted text-xs mb-4">
+              {favoriteCharacterId
+                ? `현재: ${getCharacterById(favoriteCharacterId)?.name ?? "없음"}`
+                : "선택된 상담사 없음"}
+              {isSavingFavorite && " (저장 중...)"}
+            </p>
+
+            {!userId && (
+              <p className="text-amber-400/80 text-xs mb-3">
+                로그인하면 선호 상담사가 계정에 저장됩니다.
+              </p>
+            )}
+
+            <div className="grid grid-cols-3 md:grid-cols-4 gap-3">
+              {filteredCharacters.map((char) => (
+                <button
+                  key={char.id}
+                  onClick={() => handleSelectFavorite(char.id)}
+                  className={`flex flex-col items-center gap-1.5 p-2.5 rounded-xl border text-xs transition-all ${
+                    favoriteCharacterId === char.id
+                      ? "border-arcana-purple bg-arcana-purple/15 text-arcana-purple shadow-sm"
+                      : "border-arcana-border/50 text-arcana-muted hover:border-arcana-border"
+                  }`}
+                >
+                  <div className="relative w-12 h-12 rounded-full overflow-hidden bg-arcana-surface">
+                    <Image
+                      src={char.expressions.default}
+                      alt={char.name}
+                      fill
+                      className="object-cover object-top"
+                      sizes="48px"
+                    />
+                  </div>
+                  <span className="font-sans text-xs leading-tight text-center">{char.name}</span>
+                  <span className="text-[10px] text-arcana-muted/70 leading-tight text-center">{char.speciality}</span>
                 </button>
               ))}
             </div>

--- a/src/app/shinjeom/result/[id]/ShinjeomResultShareButton.tsx
+++ b/src/app/shinjeom/result/[id]/ShinjeomResultShareButton.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { useState } from "react";
+
+interface ShinjeomResultShareButtonProps {
+  shareToken: string;
+}
+
+export function ShinjeomResultShareButton({ shareToken }: ShinjeomResultShareButtonProps) {
+  const [copied, setCopied] = useState(false);
+
+  const handleShare = async () => {
+    const url = `${window.location.origin}/shinjeom/result/${shareToken}`;
+    const text = "🔮 신점 상담 결과를 확인해보세요!\n\n- ArcanaInsight";
+
+    if (navigator.share) {
+      try {
+        await navigator.share({ title: "신점 상담 결과 - ArcanaInsight", text, url });
+      } catch {
+        /* 사용자가 공유 취소 */
+      }
+    } else {
+      try {
+        await navigator.clipboard.writeText(`${text}\n${url}`);
+        setCopied(true);
+        setTimeout(() => setCopied(false), 2000);
+      } catch {
+        /* 클립보드 접근 실패 */
+      }
+    }
+  };
+
+  return (
+    <button
+      onClick={handleShare}
+      className="px-8 py-3 rounded-full border border-amber-400 text-amber-400 font-serif font-bold text-sm hover:bg-amber-400/10 transition-colors"
+    >
+      {copied ? "링크 복사됨!" : "결과 공유하기"}
+    </button>
+  );
+}

--- a/src/app/shinjeom/result/[id]/page.tsx
+++ b/src/app/shinjeom/result/[id]/page.tsx
@@ -1,0 +1,80 @@
+import { notFound } from "next/navigation";
+import Image from "next/image";
+import { createClient } from "@/lib/supabase/server";
+import { cleanReadingText } from "@/services/core/text-cleaner";
+import { ReadingText } from "@/components/common/ReadingText";
+import { ShinjeomResultShareButton } from "./ShinjeomResultShareButton";
+
+export default async function ShinjeomResultPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  const supabase = await createClient();
+  const { data: reading } = await supabase
+    .from("shinjeom_readings")
+    .select("*")
+    .eq("share_token", id)
+    .single();
+
+  if (!reading) notFound();
+
+  const overallReading = cleanReadingText(reading.overall_reading || "");
+  const topicReading = cleanReadingText(reading.topic_reading || "");
+  const advice = cleanReadingText(reading.advice || "");
+
+  return (
+    <div className="relative min-h-screen overflow-hidden">
+      <div className="fixed inset-0 -z-10">
+        <Image src="/images/backgrounds/result-bg.jpg" alt="" fill className="object-cover" />
+        <div className="absolute inset-0 bg-arcana-bg/60" />
+      </div>
+
+      <div className="max-w-5xl mx-auto px-4 py-8 relative">
+        <div className="text-center mb-8">
+          <h1 className="text-2xl md:text-3xl font-serif font-bold text-amber-400 mb-2 drop-shadow-md">신점 상담 결과</h1>
+          <p className="text-arcana-muted text-sm">{new Date(reading.created_at).toLocaleDateString("ko-KR")}</p>
+        </div>
+
+        <div className="space-y-4 md:space-y-5">
+          {overallReading && (
+            <div className="bg-amber-500/10 backdrop-blur-sm border border-amber-500/30 rounded-2xl p-4 md:p-6">
+              <div className="flex items-center gap-2 mb-3">
+                <span className="text-lg">🔮</span>
+                <h2 className="text-amber-400 font-serif font-bold text-base md:text-lg">종합 해석</h2>
+              </div>
+              <ReadingText text={overallReading} />
+            </div>
+          )}
+
+          {topicReading && (
+            <div className="bg-arcana-card/70 backdrop-blur-sm border border-arcana-border rounded-2xl p-4 md:p-6">
+              <div className="flex items-center gap-2 mb-3">
+                <span className="text-lg">🔍</span>
+                <h2 className="text-arcana-gold font-serif font-bold text-base md:text-lg">주제별 해석</h2>
+              </div>
+              <ReadingText text={topicReading} />
+            </div>
+          )}
+
+          {advice && (
+            <div className="bg-arcana-gold/5 backdrop-blur-sm border border-arcana-gold/30 rounded-2xl p-4 md:p-6">
+              <div className="flex items-center gap-2 mb-3">
+                <span className="text-lg">✨</span>
+                <h2 className="text-arcana-gold font-serif font-bold text-base md:text-lg">조언</h2>
+              </div>
+              <ReadingText text={advice} />
+            </div>
+          )}
+        </div>
+
+        <div className="flex justify-center gap-4 mt-8">
+          <a
+            href="/shinjeom"
+            className="px-8 py-3 rounded-full bg-gradient-to-r from-amber-500 to-amber-600 text-white font-serif font-bold text-sm hover:opacity-90 transition-opacity shadow-lg shadow-amber-500/20"
+          >
+            나도 신점 상담 받기
+          </a>
+          <ShinjeomResultShareButton shareToken={id} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/supabase/migrations/010_shinjeom_rls_policies.sql
+++ b/supabase/migrations/010_shinjeom_rls_policies.sql
@@ -1,0 +1,27 @@
+-- 신점 테이블 인덱스 추가
+CREATE INDEX IF NOT EXISTS idx_shinjeom_readings_session_id ON shinjeom_readings(session_id);
+CREATE INDEX IF NOT EXISTS idx_shinjeom_readings_share_token ON shinjeom_readings(share_token);
+
+-- 신점 리딩 RLS 정책
+ALTER TABLE shinjeom_readings ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Shinjeom readings viewable by session owner" ON shinjeom_readings FOR SELECT
+  USING (EXISTS (
+    SELECT 1 FROM sessions s
+    WHERE s.id = session_id AND (s.user_id = auth.uid() OR s.user_id IS NULL)
+  ));
+CREATE POLICY "Shinjeom readings viewable by share token" ON shinjeom_readings FOR SELECT
+  USING (true);
+CREATE POLICY "Anyone can insert shinjeom readings" ON shinjeom_readings FOR INSERT
+  WITH CHECK (true);
+
+-- 신점 메시지 RLS 정책
+ALTER TABLE shinjeom_messages ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Shinjeom messages viewable by session owner" ON shinjeom_messages FOR SELECT
+  USING (EXISTS (
+    SELECT 1 FROM sessions s
+    WHERE s.id = session_id AND (s.user_id = auth.uid() OR s.user_id IS NULL)
+  ));
+CREATE POLICY "Anyone can insert shinjeom messages" ON shinjeom_messages FOR INSERT
+  WITH CHECK (true);


### PR DESCRIPTION
## Summary
- 타로/사주/신점 API의 fire-and-forget DB 저장을 await로 변경하여 share_token이 클라이언트에 정상 반환되도록 수정
- 마이페이지에서 신점 결과 경로 추가 및 신점 결과 페이지/API/공유 버튼 신규 생성
- 설정 페이지에 선호 상담사 선택/해제 기능 추가 (로그인 시 DB 저장, 비로그인 시 localStorage)
- shinjeom_readings/shinjeom_messages RLS 정책 마이그레이션 추가

## Test plan
- [ ] 타로/사주/신점 리딩 완료 후 마이페이지에서 이력 조회 가능 확인
- [ ] 신점 결과 공유 링크(`/shinjeom/result/[token]`) 정상 접근 확인
- [ ] 설정 페이지에서 선호 상담사 선택/해제 토글 동작 확인
- [ ] 성별 필터 변경 시 캐릭터 목록 갱신 확인
- [ ] 로그인 상태에서 선호 상담사 DB 저장 → 마이페이지 반영 확인
- [ ] `pnpm type-check && pnpm lint` 통과 확인

https://claude.ai/code/session_01FBturbiy5BLvavTRTKeEs5