### PR TITLE
fix: import "server-only" 제거 — 타로 리딩 API 핫픽스

### DIFF
--- a/src/lib/verum/resolver.ts
+++ b/src/lib/verum/resolver.ts
@@ -1,4 +1,3 @@
-import "server-only";
 import { VerumClient } from "./client";
 import { getVerumDeploymentId, getVerumApiUrl, getVerumApiKey, getGrokModel } from "@/lib/env";
 


### PR DESCRIPTION
## 원인

`src/lib/verum/resolver.ts` 상단의 `import "server-only"`가 Railway 프로덕션 환경에서 타로 리딩 API 모듈 초기화 실패를 유발.

- 타로 라우트만 `@/lib/verum`에서 `resolveSystemPrompt`를 임포트 → resolver.ts 로드 시도
- 사주·신점 라우트는 resolver.ts를 임포트하지 않아 정상 동작 → 타로만 깨진 이유
- Next.js App Router API 라우트는 본질적으로 server-only 컨텍스트이므로 이 가드 불필요

## 변경 내용

- `src/lib/verum/resolver.ts`에서 `import "server-only"` 1줄 제거

## 검증

- `pnpm type-check` ✅
- `pnpm lint` ✅