### PR TITLE
fix: 신점 E2E 테스트 무제한 대화 구조 반영 + CLAUDE.md 최신화

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -148,7 +148,7 @@ src/
 │   │                           # fallback-provider.ts (Grok→Claude 자동 전환),
 │   │                           # prompt-builder.ts, text-cleaner.ts
 │   ├── saju/                   # saju-service.ts, saju-calculator.ts, saju-types.ts
-│   ├── shinjeom/               # shinjeom-service.ts (대화형 3회 문답)
+│   ├── shinjeom/               # shinjeom-service.ts (무제한 대화형, isFinalTurn 플래그로 결과 요청)
 │   └── tarot/                  # tarot-service.ts, deck-manager.ts, spread-resolver.ts
 └── types/                      # card.ts, character.ts, session.ts, service.ts, user-info.ts
 
@@ -185,11 +185,12 @@ scripts/                        # 유틸리티 스크립트
 ├── regenerate-all-nukki.mjs    # 전체 캐릭터 누끼 재생성
 └── upload-skin-images.ts       # 생성된 스킨 이미지를 Supabase Storage에 업로드
 
-e2e/                            # Playwright E2E 테스트 (19개 파일, 141개 테스트, 3개 디바이스)
+e2e/                            # Playwright E2E 테스트 (19개 파일, 3개 디바이스)
 ├── home.spec.ts                # 홈 페이지 섹션 검증
 ├── tarot-flow.spec.ts          # 타로 풀 플로우
 ├── saju-flow.spec.ts           # 사주 풀 플로우
-├── shinjeom-flow.spec.ts       # 신점 풀 플로우 (대화형)
+├── shinjeom-flow.spec.ts       # 신점 풀 플로우 (무제한 대화형, 결과 받기 버튼 검증)
+├── ai-response-rendering.spec.ts # AI 응답 렌더링 — 신점/타로/사주 결과 JSON 미노출 검증
 ├── character.spec.ts           # 캐릭터 상세 (12캐릭터)
 ├── auth.spec.ts                # 로그인 페이지
 ├── auth-session.spec.ts        # 인증 상태 테스트 (Supabase 로그인)

--- a/e2e/ai-response-rendering.spec.ts
+++ b/e2e/ai-response-rendering.spec.ts
@@ -120,7 +120,7 @@ test.describe("AI 응답 렌더링 — 신점", () => {
   test("최종 결과 — 채팅에 raw JSON 미표시", async ({ page }) => {
     await mockSessionCreate(page, "**/api/shinjeom/session");
 
-    // 1~2번째 턴은 텍스트 응답
+    // 1~2번째 턴은 텍스트 응답, 3번째(버튼 클릭)는 최종 결과
     let callCount = 0;
     await page.route("**/api/shinjeom/message", (route) => {
       callCount++;
@@ -137,10 +137,9 @@ test.describe("AI 응답 렌더링 — 신점", () => {
           body: midSSE,
         });
       } else {
-        // 3번째(최종) — JSON 결과
+        // "신점 결과 받기" 버튼 클릭(최종) — JSON 결과
         const jsonStr = JSON.stringify(SHINJEOM_FINAL_RESULT);
         const finalSSE = createSSEBody(
-          // JSON을 청크로 분할
           [jsonStr.slice(0, 50), jsonStr.slice(50, 100), jsonStr.slice(100)],
           { isFinal: true, result: SHINJEOM_FINAL_RESULT },
         );
@@ -155,14 +154,18 @@ test.describe("AI 응답 렌더링 — 신점", () => {
 
     await enterShinjeomSession(page);
 
-    // 3회 대화 진행
-    for (let i = 0; i < 3; i++) {
+    // 2회 대화 진행 (중간 대화)
+    for (let i = 0; i < 2; i++) {
       const input = page.locator("input[type='text']");
       await expect(input).toBeVisible({ timeout: 5_000 });
       await input.fill(`테스트 답변 ${i + 1}`);
       await page.locator("button", { hasText: "전송" }).click();
       await page.waitForTimeout(2000);
     }
+
+    // "신점 결과 받기" 버튼 클릭으로 최종 결과 요청
+    await expect(page.locator("text=신점 결과 받기")).toBeVisible({ timeout: 5_000 });
+    await page.locator("text=신점 결과 받기").click();
 
     // 결과 화면 전환 대기
     await page.waitForTimeout(2000);
@@ -198,13 +201,18 @@ test.describe("AI 응답 렌더링 — 신점", () => {
 
     await enterShinjeomSession(page);
 
-    for (let i = 0; i < 3; i++) {
+    // 2회 대화 진행 (중간 대화)
+    for (let i = 0; i < 2; i++) {
       const input = page.locator("input[type='text']");
       await expect(input).toBeVisible({ timeout: 5_000 });
       await input.fill(`답변 ${i + 1}`);
       await page.locator("button", { hasText: "전송" }).click();
       await page.waitForTimeout(2000);
     }
+
+    // "신점 결과 받기" 버튼 클릭으로 최종 결과 요청
+    await expect(page.locator("text=신점 결과 받기")).toBeVisible({ timeout: 5_000 });
+    await page.locator("text=신점 결과 받기").click();
 
     // 결과 화면 전환 대기
     await page.waitForTimeout(3000);

--- a/e2e/form-validation.spec.ts
+++ b/e2e/form-validation.spec.ts
@@ -64,9 +64,12 @@ test.describe("폼 유효성 — 신점 메시지 입력", () => {
     await expect(sendBtn).toBeEnabled();
   });
 
-  test("대화 카운터 표시", async ({ page }) => {
+  test("입력 필드 항상 표시 + 첫 턴 전 결과 버튼 미노출", async ({ page }) => {
     await navigateToShinjeomSession(page);
-    await expect(page.locator("text=/0\\/3/")).toBeVisible();
+    // 입력 필드는 항상 표시
+    await expect(page.locator("input[type='text']")).toBeVisible();
+    // 첫 턴 전에는 "신점 결과 받기" 버튼 미노출
+    await expect(page.locator("text=신점 결과 받기")).not.toBeVisible();
   });
 });
 

--- a/e2e/shinjeom-flow.spec.ts
+++ b/e2e/shinjeom-flow.spec.ts
@@ -57,8 +57,8 @@ test.describe("신점 서비스 플로우", () => {
     // 전송 버튼 존재
     await expect(page.locator("text=전송")).toBeVisible();
 
-    // 대화 카운터 존재
-    await expect(page.locator("text=/\\d+\\/3/")).toBeVisible();
+    // 첫 턴 전에는 "신점 결과 받기" 버튼 미노출
+    await expect(page.locator("text=신점 결과 받기")).not.toBeVisible();
   });
 
   test("뒤로가기 — 캐릭터 선택으로 복귀", async ({ page }) => {


### PR DESCRIPTION
## Summary

- 신점 무제한 대화 구조(#100) 에 맞게 E2E 테스트 3개 수정
- CLAUDE.md 최신화 및 최적화

## 변경 내용

### E2E 테스트 수정
| 파일 | 변경 내용 |
|------|---------|
| `e2e/shinjeom-flow.spec.ts` | "0/3회 대화 카운터" 검증 → "첫 턴 전 결과 버튼 미노출" 검증으로 교체 |
| `e2e/form-validation.spec.ts` | "대화 카운터 표시" → "입력 필드 항상 표시 + 첫 턴 전 결과 버튼 미노출" 로 교체 |
| `e2e/ai-response-rendering.spec.ts` | 신점 최종 결과 테스트 2개: 3회 전송 자동 결과 → 2회 전송 + 버튼 클릭으로 변경 |

### CLAUDE.md
- 신점 서비스 흐름 설명 최신화 (무제한 대화, 결과 받기 버튼)
- `services/shinjeom` 주석 최신화
- `e2e/` 파일 목록에 `ai-response-rendering.spec.ts` 명시 추가

## Test plan

- [x] 신점 관련 E2E 18개 통과 확인 (Docker)
- [x] type-check + lint + build 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)