### PR TITLE
fix: SonarCloud Reliability 개선 — 빈 catch 로깅 + useEffect NOSONAR

### DIFF
--- a/src/app/saju/session/page.tsx
+++ b/src/app/saju/session/page.tsx
@@ -43,7 +43,7 @@ export default function SajuSessionPage() {
       if (!res.ok) return;
       const data = await res.json();
       if (data.session?.id) setSessionId(data.session.id);
-    }).catch(() => {});
+    }).catch((e) => console.warn("사주 세션 생성 실패 (리딩은 계속 진행):", e));
 
     setMood("default");
     const namePrefix = userInfo.name ? `${userInfo.name}님의` : "";
@@ -56,7 +56,7 @@ export default function SajuSessionPage() {
 
     startReading();
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, []); // NOSONAR
 
   const startReading = async () => {
     setLoading(true);
@@ -199,24 +199,24 @@ export default function SajuSessionPage() {
                     const url = `${window.location.origin}/saju/result/${shareToken}`;
                     const text = `☯ 사주 분석 결과를 확인해보세요!\n\n- ${siteName}`;
                     if (navigator.share) {
-                      try { await navigator.share({ title: `사주 분석 결과 - ${siteName}`, text, url }); } catch { /* 취소 */ }
+                      try { await navigator.share({ title: `사주 분석 결과 - ${siteName}`, text, url }); } catch { /* 사용자가 공유를 취소함 */ } // NOSONAR
                     } else {
                       try {
                         await navigator.clipboard.writeText(`${text}\n${url}`);
                         alert("링크가 복사되었습니다!");
-                      } catch { /* 실패 */ }
+                      } catch (e) { console.warn("클립보드 복사 실패:", e); }
                     }
                   } else {
                     const summary = r?.overallReading
                       ? `☯ 사주 분석 결과\n\n${r.overallReading.slice(0, 100)}...\n\n- ${siteName}`
                       : `☯ 사주 분석을 받아보세요!\n\n- ${siteName}`;
                     if (navigator.share) {
-                      try { await navigator.share({ title: `사주 분석 결과 - ${siteName}`, text: summary }); } catch { /* 취소 */ }
+                      try { await navigator.share({ title: `사주 분석 결과 - ${siteName}`, text: summary }); } catch { /* 사용자가 공유를 취소함 */ } // NOSONAR
                     } else {
                       try {
                         await navigator.clipboard.writeText(summary);
                         alert("결과가 복사되었습니다!");
-                      } catch { /* 실패 */ }
+                      } catch (e) { console.warn("클립보드 복사 실패:", e); }
                     }
                   }
                 }}

--- a/src/app/shinjeom/page.tsx
+++ b/src/app/shinjeom/page.tsx
@@ -43,7 +43,7 @@ function ShinjeomPageContent() {
   useEffect(() => {
     reset();
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, []); // NOSONAR
 
   // URL 파라미터로 캐릭터가 프리셀렉트된 경우 스토어에 반영
   useEffect(() => {
@@ -61,7 +61,7 @@ function ShinjeomPageContent() {
       setStep("topic-select");
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [favoriteCharacter]);
+  }, [favoriteCharacter]); // NOSONAR
 
   // 스텝 전환 시 스크롤 최상단 초기화 (3중 보정: 즉시 + rAF + rAF)
   useEffect(() => {

--- a/src/app/shinjeom/session/page.tsx
+++ b/src/app/shinjeom/session/page.tsx
@@ -37,7 +37,7 @@ export default function ShinjeomSessionPage() {
         });
         const data = await res.json();
         if (data.session?.id) setSessionId(data.session.id);
-      } catch { /* 계속 진행 */ }
+      } catch (e) { console.warn("신점 세션 생성 실패 (상담은 계속 진행):", e); }
     };
     initSession();
 
@@ -144,7 +144,7 @@ export default function ShinjeomSessionPage() {
                 ),
               }));
             }
-          } catch { /* 파싱 실패 */ }
+          } catch (e) { console.warn("SSE 파싱 실패:", e); }
         }
       }
     } catch {
@@ -228,7 +228,7 @@ export default function ShinjeomSessionPage() {
               setPhase("result");
               setMood("smile");
             }
-          } catch { /* 파싱 실패 */ }
+          } catch (e) { console.warn("SSE 파싱 실패:", e); }
         }
       }
     } catch {

--- a/src/app/tarot/session/page.tsx
+++ b/src/app/tarot/session/page.tsx
@@ -96,7 +96,7 @@ export default function TarotSessionPage() {
       });
     }, 2000);
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [topic]);
+  }, [topic]); // NOSONAR
 
   const handleCardSelect = useCallback((index: number) => {
     // 항상 fresh 상태를 읽어 stale closure 방지
@@ -136,7 +136,7 @@ export default function TarotSessionPage() {
       }, 500);
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [shuffledDeck, confirmEachCard, selectCard, setMood, addChatMessage]);
+  }, [shuffledDeck, confirmEachCard, selectCard, setMood, addChatMessage]); // NOSONAR
 
   /** 확인 → 마지막 카드면 리딩 시작, 아니면 다음 카드 선택 계속 */
   const handleConfirmCard = useCallback(() => {
@@ -153,7 +153,7 @@ export default function TarotSessionPage() {
       setMood("default");
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [requiredCards, addChatMessage, setMood]);
+  }, [requiredCards, addChatMessage, setMood]); // NOSONAR
 
   /** 취소 → 마지막 카드 제거, 다시 선택 가능 */
   const handleCancelLastCard = useCallback(() => {
@@ -232,7 +232,7 @@ export default function TarotSessionPage() {
         try {
           const errorBody = await response.json();
           errorDetail = errorBody?.error || "";
-        } catch { /* JSON 파싱 실패 무시 */ }
+        } catch (e) { console.warn("리딩 에러 응답 JSON 파싱 실패:", e); }
         console.error("리딩 API 응답 실패:", response.status, errorDetail);
         const message = errorDetail.includes("GROK_API_KEY")
           ? "AI 서비스 설정에 문제가 있어요. 관리자에게 문의해주세요."
@@ -264,7 +264,7 @@ export default function TarotSessionPage() {
                   setReadingResult(data.result);
                   setPhase("result"); setMood("smile");
                 }
-              } catch { /* 파싱 실패 무시 */ }
+              } catch (e) { console.warn("SSE 버퍼 파싱 실패:", e); }
             }
           }
           break;
@@ -586,12 +586,12 @@ export default function TarotSessionPage() {
                         const url = `${window.location.origin}/tarot/result/${shareToken}`;
                         const text = `🔮 타로 리딩 결과를 확인해보세요!\n\n- ${siteName}`;
                         if (navigator.share) {
-                          try { await navigator.share({ title: `타로 리딩 결과 - ${siteName}`, text, url }); } catch { /* 취소 */ }
+                          try { await navigator.share({ title: `타로 리딩 결과 - ${siteName}`, text, url }); } catch { /* 사용자가 공유를 취소함 */ } // NOSONAR
                         } else {
                           try {
                             await navigator.clipboard.writeText(`${text}\n${url}`);
                             alert("링크가 복사되었습니다!");
-                          } catch { /* 실패 */ }
+                          } catch (e) { console.warn("클립보드 복사 실패:", e); }
                         }
                       } else {
                         // 공유 링크 없으면 결과 텍스트 직접 공유
@@ -599,12 +599,12 @@ export default function TarotSessionPage() {
                           ? `🔮 타로 리딩 결과\n\n${result.overallReading}\n\n- ${siteName}`
                           : `🔮 타로 리딩을 받아보세요!\n\n- ${siteName}`;
                         if (navigator.share) {
-                          try { await navigator.share({ title: `타로 리딩 결과 - ${siteName}`, text: summary }); } catch { /* 취소 */ }
+                          try { await navigator.share({ title: `타로 리딩 결과 - ${siteName}`, text: summary }); } catch { /* 사용자가 공유를 취소함 */ } // NOSONAR
                         } else {
                           try {
                             await navigator.clipboard.writeText(summary);
                             alert("결과가 복사되었습니다!");
-                          } catch { /* 실패 */ }
+                          } catch (e) { console.warn("클립보드 복사 실패:", e); }
                         }
                       }
                     }}

--- a/src/components/common/UserInfoForm.tsx
+++ b/src/components/common/UserInfoForm.tsx
@@ -35,7 +35,7 @@ function saveLocalInfo(info: UserInfo): void {
   try {
     localStorage.setItem(STORAGE_KEY, JSON.stringify(info));
     localStorage.setItem(CONSENT_KEY, new Date().toISOString());
-  } catch { /* 시크릿 모드 등 localStorage 차단 시 무시 */ }
+  } catch { /* 시크릿 모드 등 localStorage 차단 시 무시 */ } // NOSONAR
 }
 
 /** localStorage에서 정보 삭제 (동의 철회) */
@@ -43,7 +43,7 @@ function clearLocalInfo(): void {
   try {
     localStorage.removeItem(STORAGE_KEY);
     localStorage.removeItem(CONSENT_KEY);
-  } catch { /* 무시 */ }
+  } catch { /* localStorage 차단 시 무시 */ } // NOSONAR
 }
 
 export function UserInfoForm({ mode, onSubmit, onBack, characterName }: UserInfoFormProps) {

--- a/src/components/effects/ParticleOverlay.tsx
+++ b/src/components/effects/ParticleOverlay.tsx
@@ -133,7 +133,7 @@ export function ParticleOverlay({ density = "medium", colorScheme, particleStyle
   useEffect(() => {
     setParticles(generateParticles(DENSITY_COUNT[density], buildColors(colorScheme)));
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [density, primaryColor, secondaryColor, accentColor, particleStyle]);
+  }, [density, primaryColor, secondaryColor, accentColor, particleStyle]); // NOSONAR
 
   return (
     <div className={`absolute inset-0 pointer-events-none overflow-hidden ${className}`}>

--- a/src/components/home/DailyCard.tsx
+++ b/src/components/home/DailyCard.tsx
@@ -42,7 +42,7 @@ export function DailyCard() {
         const result = await res.json();
         setData((prev) => ({ ...prev, [characterId]: result }));
       }
-    } catch { /* 네트워크 에러 무시 */ }
+    } catch (e) { console.warn("일일 카드 로드 실패:", e); }
     setLoading(null);
   }, [data, today]);
 

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -122,7 +122,7 @@ export const useThemeStore = create<ThemeState>((set, get) => ({
       if (typeof window !== "undefined") {
         localStorage.setItem("arcana-theme-mode", mode);
       }
-    } catch { /* Safari Private 모드 등에서 localStorage 접근 실패 시 무시 */ }
+    } catch { /* Safari Private 모드 등에서 localStorage 접근 실패 시 무시 */ } // NOSONAR
   },
 
   refresh: () => {

--- a/src/services/core/claude-provider.ts
+++ b/src/services/core/claude-provider.ts
@@ -103,7 +103,7 @@ export class ClaudeProvider implements AIProvider {
             if (parsed.type === "content_block_delta" && parsed.delta?.text) {
               yield parsed.delta.text;
             }
-          } catch { /* 파싱 실패 무시 */ }
+          } catch (e) { console.warn("Claude SSE 파싱 실패:", e); }
         }
       }
     } finally {

--- a/src/services/core/text-cleaner.ts
+++ b/src/services/core/text-cleaner.ts
@@ -48,7 +48,7 @@ export function parseJsonSafe(raw: string): Record<string, unknown> | null {
   // 1차 시도: 그대로 파싱
   try {
     return JSON.parse(text) as Record<string, unknown>;
-  } catch { /* 계속 */ }
+  } catch { /* 다음 파싱 방법으로 계속 */ } // NOSONAR
 
   // 2차 시도: 문자열 리터럴 내 개행·탭 이스케이프
   // "..." 패턴 내부의 비이스케이프 개행만 교체
@@ -57,7 +57,7 @@ export function parseJsonSafe(raw: string): Record<string, unknown> | null {
       m.replace(/\n/g, "\\n").replace(/\r/g, "").replace(/\t/g, "\\t")
     );
     return JSON.parse(sanitized) as Record<string, unknown>;
-  } catch { /* 계속 */ }
+  } catch { /* 다음 파싱 방법으로 계속 */ } // NOSONAR
 
   return null;
 }

--- a/src/services/shinjeom/shinjeom-service.ts
+++ b/src/services/shinjeom/shinjeom-service.ts
@@ -136,7 +136,7 @@ JSON 앞뒤에 어떤 텍스트도 추가하지 않습니다.`;
           advice: cleanReadingText(String(parsed.advice || "")),
         };
       }
-    } catch { /* JSON 파싱 실패 → 텍스트로 처리 */ }
+    } catch (e) { console.warn("신점 결과 JSON 파싱 실패 (텍스트로 처리):", e); }
 
     // 중간 대화 또는 파싱 실패 → 텍스트 그대로
     return {


### PR DESCRIPTION
## Summary

SonarCloud Reliability D (84 bugs) 등급 개선을 위한 코드 품질 수정.

- **빈 catch 블록 22건** 처리
  - SSE/JSON 파싱 실패 → `console.warn` 추가 (에러 가시성 확보)
  - 사용자 공유 취소 / Safari Private 모드 localStorage 차단 → `// NOSONAR` (의도적 침묵 명시)
  - 세션 생성 실패 → `console.warn` 추가
- **useEffect 의존성 누락 7건** → `// NOSONAR` 추가 (무한루프 방지 목적 의도 명시)
- **`.catch(() => {})`** → `.catch((e) => console.warn(...))` 개선

## 변경 파일 (11개)

| 파일 | 변경 내용 |
|------|---------|
| `src/app/saju/session/page.tsx` | catch 4건 수정 + useEffect NOSONAR |
| `src/app/tarot/session/page.tsx` | catch 4건 수정 + useEffect NOSONAR 3건 |
| `src/app/shinjeom/session/page.tsx` | catch 3건 수정 |
| `src/app/shinjeom/page.tsx` | useEffect NOSONAR 2건 |
| `src/components/common/UserInfoForm.tsx` | catch 2건 NOSONAR |
| `src/components/effects/ParticleOverlay.tsx` | useEffect NOSONAR |
| `src/components/home/DailyCard.tsx` | catch → console.warn |
| `src/hooks/useTheme.ts` | catch NOSONAR |
| `src/services/core/claude-provider.ts` | catch → console.warn |
| `src/services/core/text-cleaner.ts` | catch 2건 NOSONAR |
| `src/services/shinjeom/shinjeom-service.ts` | catch → console.warn |

## Test plan

- [x] `pnpm type-check` — 통과
- [x] `pnpm lint` — 통과
- [x] `pnpm test:coverage` — 380개 테스트, 95.78% coverage 통과
- [ ] SonarCloud 재분석 — PR merge 후 CI 실행 시 자동

## 수동 조치 필요 (자동화 불가)

1. **Quality Gate 설정**: SonarCloud → Project Settings → Quality Gate → "Sonar way" 선택
2. **Security Hotspots 검토**: SonarCloud → Hotspots → 각 항목 "Reviewed" 처리

🤖 Generated with [Claude Code](https://claude.com/claude-code)