### PR TITLE
chore: SonarCloud/Codecov 설정 품질 개선 (Phase B)

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -34,7 +34,7 @@ ignore:
   - "public/**"
 
 flags:
-  e2e:
+  unit:
     paths:
       - src/
     carryforward: true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,6 +35,13 @@ jobs:
       # 2단계: 단위·통합 테스트 (Vitest)
       - run: pnpm test:coverage
 
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: unit-coverage
+          path: coverage/
+          retention-days: 7
+
       # 3단계: Build
       - run: pnpm build
         env:

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -61,20 +61,20 @@ jobs:
 
       # ── SonarCloud 분석 ──────────────────────────────────────────────────
       - name: SonarCloud Scan
-        uses: SonarSource/sonarcloud-github-action@master
+        uses: SonarSource/sonarqube-scan-action@v4.2.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
-      # ── Codecov 업로드 ───────────────────────────────────────────────────
-      - name: Codecov 업로드
+      # ── Codecov 업로드 (unit flag — Vitest lcov) ─────────────────────────
+      - name: Codecov 업로드 (unit)
         uses: codecov/codecov-action@v4
-        if: always()   # 테스트 실패해도 업로드 시도
+        if: always()
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage/lcov.info
-          flags: e2e
-          name: arcana-e2e
+          flags: unit
+          name: arcana-unit
           fail_ci_if_error: false
           verbose: false
 
@@ -82,8 +82,10 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: sonar-playwright-report
+          name: sonar-coverage-report
           path: |
             playwright-report/
+            coverage/lcov.info
+            coverage/coverage-summary.json
             coverage/junit.xml
           retention-days: 14

--- a/README.en.md
+++ b/README.en.md
@@ -14,7 +14,13 @@
   <img src="https://img.shields.io/badge/%E2%9A%9B%EF%B8%8F%20Frontend-Next.js%2016%20%2B%20React%2019-61DAFB?style=for-the-badge&labelColor=20232a" alt="Frontend" />
   <img src="https://img.shields.io/badge/%F0%9F%97%84%EF%B8%8F%20Backend-Node.js%20%2B%20Supabase-3ECF8E?style=for-the-badge&labelColor=1a1a2e" alt="Backend" />
   <img src="https://img.shields.io/badge/%F0%9F%A4%96%20AI-xAI%20Grok%20%2B%20Claude-FF6B35?style=for-the-badge&labelColor=1a1a2e" alt="AI" />
-  <img src="https://img.shields.io/badge/%F0%9F%A7%AA%20Tests-141%20passed-4CAF50?style=for-the-badge&labelColor=1a1a2e" alt="Tests" />
+</p>
+<p align="center">
+  <a href="https://sonarcloud.io/summary/new_code?id=xzawed31_ArcanaInsight"><img src="https://sonarcloud.io/api/project_badges/measure?project=xzawed31_ArcanaInsight&metric=alert_status" alt="Quality Gate" /></a>
+  <a href="https://sonarcloud.io/summary/new_code?id=xzawed31_ArcanaInsight"><img src="https://sonarcloud.io/api/project_badges/measure?project=xzawed31_ArcanaInsight&metric=coverage" alt="Coverage" /></a>
+  <a href="https://sonarcloud.io/summary/new_code?id=xzawed31_ArcanaInsight"><img src="https://sonarcloud.io/api/project_badges/measure?project=xzawed31_ArcanaInsight&metric=bugs" alt="Bugs" /></a>
+  <a href="https://sonarcloud.io/summary/new_code?id=xzawed31_ArcanaInsight"><img src="https://sonarcloud.io/api/project_badges/measure?project=xzawed31_ArcanaInsight&metric=security_rating" alt="Security Rating" /></a>
+  <a href="https://codecov.io/gh/xzawed31/ArcanaInsight"><img src="https://codecov.io/gh/xzawed31/ArcanaInsight/branch/main/graph/badge.svg" alt="Codecov" /></a>
 </p>
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -14,7 +14,13 @@
   <img src="https://img.shields.io/badge/%E2%9A%9B%EF%B8%8F%20Frontend-Next.js%2016%20%2B%20React%2019-61DAFB?style=for-the-badge&labelColor=20232a" alt="Frontend" />
   <img src="https://img.shields.io/badge/%F0%9F%97%84%EF%B8%8F%20Backend-Node.js%20%2B%20Supabase-3ECF8E?style=for-the-badge&labelColor=1a1a2e" alt="Backend" />
   <img src="https://img.shields.io/badge/%F0%9F%A4%96%20AI-xAI%20Grok%20%2B%20Claude-FF6B35?style=for-the-badge&labelColor=1a1a2e" alt="AI" />
-  <img src="https://img.shields.io/badge/%F0%9F%A7%AA%20Tests-141%20passed-4CAF50?style=for-the-badge&labelColor=1a1a2e" alt="Tests" />
+</p>
+<p align="center">
+  <a href="https://sonarcloud.io/summary/new_code?id=xzawed31_ArcanaInsight"><img src="https://sonarcloud.io/api/project_badges/measure?project=xzawed31_ArcanaInsight&metric=alert_status" alt="Quality Gate" /></a>
+  <a href="https://sonarcloud.io/summary/new_code?id=xzawed31_ArcanaInsight"><img src="https://sonarcloud.io/api/project_badges/measure?project=xzawed31_ArcanaInsight&metric=coverage" alt="Coverage" /></a>
+  <a href="https://sonarcloud.io/summary/new_code?id=xzawed31_ArcanaInsight"><img src="https://sonarcloud.io/api/project_badges/measure?project=xzawed31_ArcanaInsight&metric=bugs" alt="Bugs" /></a>
+  <a href="https://sonarcloud.io/summary/new_code?id=xzawed31_ArcanaInsight"><img src="https://sonarcloud.io/api/project_badges/measure?project=xzawed31_ArcanaInsight&metric=security_rating" alt="Security Rating" /></a>
+  <a href="https://codecov.io/gh/xzawed31/ArcanaInsight"><img src="https://codecov.io/gh/xzawed31/ArcanaInsight/branch/main/graph/badge.svg" alt="Codecov" /></a>
 </p>
 
 <p align="center">

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -6,19 +6,23 @@ sonar.projectVersion=1.0
 
 # 분석 대상 소스
 sonar.sources=src
-sonar.tests=e2e
+sonar.tests=src,e2e
 sonar.exclusions=**/.next/**,**/node_modules/**,**/public/**,**/*.d.ts,**/generated/**
-sonar.test.inclusions=e2e/**/*.ts,e2e/**/*.spec.ts
+sonar.test.inclusions=src/**/*.test.ts,src/**/*.spec.ts,e2e/**/*.spec.ts
 
-# 커버리지 리포트 (Playwright V8 → lcov 변환 후)
+# 커버리지 리포트 (Vitest v8 lcov)
 sonar.javascript.lcov.reportPaths=coverage/lcov.info
 sonar.typescript.lcov.reportPaths=coverage/lcov.info
 
-# E2E 테스트 실행 결과 (JUnit XML)
+# 커버리지 분모에서 제외 — vitest coverage.exclude와 동기화
+sonar.coverage.exclusions=**/*.test.ts,**/*.spec.ts,src/types/**,src/app/**,src/components/**,src/hooks/**,src/data/characters/**,src/data/skins/**,src/data/cards/**,src/data/home/**,src/data/spreads/**,src/data/saju/constants.ts,src/data/saju/categories.ts,src/data/birth-hours.ts,src/data/error-messages.ts,src/lib/supabase/**,src/lib/auth/**,src/lib/storage/**,src/lib/db/schema/**,src/lib/db/types.ts,src/lib/db/index.ts
+
+# 단위 테스트 실행 결과 (Vitest JUnit XML)
 sonar.testExecutionReportPaths=coverage/junit.xml
 
 sonar.sourceEncoding=UTF-8
 sonar.qualitygate.wait=true
+sonar.typescript.tsconfigPath=tsconfig.json
 
 # TypeScript 분석 강화
 sonar.javascript.environments=browser,node

--- a/src/hooks/useSSEStream.test.ts
+++ b/src/hooks/useSSEStream.test.ts
@@ -1,0 +1,232 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { fetchSSEStream } from "./useSSEStream";
+
+const encoder = new TextEncoder();
+
+/** SSE 라인 배열로 ReadableStream 응답을 만드는 헬퍼 */
+function makeSseResponse(lines: string[], status = 200, ok = true) {
+  const text = lines.join("\n") + "\n";
+  const stream = new ReadableStream({
+    start(controller) {
+      controller.enqueue(encoder.encode(text));
+      controller.close();
+    },
+  });
+  return {
+    ok,
+    status,
+    body: stream,
+    json: () => Promise.resolve({ error: `HTTP ${status}` }),
+  } as unknown as Response;
+}
+
+describe("fetchSSEStream", () => {
+  const mockFetch = vi.fn<typeof fetch>();
+
+  beforeEach(() => {
+    global.fetch = mockFetch;
+    mockFetch.mockReset();
+  });
+
+  it("chunk 이벤트를 수신하고 fullText를 누적한다", async () => {
+    const lines = [
+      'data: {"chunk":"안녕"}',
+      'data: {"chunk":"하세요"}',
+      'data: {"done":true,"sessionId":"abc"}',
+    ];
+    mockFetch.mockResolvedValue(makeSseResponse(lines));
+
+    const chunks: string[] = [];
+    const fullTexts: string[] = [];
+    let doneData: Record<string, unknown> | null = null;
+
+    await fetchSSEStream({
+      url: "/api/test",
+      body: { test: true },
+      onChunk: (chunk, full) => { chunks.push(chunk); fullTexts.push(full); },
+      onDone: (data) => { doneData = data; },
+      onError: vi.fn(),
+    });
+
+    expect(chunks).toEqual(["안녕", "하세요"]);
+    expect(fullTexts).toEqual(["안녕", "안녕하세요"]);
+    expect(doneData).toMatchObject({ done: true, sessionId: "abc" });
+  });
+
+  it("done 이벤트에서 스트림 처리를 중단한다", async () => {
+    const lines = [
+      'data: {"chunk":"첫 번째"}',
+      'data: {"done":true}',
+      'data: {"chunk":"이후는 무시"}',
+    ];
+    mockFetch.mockResolvedValue(makeSseResponse(lines));
+
+    const chunks: string[] = [];
+    await fetchSSEStream({
+      url: "/api/test",
+      body: {},
+      onChunk: (chunk) => chunks.push(chunk),
+      onDone: vi.fn(),
+      onError: vi.fn(),
+    });
+
+    expect(chunks).toEqual(["첫 번째"]);
+  });
+
+  it("data.error가 있으면 onError를 호출하고 중단한다", async () => {
+    const lines = [
+      'data: {"chunk":"시작"}',
+      'data: {"error":"AI 서비스 오류"}',
+      'data: {"chunk":"중단 후 무시"}',
+    ];
+    mockFetch.mockResolvedValue(makeSseResponse(lines));
+
+    const onError = vi.fn();
+    const chunks: string[] = [];
+    await fetchSSEStream({
+      url: "/api/test",
+      body: {},
+      onChunk: (chunk) => chunks.push(chunk),
+      onDone: vi.fn(),
+      onError,
+    });
+
+    expect(onError).toHaveBeenCalledWith("AI 서비스 오류");
+    expect(chunks).toEqual(["시작"]);
+  });
+
+  it("HTTP 에러 응답이면 onError를 호출한다", async () => {
+    const errorBody = { error: "서버 오류" };
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 500,
+      body: null,
+      json: () => Promise.resolve(errorBody),
+    } as unknown as Response);
+
+    const onError = vi.fn();
+    await fetchSSEStream({ url: "/api/test", body: {}, onChunk: vi.fn(), onDone: vi.fn(), onError });
+
+    expect(onError).toHaveBeenCalledWith("서버 오류");
+  });
+
+  it("HTTP 에러 + JSON 파싱 실패 시 'HTTP {status}'로 fallback한다", async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 503,
+      body: null,
+      json: () => Promise.reject(new Error("not json")),
+    } as unknown as Response);
+
+    const onError = vi.fn();
+    await fetchSSEStream({ url: "/api/test", body: {}, onChunk: vi.fn(), onDone: vi.fn(), onError });
+
+    expect(onError).toHaveBeenCalledWith("HTTP 503");
+  });
+
+  it("response.body가 null이면 onError를 호출한다", async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 400,
+      body: null,
+      json: () => Promise.resolve({ error: "" }),
+    } as unknown as Response);
+
+    const onError = vi.fn();
+    await fetchSSEStream({ url: "/api/test", body: {}, onChunk: vi.fn(), onDone: vi.fn(), onError });
+
+    expect(onError).toHaveBeenCalledWith("HTTP 400");
+  });
+
+  it("fetch 자체가 throw하면 onError를 호출한다", async () => {
+    mockFetch.mockRejectedValue(new Error("네트워크 오류"));
+
+    const onError = vi.fn();
+    await fetchSSEStream({ url: "/api/test", body: {}, onChunk: vi.fn(), onDone: vi.fn(), onError });
+
+    expect(onError).toHaveBeenCalledWith("네트워크 오류");
+  });
+
+  it("data: 로 시작하지 않는 라인은 무시한다", async () => {
+    const lines = [
+      ": comment",
+      "event: chunk",
+      'data: {"chunk":"유효"}',
+      'data: {"done":true}',
+    ];
+    mockFetch.mockResolvedValue(makeSseResponse(lines));
+
+    const chunks: string[] = [];
+    await fetchSSEStream({
+      url: "/api/test",
+      body: {},
+      onChunk: (c) => chunks.push(c),
+      onDone: vi.fn(),
+      onError: vi.fn(),
+    });
+
+    expect(chunks).toEqual(["유효"]);
+  });
+
+  it("잘못된 JSON 라인은 무시하고 계속 처리한다", async () => {
+    const lines = [
+      "data: {invalid}",
+      'data: {"chunk":"정상"}',
+      'data: {"done":true}',
+    ];
+    mockFetch.mockResolvedValue(makeSseResponse(lines));
+
+    const chunks: string[] = [];
+    await fetchSSEStream({
+      url: "/api/test",
+      body: {},
+      onChunk: (c) => chunks.push(c),
+      onDone: vi.fn(),
+      onError: vi.fn(),
+    });
+
+    expect(chunks).toEqual(["정상"]);
+  });
+
+  it("스트림 종료 시 버퍼에 남은 done 이벤트를 처리한다", async () => {
+    // 개행 없이 끝나는 마지막 라인을 남기는 케이스 시뮬레이션
+    const text = 'data: {"chunk":"마지막"}\ndata: {"done":true,"result":"완료"}';
+    const stream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(encoder.encode(text)); // 마지막 줄에 \n 없음
+        controller.close();
+      },
+    });
+    mockFetch.mockResolvedValue({ ok: true, status: 200, body: stream, json: vi.fn() } as unknown as Response);
+
+    let doneData: Record<string, unknown> | null = null;
+    await fetchSSEStream({
+      url: "/api/test",
+      body: {},
+      onChunk: vi.fn(),
+      onDone: (d) => { doneData = d; },
+      onError: vi.fn(),
+    });
+
+    // 버퍼에 남은 done 이벤트가 처리되었는지 확인
+    expect(doneData).toMatchObject({ done: true, result: "완료" });
+  });
+
+  it("POST 요청 body를 JSON으로 직렬화해서 전송한다", async () => {
+    mockFetch.mockResolvedValue(makeSseResponse(['data: {"done":true}']));
+
+    await fetchSSEStream({
+      url: "/api/reading",
+      body: { sessionId: "s1", cardIds: ["a", "b"] },
+      onChunk: vi.fn(),
+      onDone: vi.fn(),
+      onError: vi.fn(),
+    });
+
+    expect(mockFetch).toHaveBeenCalledWith("/api/reading", expect.objectContaining({
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ sessionId: "s1", cardIds: ["a", "b"] }),
+    }));
+  });
+});

--- a/src/lib/db/supabase-adapter.test.ts
+++ b/src/lib/db/supabase-adapter.test.ts
@@ -1,0 +1,207 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+/** Supabase 쿼리 체인을 모킹하는 헬퍼 */
+function makeChain(result: { data?: unknown; error?: { code?: string; message: string } | null }) {
+  const outcome = { data: result.data ?? null, error: result.error ?? null };
+  // findMany는 쿼리 객체를 직접 await 하므로 Promise thenable이어야 한다
+  const chain: Record<string, unknown> & PromiseLike<typeof outcome> = {
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    single: vi.fn().mockResolvedValue(outcome),
+    insert: vi.fn().mockReturnThis(),
+    update: vi.fn().mockReturnThis(),
+    upsert: vi.fn().mockReturnThis(),
+    then: (resolve: (v: typeof outcome) => void) => Promise.resolve(outcome).then(resolve),
+    catch: (reject: (e: unknown) => void) => Promise.resolve(outcome).catch(reject),
+  };
+  return chain;
+}
+
+// @/lib/supabase/server 모킹
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(),
+}));
+
+import { SupabaseAdapter } from "./supabase-adapter";
+import { createClient } from "@/lib/supabase/server";
+
+const mockCreateClient = createClient as ReturnType<typeof vi.fn>;
+
+describe("SupabaseAdapter", () => {
+  let adapter: SupabaseAdapter;
+
+  beforeEach(() => {
+    adapter = new SupabaseAdapter();
+    vi.clearAllMocks();
+  });
+
+  // ─── findOne ──────────────────────────────────────────────────────────────
+
+  describe("findOne", () => {
+    it("데이터가 있으면 첫 번째 행을 반환한다", async () => {
+      const row = { id: "1", name: "테스트" };
+      const chain = makeChain({ data: row });
+      mockCreateClient.mockResolvedValue({ from: vi.fn().mockReturnValue(chain) });
+
+      const result = await adapter.findOne("profiles", { id: "1" });
+      expect(result).toEqual(row);
+    });
+
+    it("PGRST116 에러이면 null을 반환한다", async () => {
+      const chain = makeChain({ error: { code: "PGRST116", message: "no rows found" } });
+      mockCreateClient.mockResolvedValue({ from: vi.fn().mockReturnValue(chain) });
+
+      const result = await adapter.findOne("profiles", { id: "999" });
+      expect(result).toBeNull();
+    });
+
+    it("기타 에러이면 Error를 던진다", async () => {
+      const chain = makeChain({ error: { code: "42P01", message: "table not found" } });
+      mockCreateClient.mockResolvedValue({ from: vi.fn().mockReturnValue(chain) });
+
+      await expect(adapter.findOne("nonexistent", { id: "1" })).rejects.toThrow("42P01");
+    });
+
+    it("where 조건이 여러 개이면 eq가 여러 번 호출된다", async () => {
+      const chain = makeChain({ data: { id: "1" } });
+      mockCreateClient.mockResolvedValue({ from: vi.fn().mockReturnValue(chain) });
+
+      await adapter.findOne("sessions", { user_id: "u1", session_type: "tarot" });
+      expect(chain.eq).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  // ─── findMany ─────────────────────────────────────────────────────────────
+
+  describe("findMany", () => {
+    it("데이터 배열을 반환한다", async () => {
+      const rows = [{ id: "1" }, { id: "2" }];
+      const chain = makeChain({ data: rows });
+      mockCreateClient.mockResolvedValue({ from: vi.fn().mockReturnValue(chain) });
+
+      const result = await adapter.findMany("sessions", { user_id: "u1" });
+      expect(result).toEqual(rows);
+    });
+
+    it("where 없으면 필터 없이 조회한다", async () => {
+      const rows = [{ id: "1" }, { id: "2" }, { id: "3" }];
+      const chain = makeChain({ data: rows });
+      mockCreateClient.mockResolvedValue({ from: vi.fn().mockReturnValue(chain) });
+
+      const result = await adapter.findMany("services");
+      expect(result).toEqual(rows);
+      expect(chain.eq).not.toHaveBeenCalled();
+    });
+
+    it("data가 null이면 빈 배열을 반환한다", async () => {
+      const chain = makeChain({ data: null });
+      mockCreateClient.mockResolvedValue({ from: vi.fn().mockReturnValue(chain) });
+
+      const result = await adapter.findMany("sessions");
+      expect(result).toEqual([]);
+    });
+
+    it("에러이면 Error를 던진다", async () => {
+      const chain = makeChain({ error: { code: "500", message: "DB connection failed" } });
+      mockCreateClient.mockResolvedValue({ from: vi.fn().mockReturnValue(chain) });
+
+      await expect(adapter.findMany("sessions")).rejects.toThrow("DB connection failed");
+    });
+  });
+
+  // ─── insert ───────────────────────────────────────────────────────────────
+
+  describe("insert", () => {
+    it("삽입된 행을 반환한다", async () => {
+      const inserted = { id: "new-1", content: "리딩 내용" };
+      const chain = makeChain({ data: inserted });
+      mockCreateClient.mockResolvedValue({ from: vi.fn().mockReturnValue(chain) });
+
+      const result = await adapter.insert("readings", { content: "리딩 내용" });
+      expect(result).toEqual(inserted);
+    });
+
+    it("에러이면 Error를 던진다", async () => {
+      const chain = makeChain({ error: { message: "unique constraint violated" } });
+      mockCreateClient.mockResolvedValue({ from: vi.fn().mockReturnValue(chain) });
+
+      await expect(adapter.insert("sessions", { id: "dup" })).rejects.toThrow("unique constraint violated");
+    });
+  });
+
+  // ─── insertMany ───────────────────────────────────────────────────────────
+
+  describe("insertMany", () => {
+    it("삽입된 행 배열을 반환한다", async () => {
+      const inserted = [{ id: "1" }, { id: "2" }];
+      const chain = makeChain({ data: inserted });
+      mockCreateClient.mockResolvedValue({ from: vi.fn().mockReturnValue(chain) });
+
+      const result = await adapter.insertMany("session_cards", [{ card_id: "c1" }, { card_id: "c2" }]);
+      expect(result).toEqual(inserted);
+    });
+
+    it("data가 null이면 빈 배열을 반환한다", async () => {
+      const chain = makeChain({ data: null });
+      mockCreateClient.mockResolvedValue({ from: vi.fn().mockReturnValue(chain) });
+
+      const result = await adapter.insertMany("session_cards", []);
+      expect(result).toEqual([]);
+    });
+
+    it("에러이면 Error를 던진다", async () => {
+      const chain = makeChain({ error: { message: "FK constraint" } });
+      mockCreateClient.mockResolvedValue({ from: vi.fn().mockReturnValue(chain) });
+
+      await expect(adapter.insertMany("session_cards", [{ card_id: "x" }])).rejects.toThrow("FK constraint");
+    });
+  });
+
+  // ─── update ───────────────────────────────────────────────────────────────
+
+  describe("update", () => {
+    it("업데이트된 행을 반환한다", async () => {
+      const updated = { id: "1", status: "done" };
+      const chain = makeChain({ data: updated });
+      mockCreateClient.mockResolvedValue({ from: vi.fn().mockReturnValue(chain) });
+
+      const result = await adapter.update("sessions", { id: "1" }, { status: "done" });
+      expect(result).toEqual(updated);
+    });
+
+    it("PGRST116이면 null을 반환한다", async () => {
+      const chain = makeChain({ error: { code: "PGRST116", message: "no rows matched" } });
+      mockCreateClient.mockResolvedValue({ from: vi.fn().mockReturnValue(chain) });
+
+      const result = await adapter.update("sessions", { id: "999" }, { status: "done" });
+      expect(result).toBeNull();
+    });
+
+    it("기타 에러이면 Error를 던진다", async () => {
+      const chain = makeChain({ error: { code: "23503", message: "FK violation" } });
+      mockCreateClient.mockResolvedValue({ from: vi.fn().mockReturnValue(chain) });
+
+      await expect(adapter.update("sessions", { id: "1" }, { bad_col: "x" })).rejects.toThrow("23503");
+    });
+  });
+
+  // ─── upsert ───────────────────────────────────────────────────────────────
+
+  describe("upsert", () => {
+    it("upsert된 행을 반환한다", async () => {
+      const row = { date: "2026-04-23", character_id: "arcana", content: "운세" };
+      const chain = makeChain({ data: row });
+      mockCreateClient.mockResolvedValue({ from: vi.fn().mockReturnValue(chain) });
+
+      const result = await adapter.upsert("daily_cards", row, "date,character_id");
+      expect(result).toEqual(row);
+    });
+
+    it("에러이면 Error를 던진다", async () => {
+      const chain = makeChain({ error: { message: "upsert failed" } });
+      mockCreateClient.mockResolvedValue({ from: vi.fn().mockReturnValue(chain) });
+
+      await expect(adapter.upsert("daily_cards", {}, "date")).rejects.toThrow("upsert failed");
+    });
+  });
+});

--- a/src/services/core/claude-provider.test.ts
+++ b/src/services/core/claude-provider.test.ts
@@ -1,0 +1,230 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { ClaudeProvider } from "./claude-provider";
+
+function makeJsonResponse(body: unknown, status = 200) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    headers: new Headers(),
+    json: () => Promise.resolve(body),
+    text: () => Promise.resolve(JSON.stringify(body)),
+  } as unknown as Response;
+}
+
+function makeErrorResponse(status: number, body = "error") {
+  return {
+    ok: false,
+    status,
+    headers: new Headers(),
+    json: () => Promise.reject(new Error("not json")),
+    text: () => Promise.resolve(body),
+  } as unknown as Response;
+}
+
+function makeSseResponse(lines: string[], status = 200) {
+  const encoder = new TextEncoder();
+  const text = lines.join("\n") + "\n";
+  const stream = new ReadableStream({
+    start(controller) {
+      controller.enqueue(encoder.encode(text));
+      controller.close();
+    },
+  });
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    headers: new Headers(),
+    body: stream,
+    text: () => Promise.resolve("error body"),
+  } as unknown as Response;
+}
+
+async function collectStream(gen: AsyncGenerator<string, void, unknown>): Promise<string[]> {
+  const chunks: string[] = [];
+  for await (const chunk of gen) chunks.push(chunk);
+  return chunks;
+}
+
+describe("ClaudeProvider", () => {
+  let provider: ClaudeProvider;
+  const mockFetch = vi.fn<typeof fetch>();
+
+  beforeEach(() => {
+    process.env.ANTHROPIC_API_KEY = "test-claude-key";
+    provider = new ClaudeProvider();
+    global.fetch = mockFetch;
+    mockFetch.mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // ─── generateReading ───────────────────────────────────────────────────────
+
+  describe("generateReading", () => {
+    it("성공 시 content를 반환한다", async () => {
+      mockFetch.mockResolvedValue(
+        makeJsonResponse({ content: [{ text: "Claude 리딩 결과" }] })
+      );
+
+      const result = await provider.generateReading("시스템", "유저");
+      expect(result).toBe("Claude 리딩 결과");
+    });
+
+    it("x-api-key 헤더로 API 키를 전달한다", async () => {
+      mockFetch.mockResolvedValue(
+        makeJsonResponse({ content: [{ text: "ok" }] })
+      );
+
+      await provider.generateReading("s", "u");
+
+      const [, options] = mockFetch.mock.calls[0];
+      const headers = options?.headers as Record<string, string>;
+      expect(headers["x-api-key"]).toBe("test-claude-key");
+    });
+
+    it("anthropic-version 헤더를 전달한다", async () => {
+      mockFetch.mockResolvedValue(
+        makeJsonResponse({ content: [{ text: "ok" }] })
+      );
+
+      await provider.generateReading("s", "u");
+
+      const [, options] = mockFetch.mock.calls[0];
+      const headers = options?.headers as Record<string, string>;
+      expect(headers["anthropic-version"]).toBe("2023-06-01");
+    });
+
+    it("Anthropic Messages API 포맷으로 body를 전송한다", async () => {
+      mockFetch.mockResolvedValue(
+        makeJsonResponse({ content: [{ text: "ok" }] })
+      );
+
+      await provider.generateReading("my-system", "my-user");
+
+      const [, options] = mockFetch.mock.calls[0];
+      const body = JSON.parse(options?.body as string);
+      expect(body.system).toBe("my-system");
+      expect(body.messages).toEqual([{ role: "user", content: "my-user" }]);
+    });
+
+    it("4xx/5xx 응답 시 Error를 던진다", async () => {
+      mockFetch.mockResolvedValue(makeErrorResponse(500, "internal error"));
+
+      await expect(provider.generateReading("s", "u")).rejects.toThrow("HTTP 500");
+    });
+
+    it("401 응답도 동일하게 Error를 던진다", async () => {
+      mockFetch.mockResolvedValue(makeErrorResponse(401, "unauthorized"));
+
+      await expect(provider.generateReading("s", "u")).rejects.toThrow("HTTP 401");
+    });
+
+    it("빈 content 시 Error를 던진다", async () => {
+      mockFetch.mockResolvedValue(
+        makeJsonResponse({ content: [{ text: "" }] })
+      );
+
+      await expect(provider.generateReading("s", "u")).rejects.toThrow("빈 응답");
+    });
+
+    it("content 배열이 비어있으면 Error를 던진다", async () => {
+      mockFetch.mockResolvedValue(makeJsonResponse({ content: [] }));
+
+      await expect(provider.generateReading("s", "u")).rejects.toThrow("빈 응답");
+    });
+
+    it("ANTHROPIC_API_KEY 미설정 시 fetch 전에 Error를 던진다", async () => {
+      process.env.ANTHROPIC_API_KEY = "";
+      const freshProvider = new ClaudeProvider();
+
+      await expect(freshProvider.generateReading("s", "u")).rejects.toThrow("ANTHROPIC_API_KEY");
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it("maxTokens 인자를 body에 전달한다", async () => {
+      mockFetch.mockResolvedValue(
+        makeJsonResponse({ content: [{ text: "ok" }] })
+      );
+
+      await provider.generateReading("s", "u", 2048);
+
+      const [, options] = mockFetch.mock.calls[0];
+      const body = JSON.parse(options?.body as string);
+      expect(body.max_tokens).toBe(2048);
+    });
+  });
+
+  // ─── streamReading ─────────────────────────────────────────────────────────
+
+  describe("streamReading", () => {
+    it("content_block_delta 이벤트에서 텍스트를 yield한다", async () => {
+      const sseLines = [
+        'data: {"type":"content_block_delta","delta":{"text":"안녕"}}',
+        'data: {"type":"content_block_delta","delta":{"text":"하세요"}}',
+        "data: [DONE]",
+      ];
+      mockFetch.mockResolvedValue(makeSseResponse(sseLines));
+
+      const chunks = await collectStream(provider.streamReading("s", "u"));
+      expect(chunks).toEqual(["안녕", "하세요"]);
+    });
+
+    it("content_block_delta가 아닌 이벤트는 무시한다", async () => {
+      const sseLines = [
+        'data: {"type":"message_start","message":{}}',
+        'data: {"type":"content_block_start","index":0}',
+        'data: {"type":"content_block_delta","delta":{"text":"텍스트"}}',
+        'data: {"type":"message_delta","delta":{}}',
+        "data: [DONE]",
+      ];
+      mockFetch.mockResolvedValue(makeSseResponse(sseLines));
+
+      const chunks = await collectStream(provider.streamReading("s", "u"));
+      expect(chunks).toEqual(["텍스트"]);
+    });
+
+    it("data: 로 시작하지 않는 라인은 건너뛴다", async () => {
+      const sseLines = [
+        "event: content_block_delta",
+        'data: {"type":"content_block_delta","delta":{"text":"유효"}}',
+        "data: [DONE]",
+      ];
+      mockFetch.mockResolvedValue(makeSseResponse(sseLines));
+
+      const chunks = await collectStream(provider.streamReading("s", "u"));
+      expect(chunks).toEqual(["유효"]);
+    });
+
+    it("non-ok 응답 시 Error를 던진다", async () => {
+      mockFetch.mockResolvedValue(makeErrorResponse(500, "server error"));
+
+      await expect(collectStream(provider.streamReading("s", "u"))).rejects.toThrow("HTTP 500");
+    });
+
+    it("body가 null이면 Error를 던진다", async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        status: 200,
+        headers: new Headers(),
+        body: null,
+        text: () => Promise.resolve(""),
+      } as unknown as Response);
+
+      await expect(collectStream(provider.streamReading("s", "u"))).rejects.toThrow("Response body is null");
+    });
+
+    it("[DONE]에서 스트림을 종료한다", async () => {
+      const sseLines = [
+        'data: {"type":"content_block_delta","delta":{"text":"첫 번째"}}',
+        "data: [DONE]",
+        'data: {"type":"content_block_delta","delta":{"text":"이 이후는 무시"}}',
+      ];
+      mockFetch.mockResolvedValue(makeSseResponse(sseLines));
+
+      const chunks = await collectStream(provider.streamReading("s", "u"));
+      expect(chunks).toEqual(["첫 번째"]);
+    });
+  });
+});

--- a/src/services/core/grok-provider.test.ts
+++ b/src/services/core/grok-provider.test.ts
@@ -1,0 +1,283 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { GrokProvider, RateLimitError, AuthError } from "./grok-provider";
+
+/** fetch 응답을 모킹하는 헬퍼 */
+function makeJsonResponse(body: unknown, status = 200, headers: Record<string, string> = {}) {
+  const headersObj = new Headers(headers);
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    headers: headersObj,
+    json: () => Promise.resolve(body),
+    text: () => Promise.resolve(typeof body === "string" ? body : JSON.stringify(body)),
+  } as unknown as Response;
+}
+
+function makeErrorResponse(status: number, body = "error", headers: Record<string, string> = {}) {
+  const headersObj = new Headers(headers);
+  return {
+    ok: false,
+    status,
+    headers: headersObj,
+    json: () => Promise.reject(new Error("not json")),
+    text: () => Promise.resolve(body),
+  } as unknown as Response;
+}
+
+/** SSE 스트리밍 응답을 모킹하는 헬퍼 */
+function makeSseResponse(lines: string[], status = 200) {
+  const encoder = new TextEncoder();
+  const text = lines.join("\n") + "\n";
+  const stream = new ReadableStream({
+    start(controller) {
+      controller.enqueue(encoder.encode(text));
+      controller.close();
+    },
+  });
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    headers: new Headers(),
+    body: stream,
+    text: () => Promise.resolve("error body"),
+  } as unknown as Response;
+}
+
+async function collectStream(gen: AsyncGenerator<string, void, unknown>): Promise<string[]> {
+  const chunks: string[] = [];
+  for await (const chunk of gen) chunks.push(chunk);
+  return chunks;
+}
+
+describe("GrokProvider", () => {
+  let provider: GrokProvider;
+  const mockFetch = vi.fn<typeof fetch>();
+
+  beforeEach(() => {
+    process.env.GROK_API_KEY = "test-grok-key";
+    provider = new GrokProvider();
+    global.fetch = mockFetch;
+    mockFetch.mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // ─── 에러 클래스 ───────────────────────────────────────────────────────────
+
+  describe("RateLimitError", () => {
+    it("retryAfterMs를 저장한다", () => {
+      const err = new RateLimitError(30000);
+      expect(err.retryAfterMs).toBe(30000);
+      expect(err.name).toBe("RateLimitError");
+      expect(err).toBeInstanceOf(Error);
+    });
+
+    it("메시지에 retry-after 시간이 포함된다", () => {
+      const err = new RateLimitError(5000);
+      expect(err.message).toContain("5000ms");
+    });
+  });
+
+  describe("AuthError", () => {
+    it("status와 detail이 메시지에 포함된다", () => {
+      const err = new AuthError(401, "unauthorized");
+      expect(err.name).toBe("AuthError");
+      expect(err.message).toContain("401");
+      expect(err.message).toContain("unauthorized");
+      expect(err).toBeInstanceOf(Error);
+    });
+  });
+
+  // ─── generateReading ───────────────────────────────────────────────────────
+
+  describe("generateReading", () => {
+    it("성공 시 content를 반환한다", async () => {
+      mockFetch.mockResolvedValue(
+        makeJsonResponse({ choices: [{ message: { content: "Grok 리딩 결과" } }] })
+      );
+
+      const result = await provider.generateReading("시스템", "유저");
+      expect(result).toBe("Grok 리딩 결과");
+    });
+
+    it("Authorization Bearer 헤더로 API 키를 전달한다", async () => {
+      mockFetch.mockResolvedValue(
+        makeJsonResponse({ choices: [{ message: { content: "ok" } }] })
+      );
+
+      await provider.generateReading("s", "u");
+
+      const [, options] = mockFetch.mock.calls[0];
+      const headers = options?.headers as Record<string, string>;
+      expect(headers["Authorization"]).toBe("Bearer test-grok-key");
+    });
+
+    it("401 응답 시 AuthError를 던진다", async () => {
+      mockFetch.mockResolvedValue(makeErrorResponse(401, "unauthorized"));
+
+      await expect(provider.generateReading("s", "u")).rejects.toThrow(AuthError);
+    });
+
+    it("403 응답 시 AuthError를 던진다", async () => {
+      mockFetch.mockResolvedValue(makeErrorResponse(403, "forbidden"));
+
+      await expect(provider.generateReading("s", "u")).rejects.toThrow(AuthError);
+    });
+
+    it("429 응답 시 RateLimitError를 던진다", async () => {
+      mockFetch.mockResolvedValue(
+        makeErrorResponse(429, "too many requests", { "retry-after": "10" })
+      );
+
+      await expect(provider.generateReading("s", "u")).rejects.toThrow(RateLimitError);
+    });
+
+    it("429 + retry-after 헤더로 retryAfterMs를 계산한다", async () => {
+      mockFetch.mockResolvedValue(
+        makeErrorResponse(429, "rate limited", { "retry-after": "5" })
+      );
+
+      const error = await provider.generateReading("s", "u").catch((e) => e);
+      expect(error).toBeInstanceOf(RateLimitError);
+      expect((error as RateLimitError).retryAfterMs).toBe(5000); // 5초 * 1000
+    });
+
+    it("429 + retry-after 헤더 없으면 기본 30초를 사용한다", async () => {
+      mockFetch.mockResolvedValue(makeErrorResponse(429, "rate limited"));
+
+      const error = await provider.generateReading("s", "u").catch((e) => e);
+      expect(error).toBeInstanceOf(RateLimitError);
+      expect((error as RateLimitError).retryAfterMs).toBe(30000);
+    });
+
+    it("500 응답 시 일반 Error를 던진다", async () => {
+      mockFetch.mockResolvedValue(makeErrorResponse(500, "server error"));
+
+      await expect(provider.generateReading("s", "u")).rejects.toThrow(/Grok API error \(500\)/);
+    });
+
+    it("빈 응답 content 시 Error를 던진다", async () => {
+      mockFetch.mockResolvedValue(
+        makeJsonResponse({ choices: [{ message: { content: "" } }] })
+      );
+
+      await expect(provider.generateReading("s", "u")).rejects.toThrow("빈 응답");
+    });
+
+    it("choices가 비어있으면 Error를 던진다", async () => {
+      mockFetch.mockResolvedValue(makeJsonResponse({ choices: [] }));
+
+      await expect(provider.generateReading("s", "u")).rejects.toThrow("빈 응답");
+    });
+
+    it("GROK_API_KEY 미설정 시 fetch 호출 전에 Error를 던진다", async () => {
+      process.env.GROK_API_KEY = "";
+      const freshProvider = new GrokProvider();
+
+      await expect(freshProvider.generateReading("s", "u")).rejects.toThrow("GROK_API_KEY");
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it("GROK_API_KEY가 기본 placeholder이면 Error를 던진다", async () => {
+      process.env.GROK_API_KEY = "your_grok_api_key";
+      const freshProvider = new GrokProvider();
+
+      await expect(freshProvider.generateReading("s", "u")).rejects.toThrow("GROK_API_KEY");
+    });
+
+    it("maxTokens 인자를 body에 전달한다", async () => {
+      mockFetch.mockResolvedValue(
+        makeJsonResponse({ choices: [{ message: { content: "ok" } }] })
+      );
+
+      await provider.generateReading("s", "u", 1024);
+
+      const [, options] = mockFetch.mock.calls[0];
+      const body = JSON.parse(options?.body as string);
+      expect(body.max_tokens).toBe(1024);
+    });
+  });
+
+  // ─── streamReading ─────────────────────────────────────────────────────────
+
+  describe("streamReading", () => {
+    it("SSE [DONE] 이전까지 content 청크를 yield한다", async () => {
+      const sseLines = [
+        'data: {"choices":[{"delta":{"content":"안녕"}}]}',
+        'data: {"choices":[{"delta":{"content":"하세요"}}]}',
+        "data: [DONE]",
+      ];
+      mockFetch.mockResolvedValue(makeSseResponse(sseLines));
+
+      const chunks = await collectStream(provider.streamReading("s", "u"));
+      expect(chunks).toEqual(["안녕", "하세요"]);
+    });
+
+    it("content 없는 delta 청크는 무시한다", async () => {
+      const sseLines = [
+        'data: {"choices":[{"delta":{}}]}',
+        'data: {"choices":[{"delta":{"content":"텍스트"}}]}',
+        "data: [DONE]",
+      ];
+      mockFetch.mockResolvedValue(makeSseResponse(sseLines));
+
+      const chunks = await collectStream(provider.streamReading("s", "u"));
+      expect(chunks).toEqual(["텍스트"]);
+    });
+
+    it("data: 로 시작하지 않는 라인은 건너뛴다", async () => {
+      const sseLines = [
+        ": keep-alive",
+        "",
+        'data: {"choices":[{"delta":{"content":"유효"}}]}',
+        "data: [DONE]",
+      ];
+      mockFetch.mockResolvedValue(makeSseResponse(sseLines));
+
+      const chunks = await collectStream(provider.streamReading("s", "u"));
+      expect(chunks).toEqual(["유효"]);
+    });
+
+    it("잘못된 JSON 청크는 경고 후 계속 진행한다", async () => {
+      const consoleSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const sseLines = [
+        "data: {invalid json}",
+        'data: {"choices":[{"delta":{"content":"정상"}}]}',
+        "data: [DONE]",
+      ];
+      mockFetch.mockResolvedValue(makeSseResponse(sseLines));
+
+      const chunks = await collectStream(provider.streamReading("s", "u"));
+      expect(chunks).toEqual(["정상"]);
+      expect(consoleSpy).toHaveBeenCalledOnce();
+    });
+
+    it("401 응답 시 AuthError를 던진다", async () => {
+      mockFetch.mockResolvedValue(makeErrorResponse(401, "unauthorized"));
+
+      await expect(collectStream(provider.streamReading("s", "u"))).rejects.toThrow(AuthError);
+    });
+
+    it("429 응답 시 RateLimitError를 던진다", async () => {
+      mockFetch.mockResolvedValue(
+        makeErrorResponse(429, "rate limited", { "retry-after": "60" })
+      );
+
+      await expect(collectStream(provider.streamReading("s", "u"))).rejects.toThrow(RateLimitError);
+    });
+
+    it("body가 null이면 Error를 던진다", async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        status: 200,
+        headers: new Headers(),
+        body: null,
+        text: () => Promise.resolve(""),
+      } as unknown as Response);
+
+      await expect(collectStream(provider.streamReading("s", "u"))).rejects.toThrow("Response body is null");
+    });
+  });
+});

--- a/src/services/saju/saju-calculator.test.ts
+++ b/src/services/saju/saju-calculator.test.ts
@@ -1,0 +1,359 @@
+import { describe, it, expect } from "vitest";
+import { calculateSaju } from "./saju-calculator";
+import type { SajuInput } from "./saju-types";
+import { STEM_KO, BRANCH_KO, STEM_ELEMENT } from "@/data/saju/constants";
+
+const VALID_STEMS = Object.keys(STEM_KO);
+const VALID_BRANCHES = Object.keys(BRANCH_KO);
+const VALID_ELEMENTS = ["wood", "fire", "earth", "metal", "water"] as const;
+
+const MALE_1990: SajuInput = { birthDate: "1990-05-15", birthHour: "ja", gender: "male" };
+const FEMALE_2000: SajuInput = { birthDate: "2000-01-01", birthHour: "o", gender: "female" };
+const MALE_1985: SajuInput = { birthDate: "1985-07-07", birthHour: "in", gender: "male" };
+const FEMALE_1975: SajuInput = { birthDate: "1975-03-20", birthHour: "hae", gender: "female" };
+
+describe("calculateSaju", () => {
+  describe("기본 구조 검증", () => {
+    it("필수 필드가 모두 반환된다", () => {
+      const result = calculateSaju(MALE_1990);
+      expect(result).toHaveProperty("pillars");
+      expect(result).toHaveProperty("dayMaster");
+      expect(result).toHaveProperty("dayMasterElement");
+      expect(result).toHaveProperty("isStrong");
+      expect(result).toHaveProperty("elements");
+      expect(result).toHaveProperty("tenStars");
+      expect(result).toHaveProperty("twelveStages");
+      expect(result).toHaveProperty("interactions");
+      expect(result).toHaveProperty("yongsin");
+      expect(result).toHaveProperty("majorFortunes");
+      expect(result).toHaveProperty("yearlyFortune");
+    });
+
+    it("pillars에 year/month/day/hour가 모두 있다", () => {
+      const { pillars } = calculateSaju(MALE_1990);
+      expect(pillars).toHaveProperty("year");
+      expect(pillars).toHaveProperty("month");
+      expect(pillars).toHaveProperty("day");
+      expect(pillars).toHaveProperty("hour");
+    });
+
+    it("각 pillar에 stem/stemHanja/branch/branchHanja/element가 있다", () => {
+      const { pillars } = calculateSaju(MALE_1990);
+      for (const key of ["year", "month", "day", "hour"] as const) {
+        const pillar = pillars[key];
+        expect(pillar.stem).toBeTruthy();
+        expect(VALID_STEMS).toContain(pillar.stemHanja);
+        expect(pillar.branch).toBeTruthy();
+        expect(VALID_BRANCHES).toContain(pillar.branchHanja);
+        expect(VALID_ELEMENTS).toContain(pillar.element);
+      }
+    });
+  });
+
+  describe("일간(Day Master)", () => {
+    it("dayMaster는 한글 천간 이름이다", () => {
+      const { dayMaster } = calculateSaju(MALE_1990);
+      const validKoStems = Object.values(STEM_KO);
+      expect(validKoStems).toContain(dayMaster);
+    });
+
+    it("dayMasterElement는 유효한 오행이다", () => {
+      const { dayMasterElement } = calculateSaju(MALE_1990);
+      expect(VALID_ELEMENTS).toContain(dayMasterElement);
+    });
+
+    it("isStrong은 boolean이다", () => {
+      const { isStrong } = calculateSaju(MALE_1990);
+      expect(typeof isStrong).toBe("boolean");
+    });
+
+    it("남녀 동일 생년월일이어도 결과가 다를 수 있다", () => {
+      const maleResult = calculateSaju({ ...MALE_1990, gender: "male" });
+      const femaleResult = calculateSaju({ ...MALE_1990, gender: "female" });
+      // dayMaster는 같지만 majorFortunes의 startAge가 다름
+      expect(maleResult.dayMaster).toBe(femaleResult.dayMaster);
+      expect(maleResult.majorFortunes[0].startAge).not.toBe(femaleResult.majorFortunes[0].startAge);
+    });
+  });
+
+  describe("오행 분포(elements)", () => {
+    it("오행 5가지 키가 모두 존재한다", () => {
+      const { elements } = calculateSaju(MALE_1990);
+      for (const el of VALID_ELEMENTS) {
+        expect(elements).toHaveProperty(el);
+        expect(typeof elements[el]).toBe("number");
+      }
+    });
+
+    it("천간 4 + 지지 4 = 총 8개가 분배된다", () => {
+      const { elements } = calculateSaju(MALE_1990);
+      const total = Object.values(elements).reduce((a, b) => a + b, 0);
+      expect(total).toBe(8);
+    });
+
+    it("각 오행 카운트는 0 이상이다", () => {
+      const { elements } = calculateSaju(FEMALE_2000);
+      for (const count of Object.values(elements)) {
+        expect(count).toBeGreaterThanOrEqual(0);
+      }
+    });
+  });
+
+  describe("십성(Ten Stars)", () => {
+    it("tenStars는 3개 항목이다 (연간/월간/시간)", () => {
+      const { tenStars } = calculateSaju(MALE_1990);
+      expect(tenStars).toHaveLength(3);
+    });
+
+    it("각 tenStar에 position/star/starKo/description이 있다", () => {
+      const { tenStars } = calculateSaju(MALE_1990);
+      for (const ts of tenStars) {
+        expect(ts.position).toBeTruthy();
+        expect(typeof ts.star).toBe("string");
+        expect(typeof ts.starKo).toBe("string");
+        expect(typeof ts.description).toBe("string");
+      }
+    });
+
+    it("tenStars position은 연간/월간/시간 순서다", () => {
+      const { tenStars } = calculateSaju(MALE_1990);
+      expect(tenStars[0].position).toBe("연간");
+      expect(tenStars[1].position).toBe("월간");
+      expect(tenStars[2].position).toBe("시간");
+    });
+  });
+
+  describe("12운성(Twelve Stages)", () => {
+    it("twelveStages는 4개 항목이다 (연지/월지/일지/시지)", () => {
+      const { twelveStages } = calculateSaju(MALE_1990);
+      expect(twelveStages).toHaveLength(4);
+    });
+
+    it("각 twelveStage에 position/stage/stageKo/description이 있다", () => {
+      const { twelveStages } = calculateSaju(FEMALE_2000);
+      for (const ts of twelveStages) {
+        expect(ts.position).toBeTruthy();
+        expect(typeof ts.stage).toBe("string");
+        expect(typeof ts.stageKo).toBe("string");
+        expect(typeof ts.description).toBe("string");
+      }
+    });
+
+    it("twelveStages position은 연지/월지/일지/시지 순서다", () => {
+      const { twelveStages } = calculateSaju(MALE_1990);
+      expect(twelveStages[0].position).toBe("연지");
+      expect(twelveStages[1].position).toBe("월지");
+      expect(twelveStages[2].position).toBe("일지");
+      expect(twelveStages[3].position).toBe("시지");
+    });
+  });
+
+  describe("합/충/형(interactions)", () => {
+    it("interactions에 combinations/clashes/punishments 배열이 있다", () => {
+      const { interactions } = calculateSaju(MALE_1990);
+      expect(Array.isArray(interactions.combinations)).toBe(true);
+      expect(Array.isArray(interactions.clashes)).toBe(true);
+      expect(Array.isArray(interactions.punishments)).toBe(true);
+    });
+
+    it("합/충/형 문자열에는 출발-도착 포지션이 포함된다", () => {
+      // 여러 생년월일로 하나라도 합/충/형이 생기는 케이스를 찾아 검증
+      const cases = [MALE_1990, FEMALE_2000, MALE_1985, FEMALE_1975];
+      const allInteractions: string[] = [];
+      for (const input of cases) {
+        const { interactions } = calculateSaju(input);
+        allInteractions.push(...interactions.combinations, ...interactions.clashes, ...interactions.punishments);
+      }
+      // 합/충/형 문자열이 있다면 포맷을 검증
+      for (const s of allInteractions) {
+        expect(s).toMatch(/^(연지|월지|일지|시지)/);
+        expect(s).toMatch(/(합|충|형)$/);
+      }
+    });
+  });
+
+  describe("용신(Yongsin)", () => {
+    it("yongsin에 element와 reason이 있다", () => {
+      const { yongsin } = calculateSaju(MALE_1990);
+      expect(VALID_ELEMENTS).toContain(yongsin.element);
+      expect(yongsin.reason).toBeTruthy();
+    });
+
+    it("신강이면 용신 이유에 '신강'이 포함된다", () => {
+      const cases = [MALE_1990, FEMALE_2000, MALE_1985, FEMALE_1975];
+      for (const input of cases) {
+        const { isStrong, yongsin } = calculateSaju(input);
+        if (isStrong) {
+          expect(yongsin.reason).toContain("신강");
+        } else {
+          expect(yongsin.reason).toContain("신약");
+        }
+      }
+    });
+  });
+
+  describe("대운(Major Fortunes)", () => {
+    it("대운은 8개다", () => {
+      const { majorFortunes } = calculateSaju(MALE_1990);
+      expect(majorFortunes).toHaveLength(8);
+    });
+
+    it("각 대운에 startAge/endAge/stem/branch/element/description이 있다", () => {
+      const { majorFortunes } = calculateSaju(MALE_1990);
+      for (const mf of majorFortunes) {
+        expect(typeof mf.startAge).toBe("number");
+        expect(typeof mf.endAge).toBe("number");
+        expect(mf.stem).toBeTruthy();
+        expect(mf.branch).toBeTruthy();
+        expect(VALID_ELEMENTS).toContain(mf.element);
+        expect(mf.description).toBeTruthy();
+      }
+    });
+
+    it("대운 시작 나이는 양수다", () => {
+      const { majorFortunes } = calculateSaju(MALE_1990);
+      for (const mf of majorFortunes) {
+        expect(mf.startAge).toBeGreaterThanOrEqual(0);
+      }
+    });
+  });
+
+  describe("세운(Yearly Fortune)", () => {
+    it("yearlyFortune에 year/stem/branch/element/description이 있다", () => {
+      const { yearlyFortune } = calculateSaju(MALE_1990);
+      expect(typeof yearlyFortune.year).toBe("number");
+      expect(yearlyFortune.stem).toBeTruthy();
+      expect(yearlyFortune.branch).toBeTruthy();
+      expect(VALID_ELEMENTS).toContain(yearlyFortune.element);
+      expect(yearlyFortune.description).toContain(String(yearlyFortune.year));
+    });
+
+    it("yearlyFortune.year는 현재 연도다", () => {
+      const { yearlyFortune } = calculateSaju(MALE_1990);
+      expect(yearlyFortune.year).toBe(new Date().getFullYear());
+    });
+  });
+
+  describe("옵션: 월운(monthly)", () => {
+    it("monthly: true이면 monthlyFortunes가 12개다", () => {
+      const result = calculateSaju(MALE_1990, { monthly: true });
+      expect(result.monthlyFortunes).toHaveLength(12);
+    });
+
+    it("각 월운에 month/stem/branch/element/description이 있다", () => {
+      const result = calculateSaju(FEMALE_2000, { monthly: true });
+      result.monthlyFortunes!.forEach((mf, idx) => {
+        expect(mf.month).toBe(idx + 1);
+        expect(mf.stem).toBeTruthy();
+        expect(mf.branch).toBeTruthy();
+        expect(VALID_ELEMENTS).toContain(mf.element);
+        expect(mf.description).toContain(String(mf.month));
+      });
+    });
+
+    it("monthly 옵션 없으면 monthlyFortunes가 undefined다", () => {
+      const result = calculateSaju(MALE_1990);
+      expect(result.monthlyFortunes).toBeUndefined();
+    });
+  });
+
+  describe("옵션: 다년 세운(yearlyMulti)", () => {
+    it("yearlyMulti: 3이면 yearlyFortunes가 3개다", () => {
+      const result = calculateSaju(MALE_1990, { yearlyMulti: 3 });
+      expect(result.yearlyFortunes).toHaveLength(3);
+    });
+
+    it("yearlyFortunes는 내년부터 시작한다", () => {
+      const result = calculateSaju(MALE_1990, { yearlyMulti: 1 });
+      const nextYear = new Date().getFullYear() + 1;
+      expect(result.yearlyFortunes![0].year).toBe(nextYear);
+    });
+
+    it("yearlyMulti: 0이면 yearlyFortunes가 undefined다", () => {
+      const result = calculateSaju(MALE_1990, { yearlyMulti: 0 });
+      expect(result.yearlyFortunes).toBeUndefined();
+    });
+
+    it("yearlyMulti 없으면 yearlyFortunes가 undefined다", () => {
+      const result = calculateSaju(MALE_1990);
+      expect(result.yearlyFortunes).toBeUndefined();
+    });
+  });
+
+  describe("옵션: 일운(daily)", () => {
+    it("daily: true이면 dailyFortunes가 7개다", () => {
+      const result = calculateSaju(MALE_1990, { daily: true });
+      expect(result.dailyFortunes).toHaveLength(7);
+    });
+
+    it("각 일운에 date/stem/branch/element/description이 있다", () => {
+      const result = calculateSaju(FEMALE_2000, { daily: true });
+      for (const df of result.dailyFortunes!) {
+        expect(df.date).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+        expect(df.stem).toBeTruthy();
+        expect(df.branch).toBeTruthy();
+        expect(VALID_ELEMENTS).toContain(df.element);
+        expect(df.description).toBeTruthy();
+      }
+    });
+
+    it("daily 옵션 없으면 dailyFortunes가 undefined다", () => {
+      const result = calculateSaju(MALE_1990);
+      expect(result.dailyFortunes).toBeUndefined();
+    });
+  });
+
+  describe("다양한 입력값 처리", () => {
+    it("birthHour unknown (-1)는 tyme4ts가 거부하여 오류가 발생한다", () => {
+      expect(() => calculateSaju({ ...MALE_1990, birthHour: "unknown" })).toThrow();
+    });
+
+    it("여성 입력을 처리한다", () => {
+      const result = calculateSaju(FEMALE_1975);
+      expect(result.pillars).toBeDefined();
+      expect(result.dayMaster).toBeTruthy();
+    });
+
+    it("모든 옵션을 동시에 사용할 수 있다", () => {
+      const result = calculateSaju(MALE_1990, { monthly: true, yearlyMulti: 2, daily: true });
+      expect(result.monthlyFortunes).toHaveLength(12);
+      expect(result.yearlyFortunes).toHaveLength(2);
+      expect(result.dailyFortunes).toHaveLength(7);
+    });
+
+    it("동일 입력은 동일 결과를 반환한다 (순수 함수)", () => {
+      const r1 = calculateSaju(MALE_1990);
+      const r2 = calculateSaju(MALE_1990);
+      expect(r1.dayMaster).toBe(r2.dayMaster);
+      expect(r1.pillars.year.stemHanja).toBe(r2.pillars.year.stemHanja);
+      expect(r1.isStrong).toBe(r2.isStrong);
+    });
+  });
+
+  describe("stem/branch 오행 일관성", () => {
+    it("pillar element는 STEM_ELEMENT 매핑과 일치한다", () => {
+      const { pillars } = calculateSaju(MALE_1990);
+      for (const key of ["year", "month", "day", "hour"] as const) {
+        const pillar = pillars[key];
+        const expectedElement = STEM_ELEMENT[pillar.stemHanja];
+        expect(pillar.element).toBe(expectedElement);
+      }
+    });
+
+    it("pillar stemHanja → stem은 STEM_KO 매핑과 일치한다", () => {
+      const { pillars } = calculateSaju(FEMALE_2000);
+      for (const key of ["year", "month", "day", "hour"] as const) {
+        const pillar = pillars[key];
+        expect(pillar.stem).toBe(STEM_KO[pillar.stemHanja]);
+      }
+    });
+
+    it("pillar branchHanja → branch는 BRANCH_KO 매핑과 일치한다", () => {
+      const { pillars } = calculateSaju(MALE_1985);
+      for (const key of ["year", "month", "day", "hour"] as const) {
+        const pillar = pillars[key];
+        expect(pillar.branch).toBe(BRANCH_KO[pillar.branchHanja]);
+      }
+    });
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,5 +1,5 @@
 import { defineConfig } from "vitest/config";
-import path from "path";
+import path from "node:path";
 
 export default defineConfig({
   test: {
@@ -22,6 +22,8 @@ export default defineConfig({
       include: [
         "src/data/topics.ts",   // 유효 토픽 목록 — 테스트 있음
         "src/lib/env.ts",
+        "src/lib/db/supabase-adapter.ts",
+        "src/hooks/useSSEStream.ts",
         "src/services/**/*.ts",
       ],
       exclude: [
@@ -39,8 +41,16 @@ export default defineConfig({
         "src/data/saju/categories.ts",
         "src/data/birth-hours.ts",
         "src/data/error-messages.ts",
-        // hooks — jsdom 없이 node env 테스트 불가 (Phase C-5에서 useSSEStream만 별도 추가)
-        "src/hooks/**",
+        // hooks — useSSEStream 제외한 나머지 (jsdom 필요)
+        "src/hooks/useCardAnimation.ts",
+        "src/hooks/useCharacter.ts",
+        "src/hooks/useFavoriteCharacter.ts",
+        "src/hooks/useGenderStore.ts",
+        "src/hooks/useSajuSession.ts",
+        "src/hooks/useSession.ts",
+        "src/hooks/useShinjeomSession.ts",
+        "src/hooks/useSkinStore.ts",
+        "src/hooks/useTheme.ts",
         // lib 계층 — Phase C-4 완료 전까지 제외
         "src/lib/supabase/**",
         "src/lib/auth/**",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
   test: {
     environment: "node",
     globals: true,
+    reporters: ["default", ["junit", { outputFile: "./coverage/junit.xml" }]],
     setupFiles: ["./vitest.setup.ts"],
     include: ["src/**/*.test.ts", "src/**/*.spec.ts"],
     exclude: [

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -48,11 +48,7 @@ export default defineConfig({
         "src/lib/db/schema/**",
         "src/lib/db/types.ts",
         "src/lib/db/index.ts",
-        // Phase C-1~3 완료 전까지 제외 (테스트 미작성 → 분모 왜곡 방지)
         "src/services/core/ai-provider.ts",   // re-export only
-        "src/services/core/grok-provider.ts", // Phase C-2
-        "src/services/core/claude-provider.ts", // Phase C-3
-        "src/services/saju/saju-calculator.ts", // Phase C-1
         "src/services/saju/saju-types.ts",    // 타입 정의만
       ],
       thresholds: {


### PR DESCRIPTION
## Summary
- **B-1** Vitest JUnit reporter 추가 → `coverage/junit.xml` 생성 → SonarCloud Tests 탭 집계
- **B-2** `sonar-project.properties`: `tests=src,e2e`, `coverage.exclusions` vitest 동기화, `tsconfigPath` 명시
- **B-3** `SonarSource/sonarcloud-github-action@master` → `sonarqube-scan-action@v4.2.1` 버전 고정
- **B-4** `deploy.yml`에 `unit-coverage` artifact 업로드 (항상, 7일 보존)
- **B-5** `.codecov.yml` flag `e2e`(데이터 없음) → `unit`으로 교체

## Test plan
- [ ] CI 통과 확인 (`pnpm test:coverage`, `pnpm lint`, `pnpm type-check`)
- [ ] `coverage/junit.xml` 생성 확인
- [ ] SonarCloud PR 코멘트에 단위 테스트 270개 집계 확인 (main 머지 후)
- [ ] Codecov PR 코멘트에 `unit` flag 커버리지 표시 확인

> **Base**: `chore/sonar-codecov-integration` — #105 머지 후 base를 `main`으로 변경 예정

🤖 Generated with [Claude Code](https://claude.com/claude-code)