### PR TITLE
fix: 타로 리딩 400 오류 핫픽스 — Zod nullish + resolver server-only 제거

### DIFF
--- a/src/app/api/shinjeom/message/route.ts
+++ b/src/app/api/shinjeom/message/route.ts
@@ -79,7 +79,7 @@ export async function POST(request: NextRequest) {
       if (ownerErr) return ownerErr;
     }
 
-    const systemPrompt = shinjeomService.getSystemPrompt(characterId);
+    const systemPrompt = shinjeomService.getSystemPrompt(characterId ?? undefined);
     const userPrompt = shinjeomService.buildConversationPrompt(topic, currentMessage, chatHistory, isFinalTurn);
 
     const encoder = new TextEncoder();

--- a/src/lib/validation/api-schemas.ts
+++ b/src/lib/validation/api-schemas.ts
@@ -2,19 +2,19 @@ import { z } from "zod";
 
 const uuidOrNull = z.string().max(36).nullish();
 const topicStr = z.string().max(60);
-const charIdStr = z.string().max(50).optional();
+const charIdStr = z.string().max(50).nullish();
 
 export const TarotReadingSchema = z.object({
   sessionId: uuidOrNull,
   topic: topicStr,
-  spreadType: z.enum(["one-card", "three-card", "five-card", "seven-card", "ten-card", "relationship", "horseshoe", "decision", "weekly", "zodiac", "tree-of-life"]).optional(),
+  spreadType: z.enum(["one-card", "three-card", "five-card", "seven-card", "ten-card", "relationship", "horseshoe", "decision", "weekly", "zodiac", "tree-of-life"]).nullish(),
   characterId: charIdStr,
   userInfo: z.object({
     name: z.string().max(50),
     birthDate: z.string().max(20),
     gender: z.string().max(10),
     birthHour: z.string().max(20),
-  }).optional(),
+  }).nullish(),
   cards: z.array(z.object({
     cardId: z.string().max(50),
     position: z.number().int().min(0).max(21),

--- a/src/lib/verum/resolver.ts
+++ b/src/lib/verum/resolver.ts
@@ -1,4 +1,3 @@
-import "server-only";
 import { VerumClient } from "./client";
 import { getVerumDeploymentId, getVerumApiUrl, getVerumApiKey, getGrokModel } from "@/lib/env";
 


### PR DESCRIPTION
## Summary

- **`src/lib/validation/api-schemas.ts`**: `charIdStr`, `spreadType`, `userInfo` 필드를 `.optional()` → `.nullish()`로 변경
  - `useSessionStore` 초기값이 `null`이고 `JSON.stringify` 는 null을 그대로 직렬화하는데, Zod `.optional()`은 `undefined`만 허용하고 `null`은 거부 → safeParse 실패 → 400 "Invalid request"
  - `.nullish()`는 `null | undefined` 모두 허용
- **`src/app/api/shinjeom/message/route.ts`**: `characterId ?? undefined` 변환 추가 (getSystemPrompt 파라미터 타입 대응)
- **`src/lib/verum/resolver.ts`**: `import "server-only"` 제거 (Next.js 클라이언트 번들 안전장치였으나 Node route에서 불필요한 충돌 유발 가능)

## Root Cause

타로만 리딩이 안되고 사주/신점은 정상 작동하던 이유:
- 타로 스키마만 `spreadType` (enum `.optional()`) 필드가 있고, Zustand store의 `spreadType: null` 이 `{"spreadType":null}`로 직렬화되어 전달됨
- 사주/신점 스키마는 `spreadType` 없고 다른 optional 필드도 store에서 null이 되는 경우가 달랐음

## Test plan

- [x] `pnpm type-check` 통과
- [x] `pnpm test:coverage` — 433개 테스트 전부 통과
- [ ] 프로덕션 배포 후 타로 리딩 정상 작동 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)