### PR TITLE
fix: SonarCloud Phase 3 코드 품질 — Props readonly + a11y + 중첩 삼항

### DIFF
--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -280,7 +280,8 @@ export default async function MyPage() {
                 ? overallText.slice(0, 80) + "..."
                 : overallText || null;
               const shareToken = reading?.share_token;
-              const serviceLabel = session.service_type === "saju" ? "사주" : session.service_type === "shinjeom" ? "신점" : "타로";
+              const serviceLabelMap: Record<string, string> = { saju: "사주", shinjeom: "신점", tarot: "타로" };
+              const serviceLabel = serviceLabelMap[session.service_type] ?? "타로";
               const resultPath = session.service_type === "saju"
                 ? `/saju/result/${shareToken}`
                 : session.service_type === "shinjeom"

--- a/src/app/tarot/session/page.tsx
+++ b/src/app/tarot/session/page.tsx
@@ -362,7 +362,8 @@ export default function TarotSessionPage() {
   }, [chatMessages, phase]);
 
   const spread = spreadType ? spreads[spreadType] : null;
-  const particleDensity = phase === "reading" ? "high" : phase === "result" ? "low" : "medium";
+  const particleDensityMap: Record<string, "low" | "medium" | "high"> = { reading: "high", result: "low" };
+  const particleDensity = particleDensityMap[phase] ?? "medium";
   const effectTheme = character?.effectTheme;
 
   return (

--- a/src/components/card/CardBack.tsx
+++ b/src/components/card/CardBack.tsx
@@ -5,11 +5,11 @@ import Image from "next/image";
 import { getCardBackUrl } from "@/lib/storage";
 
 interface CardBackProps {
-  size?: "sm" | "md" | "lg";
-  width?: number;
-  height?: number;
-  className?: string;
-  skinId?: string;
+  readonly size?: "sm" | "md" | "lg";
+  readonly width?: number;
+  readonly height?: number;
+  readonly className?: string;
+  readonly skinId?: string;
 }
 
 const sizeDimensions = {
@@ -28,9 +28,8 @@ export function CardBack({ size = "md", width, height, className = "", skinId }:
   const r1 = Math.min(w, h) * 0.3;
   const r2 = r1 * 0.65;
   const r3 = r1 * 0.35;
-  const starSize = size === "sm" ? 6 : size === "md" ? 8 : 10;
-  const cornerStarSize = size === "sm" ? 4 : size === "md" ? 5 : 6;
-  const inset = size === "sm" ? 4 : size === "md" ? 6 : 8;
+  const sizeDetails = { sm: { starSize: 6, cornerStarSize: 4, inset: 4 }, md: { starSize: 8, cornerStarSize: 5, inset: 6 }, lg: { starSize: 10, cornerStarSize: 6, inset: 8 } };
+  const { starSize, cornerStarSize, inset } = sizeDetails[size];
 
   if (skinId && !imageError) {
     return (

--- a/src/components/card/CardDeck.tsx
+++ b/src/components/card/CardDeck.tsx
@@ -7,10 +7,10 @@ import { CardItem } from "./CardItem";
 import { useSkinStore } from "@/hooks/useSkinStore";
 
 interface CardDeckProps {
-  cards: TarotCard[];
-  isSpread: boolean;
-  selectedIndices: number[];
-  onCardSelect: (index: number) => void;
+  readonly cards: TarotCard[];
+  readonly isSpread: boolean;
+  readonly selectedIndices: number[];
+  readonly onCardSelect: (index: number) => void;
 }
 
 export function CardDeck({ cards, isSpread, selectedIndices, onCardSelect }: CardDeckProps) {

--- a/src/components/card/CardFace.tsx
+++ b/src/components/card/CardFace.tsx
@@ -7,13 +7,13 @@ import { majorSymbols, suitSymbols } from "@/data/cards/symbols";
 import { getCardImageUrl } from "@/lib/storage";
 
 interface CardFaceProps {
-  card: TarotCard;
-  isReversed: boolean;
-  size?: "sm" | "md" | "lg";
-  width?: number;
-  height?: number;
-  className?: string;
-  skinId?: string;
+  readonly card: TarotCard;
+  readonly isReversed: boolean;
+  readonly size?: "sm" | "md" | "lg";
+  readonly width?: number;
+  readonly height?: number;
+  readonly className?: string;
+  readonly skinId?: string;
 }
 
 const sizeDimensions = {
@@ -31,8 +31,10 @@ export function CardFace({ card, isReversed, size = "md", width, height, classNa
     ? majorSymbols[card.id]
     : card.suit ? suitSymbols[card.suit] : null;
 
-  const fontSize = size === "sm" ? 6 : size === "md" ? 8 : 10;
-  const numberSize = size === "sm" ? 7 : size === "md" ? 10 : 12;
+  const fontSizeMap = { sm: 6, md: 8, lg: 10 };
+  const numberSizeMap = { sm: 7, md: 10, lg: 12 };
+  const fontSize = fontSizeMap[size];
+  const numberSize = numberSizeMap[size];
 
   const cx = w / 2;
   const cy = h * 0.42;

--- a/src/components/card/CardItem.tsx
+++ b/src/components/card/CardItem.tsx
@@ -6,17 +6,17 @@ import { CardFace } from "./CardFace";
 import { CardBack } from "./CardBack";
 
 interface CardItemProps {
-  card: TarotCard;
-  isFlipped: boolean;
-  isSelected: boolean;
-  isReversed?: boolean;
-  onClick?: () => void;
-  size?: "sm" | "md" | "lg";
-  width?: number;
-  height?: number;
-  className?: string;
-  skinId?: string;
-  glowColor?: string;
+  readonly card: TarotCard;
+  readonly isFlipped: boolean;
+  readonly isSelected: boolean;
+  readonly isReversed?: boolean;
+  readonly onClick?: () => void;
+  readonly size?: "sm" | "md" | "lg";
+  readonly width?: number;
+  readonly height?: number;
+  readonly className?: string;
+  readonly skinId?: string;
+  readonly glowColor?: string;
 }
 
 const sizeClasses = { sm: "w-10 h-[60px]", md: "w-24 h-36", lg: "w-32 h-48" };

--- a/src/components/card/CardSpread.tsx
+++ b/src/components/card/CardSpread.tsx
@@ -8,10 +8,10 @@ import { CardItem } from "./CardItem";
 import { useSkinStore } from "@/hooks/useSkinStore";
 
 interface CardSpreadProps {
-  selectedCards: SelectedCard[];
-  spread: SpreadDefinition;
-  revealedPositions: number[];
-  glowColor?: string;
+  readonly selectedCards: SelectedCard[];
+  readonly spread: SpreadDefinition;
+  readonly revealedPositions: number[];
+  readonly glowColor?: string;
 }
 
 function hexToRgbBase(hex: string): string {

--- a/src/components/character/CharacterCard.tsx
+++ b/src/components/character/CharacterCard.tsx
@@ -5,10 +5,10 @@ import { motion } from "framer-motion";
 import { CharacterConfig } from "@/types/character";
 
 interface CharacterCardProps {
-  character: CharacterConfig;
-  isSelected: boolean;
-  onClick: () => void;
-  index: number;
+  readonly character: CharacterConfig;
+  readonly isSelected: boolean;
+  readonly onClick: () => void;
+  readonly index: number;
 }
 
 export function CharacterCard({ character, isSelected, onClick, index }: CharacterCardProps) {

--- a/src/components/character/CharacterDisplay.tsx
+++ b/src/components/character/CharacterDisplay.tsx
@@ -6,9 +6,9 @@ import { SpriteAnimator } from "./SpriteAnimator";
 import { useCharacterStore } from "@/hooks/useCharacter";
 
 interface CharacterDisplayProps {
-  character: CharacterConfig;
-  mood: Mood;
-  className?: string;
+  readonly character: CharacterConfig;
+  readonly mood: Mood;
+  readonly className?: string;
 }
 
 export function CharacterDisplay({ character, mood, className = "" }: CharacterDisplayProps) {

--- a/src/components/character/SpriteAnimator.tsx
+++ b/src/components/character/SpriteAnimator.tsx
@@ -52,10 +52,10 @@ const ENTER_MOTION: Record<string, Record<string, number[]>> = {
 };
 
 interface SpriteAnimatorProps {
-  characterId: string;
-  mood: Mood;
-  onAnimationEnd?: () => void;
-  className?: string;
+  readonly characterId: string;
+  readonly mood: Mood;
+  readonly onAnimationEnd?: () => void;
+  readonly className?: string;
 }
 
 export function SpriteAnimator({ characterId, mood, onAnimationEnd, className = "" }: SpriteAnimatorProps) {

--- a/src/components/character/TypingDialogue.tsx
+++ b/src/components/character/TypingDialogue.tsx
@@ -4,8 +4,8 @@ import { useState, useEffect, useRef } from "react";
 import { motion } from "framer-motion";
 
 interface TypingDialogueProps {
-  text: string; speed?: number; onComplete?: () => void;
-  className?: string; isStreaming?: boolean;
+  readonly text: string; speed?: number; onComplete?: () => void;
+  readonly className?: string; isStreaming?: boolean;
 }
 
 export function TypingDialogue({ text, speed = 30, onComplete, className = "", isStreaming = false }: TypingDialogueProps) {

--- a/src/components/chat/ChatBubble.tsx
+++ b/src/components/chat/ChatBubble.tsx
@@ -3,7 +3,7 @@
 import { motion } from "framer-motion";
 import { ChatMessage } from "@/types/session";
 
-interface ChatBubbleProps { message: ChatMessage; }
+interface ChatBubbleProps { readonly message: ChatMessage; }
 
 export function ChatBubble({ message }: ChatBubbleProps) {
   const isCharacter = message.role === "character";

--- a/src/components/chat/DialogueBox.tsx
+++ b/src/components/chat/DialogueBox.tsx
@@ -5,10 +5,10 @@ import { motion, AnimatePresence } from "framer-motion";
 import { ChatMessage } from "@/types/session";
 
 interface DialogueBoxProps {
-  messages: ChatMessage[];
-  characterName?: string;
-  isTyping?: boolean;
-  className?: string;
+  readonly messages: ChatMessage[];
+  readonly characterName?: string;
+  readonly isTyping?: boolean;
+  readonly className?: string;
 }
 
 export function DialogueBox({ messages, characterName = "아르카나", isTyping = false, className = "" }: DialogueBoxProps) {

--- a/src/components/common/Icon.tsx
+++ b/src/components/common/Icon.tsx
@@ -68,9 +68,9 @@ const iconMap: Record<string, string> = {
 };
 
 interface IconProps {
-  id: string;
-  size?: number;
-  className?: string;
+  readonly id: string;
+  readonly size?: number;
+  readonly className?: string;
 }
 
 export function Icon({ id, size = 24, className }: IconProps) {

--- a/src/components/common/PrivacyConsentModal.tsx
+++ b/src/components/common/PrivacyConsentModal.tsx
@@ -4,9 +4,9 @@ import Link from "next/link";
 import { motion, AnimatePresence } from "framer-motion";
 
 interface PrivacyConsentModalProps {
-  isOpen: boolean;
-  onAgree: () => void;
-  onCancel: () => void;
+  readonly isOpen: boolean;
+  readonly onAgree: () => void;
+  readonly onCancel: () => void;
 }
 
 export function PrivacyConsentModal({ isOpen, onAgree, onCancel }: PrivacyConsentModalProps) {

--- a/src/components/common/ReadingText.tsx
+++ b/src/components/common/ReadingText.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 interface ReadingTextProps {
-  text: string;
-  className?: string;
+  readonly text: string;
+  readonly className?: string;
 }
 
 /** AI 리딩 텍스트를 단락별로 분리하여 렌더링 */

--- a/src/components/common/UserInfoForm.tsx
+++ b/src/components/common/UserInfoForm.tsx
@@ -11,10 +11,10 @@ const STORAGE_KEY = "arcana_user_info";
 const CONSENT_KEY = "arcana_privacy_agreed";
 
 interface UserInfoFormProps {
-  mode: "tarot" | "saju";
-  onSubmit: (data: UserInfo) => void;
-  onBack: () => void;
-  characterName?: string;
+  readonly mode: "tarot" | "saju";
+  readonly onSubmit: (data: UserInfo) => void;
+  readonly onBack: () => void;
+  readonly characterName?: string;
 }
 
 /** localStorage에 저장된 정보 로드 (동의한 경우만) */
@@ -203,10 +203,11 @@ export function UserInfoForm({ mode, onSubmit, onBack, characterName }: UserInfo
 
       {/* 이름 */}
       <div>
-        <label className="text-arcana-muted text-xs font-serif mb-1.5 block">
+        <label htmlFor="userinfo-name" className="text-arcana-muted text-xs font-serif mb-1.5 block">
           이름 {mode === "tarot" ? "*" : "(선택)"}
         </label>
         <input
+          id="userinfo-name"
           type="text"
           value={name}
           onChange={(e) => setName(e.target.value)}
@@ -217,8 +218,9 @@ export function UserInfoForm({ mode, onSubmit, onBack, characterName }: UserInfo
 
       {/* 생년월일 — 단일 date input */}
       <div>
-        <label className="text-arcana-muted text-xs font-serif mb-1.5 block">생년월일 *</label>
+        <label htmlFor="userinfo-birthdate" className="text-arcana-muted text-xs font-serif mb-1.5 block">생년월일 *</label>
         <input
+          id="userinfo-birthdate"
           type="date"
           value={birthDate}
           onChange={(e) => setBirthDate(e.target.value)}
@@ -251,11 +253,12 @@ export function UserInfoForm({ mode, onSubmit, onBack, characterName }: UserInfo
 
       {/* 태어난 시 */}
       <div>
-        <label className="text-arcana-muted text-xs font-serif mb-1.5 block">
+        <label htmlFor="userinfo-birthhour" className="text-arcana-muted text-xs font-serif mb-1.5 block">
           태어난 시 {mode === "saju" ? "*" : "(선택)"}
         </label>
         <div className="relative">
         <select
+          id="userinfo-birthhour"
           value={birthHour}
           onChange={(e) => setBirthHour(e.target.value)}
           className={`${inputClasses} appearance-none pr-8`}

--- a/src/components/effects/ParticleOverlay.tsx
+++ b/src/components/effects/ParticleOverlay.tsx
@@ -10,10 +10,10 @@ interface ColorScheme {
 }
 
 interface ParticleOverlayProps {
-  density?: "low" | "medium" | "high";
-  colorScheme?: ColorScheme;
-  particleStyle?: ParticleStyle;
-  className?: string;
+  readonly density?: "low" | "medium" | "high";
+  readonly colorScheme?: ColorScheme;
+  readonly particleStyle?: ParticleStyle;
+  readonly className?: string;
 }
 
 interface Particle {

--- a/src/components/effects/ScrollReveal.tsx
+++ b/src/components/effects/ScrollReveal.tsx
@@ -4,21 +4,23 @@ import { useRef } from "react";
 import { motion, useInView } from "framer-motion";
 
 interface ScrollRevealProps {
-  children: React.ReactNode;
-  delay?: number;
-  direction?: "up" | "left" | "right" | "none";
-  className?: string;
+  readonly children: React.ReactNode;
+  readonly delay?: number;
+  readonly direction?: "up" | "left" | "right" | "none";
+  readonly className?: string;
 }
 
 export function ScrollReveal({ children, delay = 0, direction = "up", className = "" }: ScrollRevealProps) {
   const ref = useRef(null);
   const isInView = useInView(ref, { once: true, margin: "-80px" });
 
+  const xOffsetMap: Record<string, number> = { left: -30, right: 30 };
+  const xOffset = xOffsetMap[direction] ?? 0;
   const variants = {
     hidden: {
       opacity: 0,
       y: direction === "up" ? 30 : 0,
-      x: direction === "left" ? -30 : direction === "right" ? 30 : 0,
+      x: xOffset,
     },
     visible: {
       opacity: 1,

--- a/src/components/saju/DaeunTimeline.tsx
+++ b/src/components/saju/DaeunTimeline.tsx
@@ -4,9 +4,9 @@ import { OHAENG } from "@/data/saju/constants";
 import type { SajuResult } from "@/services/saju/saju-types";
 
 interface DaeunTimelineProps {
-  majorFortunes: SajuResult["majorFortunes"];
-  yearlyFortune: SajuResult["yearlyFortune"];
-  birthYear: number;
+  readonly majorFortunes: SajuResult["majorFortunes"];
+  readonly yearlyFortune: SajuResult["yearlyFortune"];
+  readonly birthYear: number;
 }
 
 export function DaeunTimeline({ majorFortunes, yearlyFortune, birthYear }: DaeunTimelineProps) {

--- a/src/components/saju/OhaengGraph.tsx
+++ b/src/components/saju/OhaengGraph.tsx
@@ -4,8 +4,8 @@ import { OHAENG } from "@/data/saju/constants";
 import type { OhaengType } from "@/data/saju/constants";
 
 interface OhaengGraphProps {
-  elements: Record<OhaengType, number>;
-  yongsinElement: OhaengType;
+  readonly elements: Record<OhaengType, number>;
+  readonly yongsinElement: OhaengType;
 }
 
 export function OhaengGraph({ elements, yongsinElement }: OhaengGraphProps) {

--- a/src/components/saju/SajuChart.tsx
+++ b/src/components/saju/SajuChart.tsx
@@ -5,11 +5,11 @@ import type { SajuResult } from "@/services/saju/saju-types";
 import type { OhaengType } from "@/data/saju/constants";
 
 interface SajuChartProps {
-  pillars: SajuResult["pillars"];
-  dayMaster: string;
-  dayMasterElement: OhaengType;
-  isStrong: boolean;
-  yongsin: SajuResult["yongsin"];
+  readonly pillars: SajuResult["pillars"];
+  readonly dayMaster: string;
+  readonly dayMasterElement: OhaengType;
+  readonly isStrong: boolean;
+  readonly yongsin: SajuResult["yongsin"];
 }
 
 export function SajuChart({ pillars, dayMaster, dayMasterElement, isStrong, yongsin }: SajuChartProps) {

--- a/src/components/skin/SkinSelector.tsx
+++ b/src/components/skin/SkinSelector.tsx
@@ -7,9 +7,9 @@ import type { CardSkin } from "@/data/skins";
 import { getCardThumbnailUrl } from "@/lib/storage";
 
 interface SkinSelectorProps {
-  skin: CardSkin;
-  isSelected: boolean;
-  onSelect: (skinId: string) => void;
+  readonly skin: CardSkin;
+  readonly isSelected: boolean;
+  readonly onSelect: (skinId: string) => void;
 }
 
 // 카드 팬 배치: 3장 회전 오프셋


### PR DESCRIPTION
## Summary
- Props interface 전체 필드에 `readonly` 추가 — 21개 컴포넌트 (S6759)
- UserInfoForm `<label htmlFor>` / `<input id>` 연결 3개 (S6853)
- 중첩 삼항 연산자 룩업 테이블·변수 추출로 대체 (S3358): CardBack, CardFace, ScrollReveal, mypage, tarot session

## Changes
- `src/components/` 21개 파일 — Props readonly
- `src/components/common/UserInfoForm.tsx` — htmlFor/id 연결
- `src/components/card/CardBack.tsx`, `CardFace.tsx` — sizeDetails/fontSizeMap 룩업
- `src/components/effects/ScrollReveal.tsx` — xOffsetMap 룩업
- `src/app/mypage/page.tsx` — serviceLabelMap 룩업
- `src/app/tarot/session/page.tsx` — particleDensityMap 룩업

## Test plan
- [x] `pnpm type-check` — 통과
- [x] `pnpm lint` — 통과
- [x] `pnpm test:coverage` — 380개 테스트, 95.78% 커버리지
- [ ] CI E2E 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)