### PR TITLE
fix: React error #418 hydration mismatch 수정 — ParticleOverlay/DailyCard

### DIFF
--- a/src/components/effects/ParticleOverlay.tsx
+++ b/src/components/effects/ParticleOverlay.tsx
@@ -126,9 +126,7 @@ export function ParticleOverlay({ density = "medium", colorScheme, particleStyle
   const secondaryColor = colorScheme?.secondary;
   const accentColor = colorScheme?.accent;
 
-  const [particles, setParticles] = useState<Particle[]>(() =>
-    generateParticles(DENSITY_COUNT[density], buildColors(colorScheme))
-  );
+  const [particles, setParticles] = useState<Particle[]>([]);
 
   useEffect(() => {
     setParticles(generateParticles(DENSITY_COUNT[density], buildColors(colorScheme)));

--- a/src/components/home/DailyCard.tsx
+++ b/src/components/home/DailyCard.tsx
@@ -26,8 +26,14 @@ export function DailyCard() {
   const [data, setData] = useState<Record<string, DailyCardData>>({});
   const [loading, setLoading] = useState<string | null>(null);
   const [flipped, setFlipped] = useState<Record<string, boolean>>({});
+  const [todayLabel, setTodayLabel] = useState("");
 
   const today = new Date().toISOString().split("T")[0];
+
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setTodayLabel(new Date().toLocaleDateString("ko-KR", { year: "numeric", month: "long", day: "numeric", weekday: "long" }));
+  }, []);
 
   const fetchDailyCard = useCallback(async (characterId: string) => {
     if (data[characterId]) return;
@@ -75,7 +81,7 @@ export function DailyCard() {
       <div className="max-w-4xl mx-auto">
         <ScrollReveal className="text-center mb-8">
           <h2 className="text-xl md:text-2xl font-display font-bold mb-2">오늘의 카드</h2>
-          <p className="text-arcana-muted text-sm">{new Date().toLocaleDateString("ko-KR", { year: "numeric", month: "long", day: "numeric", weekday: "long" })}</p>
+          <p className="text-arcana-muted text-sm" suppressHydrationWarning>{todayLabel}</p>
         </ScrollReveal>
 
         {/* 캐릭터 탭 */}


### PR DESCRIPTION
## Summary

- **`ParticleOverlay.tsx`**: `useState` lazy initializer에서 `Math.random()` 직접 호출 → 서버/클라이언트 random 값이 달라 hydration mismatch 발생. 초기값을 `[]`으로 변경하고 `useEffect`에서만 파티클 생성
- **`DailyCard.tsx`**: JSX에서 `new Date().toLocaleDateString("ko-KR", ...)` 인라인 렌더 → 서버(UTC)/클라이언트(KST) 시간대 차이로 날짜 문자열 불일치. `todayLabel` state + `useEffect`로 클라이언트에서만 날짜 설정, `suppressHydrationWarning` 추가

## Root Cause

React error #418 (Minified React error #418) = hydration mismatch.  
메인 페이지 진입 시 콘솔에 출력되던 에러의 원인 2가지:

1. `ParticleOverlay`: 서버 렌더 시 lazy initializer 실행 → random 좌표/크기 생성 → 클라이언트 hydration 시 다른 random 값으로 DOM 불일치
2. `DailyCard`: `new Date()`가 서버(UTC)와 브라우저(KST, UTC+9)에서 다른 날짜 문자열 반환

## Test plan

- [x] `pnpm type-check` 통과
- [x] `pnpm lint` 통과
- [ ] 프로덕션 배포 후 메인 페이지에서 React error #418 미발생 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)