### PR TITLE
feat: 신점 무제한 대화 구조 — 사용자가 직접 종료 시점 결정

### DIFF
--- a/src/app/api/shinjeom/message/route.ts
+++ b/src/app/api/shinjeom/message/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest } from "next/server";
-import { ShinjeomService, MAX_TURNS } from "@/services/shinjeom/shinjeom-service";
+import { ShinjeomService } from "@/services/shinjeom/shinjeom-service";
 import { FallbackProvider } from "@/services/core/fallback-provider";
 import { Topic, ChatMessage } from "@/types/session";
 
@@ -13,7 +13,7 @@ async function saveToDb(sessionId: string | null | undefined, params: {
   result?: { overallReading: string; topicReading?: string; advice: string };
   currentMessage?: string;
   fullResponse?: string;
-  turnNumber?: number;
+  messageIndex?: number;
 }) {
   if (!sessionId) return;
   try {
@@ -32,10 +32,10 @@ async function saveToDb(sessionId: string | null | undefined, params: {
           status: "completed", completed_at: new Date().toISOString(),
         }).eq("id", sessionId),
       ]);
-    } else if (params.currentMessage && params.fullResponse && params.turnNumber) {
+    } else if (params.currentMessage && params.fullResponse && params.messageIndex !== undefined) {
       await supabase.from("shinjeom_messages").insert([
-        { session_id: sessionId, role: "user", content: params.currentMessage, message_index: (params.turnNumber - 1) * 2 },
-        { session_id: sessionId, role: "character", content: params.fullResponse, message_index: (params.turnNumber - 1) * 2 + 1 },
+        { session_id: sessionId, role: "user", content: params.currentMessage, message_index: params.messageIndex },
+        { session_id: sessionId, role: "character", content: params.fullResponse, message_index: params.messageIndex + 1 },
       ]);
     }
   } catch (e) { console.error("신점 DB 저장 실패:", e); }
@@ -44,22 +44,25 @@ async function saveToDb(sessionId: string | null | undefined, params: {
 export async function POST(request: NextRequest) {
   try {
     const body = await request.json();
-    const { sessionId, topic, characterId, currentMessage, chatHistory, turnNumber } = body as {
+    const { sessionId, topic, characterId, currentMessage, chatHistory, isFinalTurn, messageIndex } = body as {
       sessionId?: string | null;
       topic: Topic;
       characterId?: string;
-      currentMessage: string;
+      currentMessage?: string;
       chatHistory: ChatMessage[];
-      turnNumber: number;
+      isFinalTurn: boolean;
+      messageIndex: number;
     };
 
-    if (!topic || !currentMessage) {
+    if (!topic) {
       return new Response(JSON.stringify({ error: "Missing required fields" }), { status: 400, headers: { "Content-Type": "application/json" } });
+    }
+    if (!isFinalTurn && !currentMessage) {
+      return new Response(JSON.stringify({ error: "Message required for non-final turns" }), { status: 400, headers: { "Content-Type": "application/json" } });
     }
 
     const systemPrompt = shinjeomService.getSystemPrompt(characterId);
-    const userPrompt = shinjeomService.buildConversationPrompt(topic, currentMessage, chatHistory, turnNumber);
-    const isFinalTurn = turnNumber >= MAX_TURNS;
+    const userPrompt = shinjeomService.buildConversationPrompt(topic, currentMessage, chatHistory, isFinalTurn);
 
     const encoder = new TextEncoder();
     const stream = new ReadableStream({
@@ -81,7 +84,7 @@ export async function POST(request: NextRequest) {
           } else {
             // 중간 대화 — 응답 먼저 전송, DB 저장은 비동기
             controller.enqueue(encoder.encode(`data: ${JSON.stringify({ done: true, isFinal: false, message: fullResponse })}\n\n`));
-            saveToDb(sessionId, { isFinalTurn: false, currentMessage, fullResponse, turnNumber });
+            saveToDb(sessionId, { isFinalTurn: false, currentMessage, fullResponse, messageIndex });
           }
         } catch (e) {
           const errMsg = e instanceof Error ? e.message : String(e);

--- a/src/app/shinjeom/session/page.tsx
+++ b/src/app/shinjeom/session/page.tsx
@@ -10,7 +10,6 @@ import { ParticleOverlay } from "@/components/effects/ParticleOverlay";
 import { ReadingText } from "@/components/common/ReadingText";
 import { getCharacterById } from "@/data/characters";
 import { useCharacterStore } from "@/hooks/useCharacter";
-import { MAX_TURNS } from "@/services/shinjeom/shinjeom-service";
 
 export default function ShinjeomSessionPage() {
   const router = useRouter();
@@ -68,10 +67,12 @@ export default function ShinjeomSessionPage() {
     const message = inputText.trim();
     if (!message || isLoading) return;
 
-    const newTurn = turnCount + 1;
     setInputText("");
     setLoading(true);
     setMood("mystical");
+
+    // messageIndex: addChatMessage 호출 전 현재 길이를 캡처
+    const messageIndex = useShinjeomSessionStore.getState().chatMessages.length;
 
     // 사용자 메시지 추가
     addChatMessage({
@@ -88,7 +89,8 @@ export default function ShinjeomSessionPage() {
           topic, characterId,
           currentMessage: message,
           chatHistory: useShinjeomSessionStore.getState().chatMessages,
-          turnNumber: newTurn,
+          isFinalTurn: false,
+          messageIndex,
         }),
       });
 
@@ -107,13 +109,12 @@ export default function ShinjeomSessionPage() {
       const decoder = new TextDecoder();
       let sseBuffer = "";
       let fullText = "";
-      const isFinalTurn = newTurn >= MAX_TURNS;
 
       // 스트리밍 메시지를 위한 임시 ID
       const msgId = crypto.randomUUID();
       addChatMessage({
         id: msgId, role: "character",
-        content: isFinalTurn ? "신점 결과를 준비하고 있어요..." : "",
+        content: "",
         mood: "mystical", timestamp: new Date(),
       });
 
@@ -138,25 +139,95 @@ export default function ShinjeomSessionPage() {
             }
             if (data.chunk) {
               fullText += data.chunk;
-              // 최종 턴에서는 JSON이 오므로 채팅에 표시하지 않음
-              if (!isFinalTurn) {
-                useShinjeomSessionStore.setState((state) => ({
-                  chatMessages: state.chatMessages.map((m) =>
-                    m.id === msgId ? { ...m, content: fullText } : m
-                  ),
-                }));
-              }
+              useShinjeomSessionStore.setState((state) => ({
+                chatMessages: state.chatMessages.map((m) =>
+                  m.id === msgId ? { ...m, content: fullText } : m
+                ),
+              }));
             }
-            if (data.done) {
-              if (data.isFinal && data.result) {
-                // 최종 결과 → 대기 메시지 제거 후 결과 화면 전환
-                useShinjeomSessionStore.setState((state) => ({
-                  chatMessages: state.chatMessages.filter((m) => m.id !== msgId),
-                }));
-                setReadingResult(data.result);
-                setPhase("result");
-                setMood("smile");
-              }
+          } catch { /* 파싱 실패 */ }
+        }
+      }
+    } catch {
+      addChatMessage({
+        id: crypto.randomUUID(), role: "character",
+        content: "네트워크 문제가 발생했어요. 다시 시도해주세요.",
+        mood: "default", timestamp: new Date(),
+      });
+      setMood("default");
+    }
+    setLoading(false);
+  };
+
+  const handleEndConsultation = async () => {
+    if (turnCount < 1 || isLoading) return;
+
+    setLoading(true);
+    setMood("mystical");
+
+    try {
+      const currentChatMessages = useShinjeomSessionStore.getState().chatMessages;
+
+      const response = await fetch("/api/shinjeom/message", {
+        method: "POST", headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          sessionId: useShinjeomSessionStore.getState().sessionId,
+          topic, characterId,
+          currentMessage: undefined,
+          chatHistory: currentChatMessages,
+          isFinalTurn: true,
+          messageIndex: currentChatMessages.length,
+        }),
+      });
+
+      if (!response.ok || !response.body) {
+        addChatMessage({
+          id: crypto.randomUUID(), role: "character",
+          content: "죄송해요, 결과를 가져오는 중 오류가 발생했어요. 다시 시도해주세요.",
+          mood: "default", timestamp: new Date(),
+        });
+        setMood("default");
+        setLoading(false);
+        return;
+      }
+
+      const msgId = crypto.randomUUID();
+      addChatMessage({
+        id: msgId, role: "character",
+        content: "신점 결과를 준비하고 있어요...",
+        mood: "mystical", timestamp: new Date(),
+      });
+
+      const reader = response.body.getReader();
+      const decoder = new TextDecoder();
+      let sseBuffer = "";
+
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        sseBuffer += decoder.decode(value, { stream: true });
+        const lines = sseBuffer.split("\n");
+        sseBuffer = lines.pop() || "";
+
+        for (const line of lines) {
+          if (!line.startsWith("data: ")) continue;
+          try {
+            const data = JSON.parse(line.slice(6));
+            if (data.error) {
+              useShinjeomSessionStore.setState((state) => ({
+                chatMessages: state.chatMessages.map((m) =>
+                  m.id === msgId ? { ...m, content: "문제가 발생했어요. 다시 시도해주세요." } : m
+                ),
+              }));
+              break;
+            }
+            if (data.done && data.isFinal && data.result) {
+              useShinjeomSessionStore.setState((state) => ({
+                chatMessages: state.chatMessages.filter((m) => m.id !== msgId),
+              }));
+              setReadingResult(data.result);
+              setPhase("result");
+              setMood("smile");
             }
           } catch { /* 파싱 실패 */ }
         }
@@ -270,31 +341,35 @@ export default function ShinjeomSessionPage() {
               </div>
 
               {/* 입력 */}
-              {turnCount < MAX_TURNS && (
-                <div className="flex-shrink-0 py-3">
-                  <div className="flex gap-2">
-                    <input
-                      type="text"
-                      value={inputText}
-                      onChange={(e) => setInputText(e.target.value)}
-                      onKeyDown={(e) => { if (e.key === "Enter" && !e.nativeEvent.isComposing) handleSend(); }}
-                      placeholder={turnCount === 0 ? "고민을 말씀해주세요..." : "답변을 입력하세요..."}
-                      disabled={isLoading}
-                      className="flex-1 px-4 py-2.5 rounded-full bg-arcana-card/70 border border-arcana-border text-arcana-text text-sm placeholder:text-arcana-muted/50 focus:outline-none focus:border-arcana-purple transition-colors"
-                    />
-                    <button
-                      onClick={handleSend}
-                      disabled={!inputText.trim() || isLoading}
-                      className="px-5 py-2.5 rounded-full bg-gradient-to-r from-arcana-purple to-arcana-indigo text-white font-serif font-bold text-sm disabled:opacity-40 transition-opacity"
-                    >
-                      전송
-                    </button>
-                  </div>
-                  <p className="text-arcana-muted text-[10px] text-center mt-1.5">
-                    {turnCount}/{MAX_TURNS}회 대화 · {MAX_TURNS - turnCount}회 남음
-                  </p>
+              <div className="flex-shrink-0 py-3">
+                <div className="flex gap-2">
+                  <input
+                    type="text"
+                    value={inputText}
+                    onChange={(e) => setInputText(e.target.value)}
+                    onKeyDown={(e) => { if (e.key === "Enter" && !e.nativeEvent.isComposing) handleSend(); }}
+                    placeholder={turnCount === 0 ? "고민을 말씀해주세요..." : "답변을 입력하세요..."}
+                    disabled={isLoading}
+                    className="flex-1 px-4 py-2.5 rounded-full bg-arcana-card/70 border border-arcana-border text-arcana-text text-sm placeholder:text-arcana-muted/50 focus:outline-none focus:border-arcana-purple transition-colors"
+                  />
+                  <button
+                    onClick={handleSend}
+                    disabled={!inputText.trim() || isLoading}
+                    className="px-5 py-2.5 rounded-full bg-gradient-to-r from-arcana-purple to-arcana-indigo text-white font-serif font-bold text-sm disabled:opacity-40 transition-opacity"
+                  >
+                    전송
+                  </button>
                 </div>
-              )}
+                {turnCount >= 1 && (
+                  <button
+                    onClick={handleEndConsultation}
+                    disabled={isLoading}
+                    className="w-full mt-2 py-2.5 rounded-full border border-arcana-gold/60 text-arcana-gold font-serif font-bold text-sm disabled:opacity-40 transition-opacity hover:bg-arcana-gold/10"
+                  >
+                    신점 결과 받기
+                  </button>
+                )}
+              </div>
             </>
           )}
         </div>

--- a/src/services/shinjeom/shinjeom-service.ts
+++ b/src/services/shinjeom/shinjeom-service.ts
@@ -13,8 +13,6 @@ const topicLabels: Record<string, string> = {
   "shinjeom-auspicious": "택일 (날짜 선택)",
 };
 
-const MAX_TURNS = 3; // 사용자 질문 3회
-
 export class ShinjeomService implements DivinationService {
   id = "shinjeom";
   name = "신점";
@@ -56,9 +54,9 @@ export class ShinjeomService implements DivinationService {
 - 구체적이고 실용적인 조언을 포함합니다.
 
 중요 규칙 — 대화 구조:
-- 사용자가 처음 고민을 말하면, 더 깊이 이해하기 위한 질문을 1개 던집니다.
-- 사용자가 답변하면, 한 번 더 핵심을 파악하는 질문을 합니다.
-- 3번째 사용자 답변 이후에는 최종 신점 결과를 제공합니다.
+- 사용자의 고민에 공감하며 핵심을 파악하기 위한 질문을 1개씩 이어갑니다.
+- 사용자가 충분히 털어놓았다고 느낄 때 자연스럽게 대화를 마무리합니다.
+- 최종 신점 결과는 사용자가 상담 종료를 요청할 때 제공합니다.
 - 질문은 짧고 명확하게, 답변은 풍부하고 깊이 있게 합니다.
 
 중요 규칙 — 가독성:
@@ -71,12 +69,11 @@ export class ShinjeomService implements DivinationService {
 - 최종이 아닌 중간 대화에서는 일반 텍스트로 응답합니다.`;
   }
 
-  /** 중간 대화 프롬프트 (1~2번째 답변) */
   buildConversationPrompt(
     topic: Topic,
-    currentMessage: string,
+    currentMessage: string | undefined,
     chatHistory: ChatMessage[],
-    turnNumber: number,
+    isFinalTurn: boolean,
   ): string {
     const topicLabel = topicLabels[topic] || topic;
     const historyText = chatHistory
@@ -84,7 +81,7 @@ export class ShinjeomService implements DivinationService {
       .map((m) => `${m.role === "user" ? "사용자" : "상담사"}: ${m.content}`)
       .join("\n\n");
 
-    if (turnNumber < MAX_TURNS) {
+    if (!isFinalTurn) {
       return `상담 주제: ${topicLabel}
 
 이전 대화:
@@ -98,15 +95,13 @@ ${historyText}
 - 일반 텍스트로 응답하세요 (JSON 아님)`;
     }
 
-    // 3번째 답변 → 최종 결과
+    // 사용자 종료 요청 → 전체 대화 종합하여 최종 결과
     return `상담 주제: ${topicLabel}
 
 전체 대화:
 ${historyText}
 
-사용자의 마지막 답변: ${currentMessage}
-
-이제 모든 대화를 종합하여 최종 신점 결과를 제공해주세요.
+지금까지의 모든 대화를 종합하여 최종 신점 결과를 제공해주세요.
 
 응답 형식 — 반드시 아래 JSON:
 {
@@ -124,7 +119,7 @@ JSON 앞뒤에 어떤 텍스트도 추가하지 않습니다.`;
       context.topic,
       context.chatHistory[context.chatHistory.length - 1]?.content || "",
       context.chatHistory,
-      context.chatHistory.filter((m) => m.role === "user").length,
+      false,
     );
   }
 
@@ -150,5 +145,3 @@ JSON 앞뒤에 어떤 텍스트도 추가하지 않습니다.`;
     };
   }
 }
-
-export { MAX_TURNS };


### PR DESCRIPTION
## Summary

- 신점 서비스의 3회 고정 대화 제한을 제거하고, 사용자가 원하는 만큼 대화 후 직접 종료할 수 있도록 변경
- 1턴 이상 대화 후 **신점 결과 받기** 버튼이 나타나며, 클릭 시 전체 대화를 종합한 최종 신점 결과를 생성
- 대화 진행률 텍스트("0/3회 대화 · 3회 남음") 제거

## 변경 파일

| 파일 | 변경 내용 |
|------|---------|
| `src/services/shinjeom/shinjeom-service.ts` | `MAX_TURNS` 상수 제거, `buildConversationPrompt` 시그니처 `turnNumber→isFinalTurn` 변경 |
| `src/app/api/shinjeom/message/route.ts` | `isFinalTurn`/`messageIndex`를 클라이언트에서 직접 수신, DB message_index 계산 방식 개선 |
| `src/app/shinjeom/session/page.tsx` | 입력 필드 항상 표시, `handleEndConsultation` 함수 추가, 결과 받기 버튼 JSX 추가 |

## Test plan

- [ ] 신점 세션 진입 → 입력 필드 항상 표시 확인
- [ ] 1턴 전: "신점 결과 받기" 버튼 미노출 확인
- [ ] 1턴 이후: 버튼 노출 확인
- [ ] 버튼 클릭 → "신점 결과를 준비하고 있어요..." → 결과 화면 전환 확인
- [ ] 스트리밍 중 버튼 비활성화 확인
- [ ] 5회 이상 대화 후 종료 버튼 클릭 → 정상 결과 생성 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)