### PR TITLE
fix: SonarCloud org slug + 뱃지 URL 수정 (PR #119 squash merge 누락분)

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -16,11 +16,11 @@
   <img src="https://img.shields.io/badge/%F0%9F%A4%96%20AI-xAI%20Grok%20%2B%20Claude-FF6B35?style=for-the-badge&labelColor=1a1a2e" alt="AI" />
 </p>
 <p align="center">
-  <a href="https://sonarcloud.io/summary/new_code?id=xzawed31_ArcanaInsight"><img src="https://sonarcloud.io/api/project_badges/measure?project=xzawed31_ArcanaInsight&metric=alert_status" alt="Quality Gate" /></a>
-  <a href="https://sonarcloud.io/summary/new_code?id=xzawed31_ArcanaInsight"><img src="https://sonarcloud.io/api/project_badges/measure?project=xzawed31_ArcanaInsight&metric=coverage" alt="Coverage" /></a>
-  <a href="https://sonarcloud.io/summary/new_code?id=xzawed31_ArcanaInsight"><img src="https://sonarcloud.io/api/project_badges/measure?project=xzawed31_ArcanaInsight&metric=bugs" alt="Bugs" /></a>
-  <a href="https://sonarcloud.io/summary/new_code?id=xzawed31_ArcanaInsight"><img src="https://sonarcloud.io/api/project_badges/measure?project=xzawed31_ArcanaInsight&metric=security_rating" alt="Security Rating" /></a>
-  <a href="https://codecov.io/gh/xzawed31/ArcanaInsight"><img src="https://codecov.io/gh/xzawed31/ArcanaInsight/branch/main/graph/badge.svg" alt="Codecov" /></a>
+  <a href="https://sonarcloud.io/summary/new_code?id=xzawed_ArcanaInsight"><img src="https://sonarcloud.io/api/project_badges/measure?project=xzawed_ArcanaInsight&metric=alert_status" alt="Quality Gate" /></a>
+  <a href="https://sonarcloud.io/summary/new_code?id=xzawed_ArcanaInsight"><img src="https://sonarcloud.io/api/project_badges/measure?project=xzawed_ArcanaInsight&metric=coverage" alt="Coverage" /></a>
+  <a href="https://sonarcloud.io/summary/new_code?id=xzawed_ArcanaInsight"><img src="https://sonarcloud.io/api/project_badges/measure?project=xzawed_ArcanaInsight&metric=bugs" alt="Bugs" /></a>
+  <a href="https://sonarcloud.io/summary/new_code?id=xzawed_ArcanaInsight"><img src="https://sonarcloud.io/api/project_badges/measure?project=xzawed_ArcanaInsight&metric=security_rating" alt="Security Rating" /></a>
+  <a href="https://codecov.io/gh/xzawed/ArcanaInsight"><img src="https://codecov.io/gh/xzawed/ArcanaInsight/branch/main/graph/badge.svg" alt="Codecov" /></a>
 </p>
 
 <p align="center">
@@ -140,7 +140,7 @@ ArcanaInsight is a web application where users have natural conversations with *
 
 ```bash
 # 1. Clone
-git clone https://github.com/xzawed31/ArcanaInsight.git
+git clone https://github.com/xzawed/ArcanaInsight.git
 cd ArcanaInsight
 
 # 2. Install dependencies (pnpm required)

--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@
   <img src="https://img.shields.io/badge/%F0%9F%A4%96%20AI-xAI%20Grok%20%2B%20Claude-FF6B35?style=for-the-badge&labelColor=1a1a2e" alt="AI" />
 </p>
 <p align="center">
-  <a href="https://sonarcloud.io/summary/new_code?id=xzawed31_ArcanaInsight"><img src="https://sonarcloud.io/api/project_badges/measure?project=xzawed31_ArcanaInsight&metric=alert_status" alt="Quality Gate" /></a>
-  <a href="https://sonarcloud.io/summary/new_code?id=xzawed31_ArcanaInsight"><img src="https://sonarcloud.io/api/project_badges/measure?project=xzawed31_ArcanaInsight&metric=coverage" alt="Coverage" /></a>
-  <a href="https://sonarcloud.io/summary/new_code?id=xzawed31_ArcanaInsight"><img src="https://sonarcloud.io/api/project_badges/measure?project=xzawed31_ArcanaInsight&metric=bugs" alt="Bugs" /></a>
-  <a href="https://sonarcloud.io/summary/new_code?id=xzawed31_ArcanaInsight"><img src="https://sonarcloud.io/api/project_badges/measure?project=xzawed31_ArcanaInsight&metric=security_rating" alt="Security Rating" /></a>
-  <a href="https://codecov.io/gh/xzawed31/ArcanaInsight"><img src="https://codecov.io/gh/xzawed31/ArcanaInsight/branch/main/graph/badge.svg" alt="Codecov" /></a>
+  <a href="https://sonarcloud.io/summary/new_code?id=xzawed_ArcanaInsight"><img src="https://sonarcloud.io/api/project_badges/measure?project=xzawed_ArcanaInsight&metric=alert_status" alt="Quality Gate" /></a>
+  <a href="https://sonarcloud.io/summary/new_code?id=xzawed_ArcanaInsight"><img src="https://sonarcloud.io/api/project_badges/measure?project=xzawed_ArcanaInsight&metric=coverage" alt="Coverage" /></a>
+  <a href="https://sonarcloud.io/summary/new_code?id=xzawed_ArcanaInsight"><img src="https://sonarcloud.io/api/project_badges/measure?project=xzawed_ArcanaInsight&metric=bugs" alt="Bugs" /></a>
+  <a href="https://sonarcloud.io/summary/new_code?id=xzawed_ArcanaInsight"><img src="https://sonarcloud.io/api/project_badges/measure?project=xzawed_ArcanaInsight&metric=security_rating" alt="Security Rating" /></a>
+  <a href="https://codecov.io/gh/xzawed/ArcanaInsight"><img src="https://codecov.io/gh/xzawed/ArcanaInsight/branch/main/graph/badge.svg" alt="Codecov" /></a>
 </p>
 
 <p align="center">
@@ -140,7 +140,7 @@ ArcanaInsight는 일본 애니메이션 스타일의 **12명 개성 캐릭터**�
 
 ```bash
 # 1. 클론
-git clone https://github.com/xzawed31/ArcanaInsight.git
+git clone https://github.com/xzawed/ArcanaInsight.git
 cd ArcanaInsight
 
 # 2. 의존성 설치 (pnpm 필수)

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -52,9 +52,6 @@ sonar.coverage.exclusions=\
   src/services/core/ai-provider.ts,\
   src/services/saju/saju-types.ts
 
-# 단위 테스트 실행 결과 (Vitest JUnit XML)
-sonar.testExecutionReportPaths=coverage/junit.xml
-
 sonar.sourceEncoding=UTF-8
 sonar.qualitygate.wait=false
 sonar.typescript.tsconfigPath=tsconfig.json

--- a/src/app/character/[id]/page.tsx
+++ b/src/app/character/[id]/page.tsx
@@ -60,6 +60,7 @@ export default function CharacterPage() {
             src={`/images/characters/${character.id}/nukki/idle.png`}
             alt={character.name}
             fill
+            sizes="(max-width: 768px) 100vw, 50vw"
             className="object-cover object-top"
           />
         </div>

--- a/src/app/saju/session/page.tsx
+++ b/src/app/saju/session/page.tsx
@@ -108,7 +108,7 @@ export default function SajuSessionPage() {
   };
 
   useEffect(() => {
-    // 결과 스트리밍 시 컨테이너 내부만 하단 스크롤 (윈도우 스크롤 방��)
+    // 결과 스트리밍 시 컨테이너 내부만 하단 스크롤 (윈도우 스크롤 방지)
     if (phase === "result") {
       const container = resultContainerRef.current;
       if (container) container.scrollTop = container.scrollHeight;

--- a/src/components/character/CharacterCard.tsx
+++ b/src/components/character/CharacterCard.tsx
@@ -31,6 +31,7 @@ export function CharacterCard({ character, isSelected, onClick, index }: Charact
           src={`/images/characters/${character.id}/nukki/idle.png`}
           alt={character.name}
           fill
+          sizes="(max-width: 768px) 33vw, (max-width: 1024px) 13vw, 9vw"
           className="object-cover object-top"
         />
         <div className="absolute top-0 left-0 right-0 h-1/4 bg-gradient-to-b from-arcana-card/60 to-transparent" />

--- a/src/components/common/Icon.tsx
+++ b/src/components/common/Icon.tsx
@@ -1,7 +1,7 @@
 import Image from "next/image";
 
 const iconMap: Record<string, string> = {
-  // 네비��이션
+  // 네비게이션
   "nav-home": "/images/icons/nav-home.png",
   "nav-tarot": "/images/icons/nav-tarot.png",
   "nav-saju": "/images/icons/nav-saju.png",

--- a/src/components/home/CharacterGallery.tsx
+++ b/src/components/home/CharacterGallery.tsx
@@ -38,6 +38,7 @@ export function CharacterGallery() {
                       src={`/images/characters/${char.id}/nukki/idle.png`}
                       alt={`${char.name} - ${char.personality}`}
                       fill
+                      sizes="(max-width: 640px) 50vw, (max-width: 768px) 33vw, (max-width: 1024px) 25vw, 17vw"
                       className="object-cover object-top"
                     />
                     <div className="absolute bottom-0 left-0 right-0 h-1/3 bg-gradient-to-t from-arcana-card to-transparent" />

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
   test: {
     environment: "node",
     globals: true,
-    reporters: ["default", ["junit", { outputFile: "./coverage/junit.xml" }]],
+    reporters: ["default"],
     setupFiles: ["./vitest.setup.ts"],
     include: ["src/**/*.test.ts", "src/**/*.spec.ts"],
     exclude: [


### PR DESCRIPTION
## Summary

PR #119가 squash merge되면서 이후 추가된 Sonar 수정 커밋 3개가 main에 포함되지 않아 후속 반영합니다.

- **`sonar-project.properties`**: `xzawed31` → `xzawed` (organization slug 수정), `sonar.testExecutionReportPaths` 제거 (JUnit 포맷 불일치 → EXECUTION FAILURE)
- **`vitest.config.ts`**: `junit` reporter 제거 (Sonar용이었으나 불필요)
- **`Icon.tsx`, `saju/session/page.tsx`**: 깨진 한글 문자 복원 (UTF-8 WARN 제거)
- **`README.md`, `README.en.md`**: SonarCloud/Codecov 뱃지 URL `xzawed31` → `xzawed` 수정

## Test plan

- [ ] CI 통과 후 README 뱃지가 "Project not found" 대신 실제 메트릭 표시 확인
- [ ] SonarCloud 스캔 `EXECUTION FAILURE` 없이 완료 확인

🤖 Generated with [Claude Code](https://claude.ai/claude-code)