### PR TITLE
fix: SonarCloud Phase 2 보안 강화 — IDOR/Rate Limit/ReDoS/입력검증

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "react": "19.2.4",
     "react-dom": "19.2.4",
     "tyme4ts": "^1.4.5",
+    "zod": "^4.3.6",
     "zustand": "^5.0.12"
   },
   "devDependencies": {
@@ -38,6 +39,7 @@
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "@vitest/coverage-v8": "^2.0.0",
     "dotenv": "^17.4.0",
     "drizzle-kit": "^0.31.10",
     "eslint": "^9",
@@ -45,7 +47,6 @@
     "tailwindcss": "^4",
     "tsx": "^4.21.0",
     "typescript": "^5",
-    "vitest": "^2.0.0",
-    "@vitest/coverage-v8": "^2.0.0"
+    "vitest": "^2.0.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       tyme4ts:
         specifier: ^1.4.5
         version: 1.4.5
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
       zustand:
         specifier: ^5.0.12
         version: 5.0.12(@types/react@19.2.14)(react@19.2.4)

--- a/src/app/api/saju/reading/route.ts
+++ b/src/app/api/saju/reading/route.ts
@@ -5,6 +5,9 @@ import { calculateSaju } from "@/services/saju/saju-calculator";
 import { Topic, SajuTimeRange } from "@/types/session";
 import { sajuTimeOptions } from "@/data/saju/categories";
 import { getDb } from "@/lib/db";
+import { assertSessionOwnership } from "@/lib/auth";
+import { SajuReadingSchema } from "@/lib/validation/api-schemas";
+import { checkRateLimit, rateLimitResponse } from "@/lib/rate-limit";
 
 const sajuService = new SajuService();
 const grokProvider = new FallbackProvider();
@@ -35,8 +38,18 @@ function resolveCalcOptions(timeRange: SajuTimeRange, includeMonthly: boolean) {
 
 export async function POST(request: NextRequest) {
   try {
-    const body = await request.json();
-    const { sessionId, topic, timeRange, includeMonthly, characterId, userInfo } = body as {
+    // Rate limiting
+    const ip = request.headers.get("x-forwarded-for") ?? request.headers.get("x-real-ip") ?? "anon";
+    if (!checkRateLimit(`saju:${ip}`, 10, 60_000)) return rateLimitResponse();
+
+    const rawBody = await request.json();
+
+    // Zod 입력 검증
+    const parsed = SajuReadingSchema.safeParse(rawBody);
+    if (!parsed.success) {
+      return new Response(JSON.stringify({ error: "Invalid request" }), { status: 400, headers: { "Content-Type": "application/json" } });
+    }
+    const { sessionId, topic, timeRange, includeMonthly, characterId, userInfo } = parsed.data as {
       sessionId?: string | null;
       topic: Topic;
       timeRange: SajuTimeRange;
@@ -45,14 +58,17 @@ export async function POST(request: NextRequest) {
       userInfo: { name?: string; birthDate: string; birthHour: string; gender: "male" | "female" | "other" };
     };
 
-    if (!topic || !timeRange || !userInfo?.birthDate || !userInfo?.birthHour || !userInfo?.gender) {
-      return new Response(JSON.stringify({ error: "생년월일, 출생시간, 성별, 분석 설정은 필수입니다." }), { status: 400, headers: { "Content-Type": "application/json" } });
-    }
     if (!VALID_TOPICS.includes(topic)) {
       return new Response(JSON.stringify({ error: "Invalid topic" }), { status: 400, headers: { "Content-Type": "application/json" } });
     }
     if (!VALID_TIME_RANGES.includes(timeRange)) {
       return new Response(JSON.stringify({ error: "Invalid timeRange" }), { status: 400, headers: { "Content-Type": "application/json" } });
+    }
+
+    // 세션 소유권 검증 (sessionId 있을 때만 — 익명 리딩은 허용)
+    if (sessionId) {
+      const ownerErr = await assertSessionOwnership(sessionId);
+      if (ownerErr) return ownerErr;
     }
 
     // 사주팔자 계산 (서버 사이드)

--- a/src/app/api/shinjeom/message/route.ts
+++ b/src/app/api/shinjeom/message/route.ts
@@ -3,6 +3,9 @@ import { ShinjeomService } from "@/services/shinjeom/shinjeom-service";
 import { FallbackProvider } from "@/services/core/fallback-provider";
 import { Topic, ChatMessage } from "@/types/session";
 import { getDb } from "@/lib/db";
+import { assertSessionOwnership } from "@/lib/auth";
+import { ShinjeomMessageSchema } from "@/lib/validation/api-schemas";
+import { checkRateLimit, rateLimitResponse } from "@/lib/rate-limit";
 
 
 const shinjeomService = new ShinjeomService();
@@ -47,22 +50,33 @@ async function saveToDb(sessionId: string | null | undefined, params: {
 
 export async function POST(request: NextRequest) {
   try {
-    const body = await request.json();
-    const { sessionId, topic, characterId, currentMessage, chatHistory, isFinalTurn, messageIndex } = body as {
-      sessionId?: string | null;
-      topic: Topic;
-      characterId?: string;
-      currentMessage?: string;
-      chatHistory: ChatMessage[];
-      isFinalTurn: boolean;
-      messageIndex: number;
-    };
+    // Rate limiting
+    const ip = request.headers.get("x-forwarded-for") ?? request.headers.get("x-real-ip") ?? "anon";
+    if (!checkRateLimit(`shinjeom:${ip}`, 20, 60_000)) return rateLimitResponse();
 
-    if (!topic) {
-      return new Response(JSON.stringify({ error: "Missing required fields" }), { status: 400, headers: { "Content-Type": "application/json" } });
+    const rawBody = await request.json();
+
+    // Zod 입력 검증 (chatHistory 100개 상한으로 토큰 과소비 방어)
+    const parsed = ShinjeomMessageSchema.safeParse(rawBody);
+    if (!parsed.success) {
+      return new Response(JSON.stringify({ error: "Invalid request" }), { status: 400, headers: { "Content-Type": "application/json" } });
     }
+    const { sessionId, characterId, currentMessage, isFinalTurn, messageIndex } = parsed.data;
+    const topic = parsed.data.topic as Topic;
+    // timestamp는 네트워크 전송 시 문자열/숫자로 직렬화되므로 Date로 복원
+    const chatHistory: ChatMessage[] = parsed.data.chatHistory.map((m) => ({
+      ...m,
+      timestamp: new Date(m.timestamp),
+    }));
+
     if (!isFinalTurn && !currentMessage) {
       return new Response(JSON.stringify({ error: "Message required for non-final turns" }), { status: 400, headers: { "Content-Type": "application/json" } });
+    }
+
+    // 세션 소유권 검증 (sessionId 있을 때만)
+    if (sessionId) {
+      const ownerErr = await assertSessionOwnership(sessionId);
+      if (ownerErr) return ownerErr;
     }
 
     const systemPrompt = shinjeomService.getSystemPrompt(characterId);

--- a/src/app/api/tarot/reading/route.ts
+++ b/src/app/api/tarot/reading/route.ts
@@ -7,7 +7,10 @@ import { Topic } from "@/types/session";
 import { SelectedCard } from "@/types/card";
 import { buildUserInfoPrompt } from "@/services/core/prompt-builder";
 import { getDb } from "@/lib/db";
+import { assertSessionOwnership } from "@/lib/auth";
 import { TAROT_TOPICS } from "@/data/topics";
+import { TarotReadingSchema } from "@/lib/validation/api-schemas";
+import { checkRateLimit, rateLimitResponse } from "@/lib/rate-limit";
 
 const tarotService = new TarotService();
 const grokProvider = new FallbackProvider();
@@ -22,20 +25,32 @@ const TOKENS_MANY_CARDS = 6000;
 
 export async function POST(request: NextRequest) {
   try {
-    const body = await request.json();
-    const { sessionId, topic, spreadType, characterId, userInfo, cards } = body as {
+    // Rate limiting
+    const ip = request.headers.get("x-forwarded-for") ?? request.headers.get("x-real-ip") ?? "anon";
+    if (!checkRateLimit(`tarot:${ip}`, 10, 60_000)) return rateLimitResponse();
+
+    const rawBody = await request.json();
+
+    // Zod 입력 검증
+    const parsed = TarotReadingSchema.safeParse(rawBody);
+    if (!parsed.success) {
+      return new Response(JSON.stringify({ error: "Invalid request" }), { status: 400, headers: { "Content-Type": "application/json" } });
+    }
+    const { sessionId, topic, spreadType, characterId, userInfo, cards } = parsed.data as {
       sessionId?: string | null; topic: Topic; spreadType?: string; characterId?: string;
       userInfo?: { name: string; birthDate: string; gender: string; birthHour: string };
       cards: { cardId: string; position: number; isReversed: boolean }[];
     };
 
     // 입력 검증
-    if (!topic || !Array.isArray(cards) || cards.length === 0) {
-      return new Response(JSON.stringify({ error: "Missing required fields" }), { status: 400, headers: { "Content-Type": "application/json" } });
-    }
-
     if (!TAROT_TOPICS.includes(topic)) {
       return new Response(JSON.stringify({ error: "Invalid topic" }), { status: 400, headers: { "Content-Type": "application/json" } });
+    }
+
+    // 세션 소유권 검증 (sessionId 있을 때만 — 익명 리딩은 허용)
+    if (sessionId) {
+      const ownerErr = await assertSessionOwnership(sessionId);
+      if (ownerErr) return ownerErr;
     }
 
     const selectedCards: SelectedCard[] = cards.map((c) => {

--- a/src/lib/auth/index.ts
+++ b/src/lib/auth/index.ts
@@ -19,3 +19,24 @@ export async function requireUser(): Promise<AuthUser> {
   if (!user) throw new Error("Unauthorized")
   return user
 }
+
+const JSON_HEADER = { "Content-Type": "application/json" };
+
+/**
+ * 세션 소유권 검증.
+ * 로그인 사용자가 다른 사람의 세션에 쓰기 요청하는 IDOR를 차단.
+ * 익명 사용자(user=null)는 허용, 미인증 로그인 사용자도 허용.
+ * 반환값: 에러 Response(403/404) 또는 null(통과)
+ */
+export async function assertSessionOwnership(sessionId: string): Promise<Response | null> {
+  const { getDb } = await import("@/lib/db")
+  const user = await getCurrentUser()
+  if (!user) return null
+  const db = getDb()
+  const session = await db.findOne<{ user_id: string | null }>("sessions", { id: sessionId })
+  if (!session) return new Response(JSON.stringify({ error: "Session not found" }), { status: 404, headers: JSON_HEADER })
+  if (session.user_id && session.user_id !== user.id) {
+    return new Response(JSON.stringify({ error: "Forbidden" }), { status: 403, headers: JSON_HEADER })
+  }
+  return null
+}

--- a/src/lib/rate-limit.test.ts
+++ b/src/lib/rate-limit.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { checkRateLimit } from "./rate-limit";
+
+describe("checkRateLimit", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  it("첫 번째 요청은 항상 허용", () => {
+    expect(checkRateLimit("test-key-1", 5, 60_000)).toBe(true);
+  });
+
+  it("한도 내 요청은 허용", () => {
+    const key = "test-key-2";
+    for (let i = 0; i < 5; i++) {
+      expect(checkRateLimit(key, 5, 60_000)).toBe(true);
+    }
+  });
+
+  it("한도 초과 요청은 거부", () => {
+    const key = "test-key-3";
+    for (let i = 0; i < 5; i++) checkRateLimit(key, 5, 60_000);
+    expect(checkRateLimit(key, 5, 60_000)).toBe(false);
+  });
+
+  it("윈도우 만료 후 리셋", () => {
+    const key = "test-key-4";
+    for (let i = 0; i < 5; i++) checkRateLimit(key, 5, 60_000);
+    expect(checkRateLimit(key, 5, 60_000)).toBe(false);
+    vi.advanceTimersByTime(61_000);
+    expect(checkRateLimit(key, 5, 60_000)).toBe(true);
+  });
+
+  it("다른 키는 독립적으로 카운트", () => {
+    const keyA = "test-key-5a";
+    const keyB = "test-key-5b";
+    for (let i = 0; i < 5; i++) checkRateLimit(keyA, 5, 60_000);
+    expect(checkRateLimit(keyA, 5, 60_000)).toBe(false);
+    expect(checkRateLimit(keyB, 5, 60_000)).toBe(true);
+  });
+
+  it("limit=1이면 두 번째 요청부터 거부", () => {
+    const key = "test-key-6";
+    expect(checkRateLimit(key, 1, 60_000)).toBe(true);
+    expect(checkRateLimit(key, 1, 60_000)).toBe(false);
+  });
+});

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -1,0 +1,25 @@
+interface RateLimitEntry {
+  count: number;
+  resetAt: number;
+}
+
+const hits = new Map<string, RateLimitEntry>();
+
+export function checkRateLimit(key: string, limit: number, windowMs: number): boolean {
+  const now = Date.now();
+  const entry = hits.get(key);
+  if (!entry || entry.resetAt < now) {
+    hits.set(key, { count: 1, resetAt: now + windowMs });
+    return true;
+  }
+  if (entry.count >= limit) return false;
+  entry.count++;
+  return true;
+}
+
+export function rateLimitResponse(): Response {
+  return new Response(
+    JSON.stringify({ error: "요청이 너무 많습니다. 잠시 후 다시 시도해주세요." }),
+    { status: 429, headers: { "Content-Type": "application/json", "Retry-After": "60" } },
+  );
+}

--- a/src/lib/validation/api-schemas.ts
+++ b/src/lib/validation/api-schemas.ts
@@ -1,0 +1,53 @@
+import { z } from "zod";
+
+const uuidOrNull = z.string().max(36).nullish();
+const topicStr = z.string().max(60);
+const charIdStr = z.string().max(50).optional();
+
+export const TarotReadingSchema = z.object({
+  sessionId: uuidOrNull,
+  topic: topicStr,
+  spreadType: z.enum(["one-card", "three-card", "five-card", "seven-card", "ten-card", "relationship", "horseshoe", "decision", "weekly", "zodiac", "tree-of-life"]).optional(),
+  characterId: charIdStr,
+  userInfo: z.object({
+    name: z.string().max(50),
+    birthDate: z.string().max(20),
+    gender: z.string().max(10),
+    birthHour: z.string().max(20),
+  }).optional(),
+  cards: z.array(z.object({
+    cardId: z.string().max(50),
+    position: z.number().int().min(0).max(21),
+    isReversed: z.boolean(),
+  })).min(1).max(22),
+});
+
+export const SajuReadingSchema = z.object({
+  sessionId: uuidOrNull,
+  topic: topicStr,
+  timeRange: z.string().max(30),
+  includeMonthly: z.boolean(),
+  characterId: charIdStr,
+  userInfo: z.object({
+    name: z.string().max(50).optional(),
+    birthDate: z.string().max(20),
+    birthHour: z.string().max(20),
+    gender: z.enum(["male", "female", "other"]),
+  }),
+});
+
+export const ShinjeomMessageSchema = z.object({
+  sessionId: uuidOrNull,
+  topic: topicStr,
+  characterId: charIdStr,
+  currentMessage: z.string().max(2000).optional(),
+  chatHistory: z.array(z.object({
+    id: z.string().max(100),
+    role: z.enum(["user", "character", "system"]),
+    content: z.string().max(5000),
+    mood: z.string().max(30).optional(),
+    timestamp: z.union([z.string(), z.number()]),
+  })).max(100),
+  isFinalTurn: z.boolean(),
+  messageIndex: z.number().int().min(0).max(200),
+});

--- a/src/services/core/text-cleaner.test.ts
+++ b/src/services/core/text-cleaner.test.ts
@@ -230,4 +230,13 @@ describe("parseJsonSafe", () => {
     expect(result).not.toBeNull();
     expect(result?.value).toBe(123);
   });
+
+  it("50,000자 초과 입력은 null 반환 (ReDoS 방어)", () => {
+    const oversized = "x".repeat(50_001);
+    expect(parseJsonSafe(oversized)).toBeNull();
+  });
+
+  it("닫히지 않은 중괄호는 null 반환", () => {
+    expect(parseJsonSafe('{"key": "unclosed')).toBeNull();
+  });
 });

--- a/src/services/core/text-cleaner.ts
+++ b/src/services/core/text-cleaner.ts
@@ -40,10 +40,20 @@ export function parseJsonSafe(raw: string): Record<string, unknown> | null {
   const codeMatch = text.match(/```(?:json)?\s*([\s\S]*?)```/);
   if (codeMatch) text = codeMatch[1].trim();
 
-  // 가장 바깥 JSON 객체만 추출
-  const objMatch = text.match(/\{[\s\S]*\}/);
-  if (!objMatch) return null;
-  text = objMatch[0];
+  // 입력 길이 상한 (ReDoS 방어)
+  if (text.length > 50_000) return null;
+
+  // 가장 바깥 JSON 객체만 추출 — 괄호 카운터 기반으로 ReDoS 방지
+  const start = text.indexOf("{");
+  if (start === -1) return null;
+  let depth = 0;
+  let end = -1;
+  for (let i = start; i < text.length; i++) {
+    if (text[i] === "{") depth++;
+    else if (text[i] === "}") { depth--; if (depth === 0) { end = i; break; } }
+  }
+  if (end === -1) return null;
+  text = text.slice(start, end + 1);
 
   // 1차 시도: 그대로 파싱
   try {


### PR DESCRIPTION
## Summary
- `assertSessionOwnership()` 헬퍼로 세션 소유권 IDOR 방어 (타로/사주/신점 3개 API 라우트)
- Zod 스키마 입력 검증 (chatHistory 100개 상한, 각 필드 max 길이 제한)
- 메모리 기반 Rate Limiting — 타로/사주 10req/min, 신점 20req/min, 429 반환
- `parseJsonSafe()` ReDoS 방어 — greedy 정규식 → 괄호 카운터 기반 + 50K 길이 제한

## Changes
- `src/lib/auth/index.ts` — `assertSessionOwnership()` 추가
- `src/lib/validation/api-schemas.ts` — Zod 스키마 신규
- `src/lib/rate-limit.ts` — Rate limit 유틸 신규
- `src/lib/rate-limit.test.ts` — 6개 단위 테스트 신규
- `src/services/core/text-cleaner.ts` — ReDoS 수정
- `src/services/core/text-cleaner.test.ts` — 2개 테스트 추가
- `src/app/api/tarot/reading/route.ts`, `saju/reading/route.ts`, `shinjeom/message/route.ts` — 검증 적용

## Test plan
- [x] `pnpm type-check` — 통과
- [x] `pnpm lint` — 통과
- [x] `pnpm test:coverage` — 395개 테스트, 95.81% 커버리지
- [ ] CI E2E 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)