### PR TITLE
test: PR B — 세션 라우트 단위 테스트 + mock helper 인프라 신설

### DIFF
--- a/src/__tests__/api/saju-session.test.ts
+++ b/src/__tests__/api/saju-session.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi } from "vitest";
+import { setupDoMock } from "@/test-helpers/reset-modules";
+import { makeMockDb } from "@/test-helpers/mock-db";
+import { makeAuthMock, MOCK_USER } from "@/test-helpers/mock-auth";
+import { makePostRequest } from "@/test-helpers/mock-request";
+
+setupDoMock();
+
+const MOCK_SESSION = { id: "saju-session-abc", service_type: "saju", topic: "saju-general", status: "in_progress" };
+
+async function setup(options: { user?: typeof MOCK_USER | null } = {}) {
+  const mockDb = makeMockDb();
+  mockDb.insert.mockResolvedValue(MOCK_SESSION);
+
+  const user = "user" in options ? options.user : MOCK_USER;
+  vi.doMock("@/lib/db", () => ({ getDb: vi.fn().mockReturnValue(mockDb) }));
+  vi.doMock("@/lib/auth", () => makeAuthMock(user));
+
+  const { POST } = await import("@/app/api/saju/session/route");
+  return { POST, mockDb };
+}
+
+describe("POST /api/saju/session", () => {
+  it("유효한 요청 → session 반환", async () => {
+    const { POST } = await setup();
+    const res = await POST(makePostRequest({ topic: "saju-general", characterId: null }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({ session: MOCK_SESSION });
+  });
+
+  it("topic 누락 → 400", async () => {
+    const { POST } = await setup();
+    const res = await POST(makePostRequest({ characterId: null }));
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toBe("Invalid request");
+  });
+
+  it("유효하지 않은 topic → 400", async () => {
+    const { POST } = await setup();
+    const res = await POST(makePostRequest({ topic: "invalid-topic", characterId: null }));
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toBe("Invalid topic");
+  });
+
+  it("타로 topic은 사주에서 거부 → 400", async () => {
+    const { POST } = await setup();
+    const res = await POST(makePostRequest({ topic: "finance", characterId: null }));
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toBe("Invalid topic");
+  });
+
+  it("유효하지 않은 characterId → character_id: null로 저장", async () => {
+    const { POST, mockDb } = await setup();
+    await POST(makePostRequest({ topic: "saju-love-single", characterId: "no-such-char" }));
+    expect(mockDb.insert).toHaveBeenCalledWith("sessions", expect.objectContaining({ character_id: null }));
+  });
+
+  it("유효한 characterId → character_id에 반영", async () => {
+    const { POST, mockDb } = await setup();
+    await POST(makePostRequest({ topic: "saju-career", characterId: "arcana" }));
+    expect(mockDb.insert).toHaveBeenCalledWith("sessions", expect.objectContaining({ character_id: "arcana" }));
+  });
+
+  it("비로그인 사용자 → user_id: null", async () => {
+    const { POST, mockDb } = await setup({ user: null });
+    await POST(makePostRequest({ topic: "saju-general" }));
+    expect(mockDb.insert).toHaveBeenCalledWith("sessions", expect.objectContaining({ user_id: null }));
+  });
+
+  it("로그인 사용자 → user_id에 userId 반영", async () => {
+    const { POST, mockDb } = await setup({ user: MOCK_USER });
+    await POST(makePostRequest({ topic: "saju-general" }));
+    expect(mockDb.insert).toHaveBeenCalledWith("sessions", expect.objectContaining({ user_id: MOCK_USER.id }));
+  });
+
+  it("service_type이 saju로 설정, spread_type은 null", async () => {
+    const { POST, mockDb } = await setup();
+    await POST(makePostRequest({ topic: "saju-health" }));
+    expect(mockDb.insert).toHaveBeenCalledWith("sessions", expect.objectContaining({ service_type: "saju", spread_type: null }));
+  });
+
+  it("DB insert 실패 → 500", async () => {
+    const { POST, mockDb } = await setup();
+    mockDb.insert.mockRejectedValue(new Error("DB error"));
+    const res = await POST(makePostRequest({ topic: "saju-general" }));
+    expect(res.status).toBe(500);
+  });
+
+  it("saju-auspicious-date topic → 200 정상 처리", async () => {
+    const { POST } = await setup();
+    const res = await POST(makePostRequest({ topic: "saju-auspicious-date" }));
+    expect(res.status).toBe(200);
+  });
+});

--- a/src/__tests__/api/shinjeom-session.test.ts
+++ b/src/__tests__/api/shinjeom-session.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi } from "vitest";
+import { setupDoMock } from "@/test-helpers/reset-modules";
+import { makeMockDb } from "@/test-helpers/mock-db";
+import { makeAuthMock, MOCK_USER } from "@/test-helpers/mock-auth";
+import { makePostRequest } from "@/test-helpers/mock-request";
+
+setupDoMock();
+
+const MOCK_SESSION = { id: "shinjeom-session-abc", service_type: "shinjeom", topic: "shinjeom-general", status: "in_progress" };
+
+async function setup(options: { user?: typeof MOCK_USER | null } = {}) {
+  const mockDb = makeMockDb();
+  mockDb.insert.mockResolvedValue(MOCK_SESSION);
+
+  const user = "user" in options ? options.user : MOCK_USER;
+  vi.doMock("@/lib/db", () => ({ getDb: vi.fn().mockReturnValue(mockDb) }));
+  vi.doMock("@/lib/auth", () => makeAuthMock(user));
+
+  const { POST } = await import("@/app/api/shinjeom/session/route");
+  return { POST, mockDb };
+}
+
+describe("POST /api/shinjeom/session", () => {
+  it("유효한 요청 → session 반환", async () => {
+    const { POST } = await setup();
+    const res = await POST(makePostRequest({ topic: "shinjeom-general", characterId: "arcana" }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({ session: MOCK_SESSION });
+  });
+
+  it("topic 누락 → 400", async () => {
+    const { POST } = await setup();
+    const res = await POST(makePostRequest({ characterId: "arcana" }));
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toBe("Invalid request");
+  });
+
+  it("characterId 누락 → 400 (신점은 characterId 필수)", async () => {
+    const { POST } = await setup();
+    const res = await POST(makePostRequest({ topic: "shinjeom-general" }));
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toBe("Invalid request");
+  });
+
+  it("DB insert 실패해도 200 반환 (신점은 세션 없이 계속 진행)", async () => {
+    const { POST, mockDb } = await setup();
+    mockDb.insert.mockRejectedValue(new Error("DB unavailable"));
+    const res = await POST(makePostRequest({ topic: "shinjeom-love", characterId: "arcana" }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({ session: null });
+  });
+
+  it("getCurrentUser 실패해도 200 반환 (신점은 세션 없이 계속)", async () => {
+    const mockDb = makeMockDb();
+    vi.doMock("@/lib/db", () => ({ getDb: vi.fn().mockReturnValue(mockDb) }));
+    vi.doMock("@/lib/auth", () => ({
+      getCurrentUser: vi.fn().mockRejectedValue(new Error("Auth service down")),
+    }));
+    const { POST } = await import("@/app/api/shinjeom/session/route");
+    const res = await POST(makePostRequest({ topic: "shinjeom-health", characterId: "luna" }));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ session: null });
+  });
+
+  it("비로그인 사용자 → user_id: null로 저장", async () => {
+    const { POST, mockDb } = await setup({ user: null });
+    await POST(makePostRequest({ topic: "shinjeom-general", characterId: "arcana" }));
+    expect(mockDb.insert).toHaveBeenCalledWith("sessions", expect.objectContaining({ user_id: null }));
+  });
+
+  it("로그인 사용자 → user_id에 userId 반영", async () => {
+    const { POST, mockDb } = await setup({ user: MOCK_USER });
+    await POST(makePostRequest({ topic: "shinjeom-general", characterId: "arcana" }));
+    expect(mockDb.insert).toHaveBeenCalledWith("sessions", expect.objectContaining({ user_id: MOCK_USER.id }));
+  });
+
+  it("service_type이 shinjeom으로 설정", async () => {
+    const { POST, mockDb } = await setup();
+    await POST(makePostRequest({ topic: "shinjeom-wealth", characterId: "miko" }));
+    expect(mockDb.insert).toHaveBeenCalledWith("sessions", expect.objectContaining({ service_type: "shinjeom" }));
+  });
+
+  it("topic이 insert에 전달됨", async () => {
+    const { POST, mockDb } = await setup();
+    await POST(makePostRequest({ topic: "shinjeom-career", characterId: "rei" }));
+    expect(mockDb.insert).toHaveBeenCalledWith("sessions", expect.objectContaining({ topic: "shinjeom-career" }));
+  });
+
+  it("shinjeom-auspicious topic → 200 정상 처리", async () => {
+    const { POST } = await setup();
+    const res = await POST(makePostRequest({ topic: "shinjeom-auspicious", characterId: "hoshi" }));
+    expect(res.status).toBe(200);
+    expect((await res.json()).session).toEqual(MOCK_SESSION);
+  });
+
+  it("request.json() 실패 시 500 반환 (outer catch)", async () => {
+    const { POST } = await setup();
+    const badRequest = new (await import("next/server")).NextRequest("http://localhost/api/test", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "invalid { json {{",
+    });
+    const res = await POST(badRequest);
+    expect(res.status).toBe(500);
+    expect((await res.json()).error).toBe("Internal server error");
+  });
+});

--- a/src/__tests__/api/tarot-session.test.ts
+++ b/src/__tests__/api/tarot-session.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi } from "vitest";
+import { setupDoMock } from "@/test-helpers/reset-modules";
+import { makeMockDb } from "@/test-helpers/mock-db";
+import { makeAuthMock, MOCK_USER } from "@/test-helpers/mock-auth";
+import { makePostRequest } from "@/test-helpers/mock-request";
+
+setupDoMock();
+
+const MOCK_SESSION = { id: "session-abc", service_type: "tarot", topic: "love", status: "in_progress" };
+
+async function setup(options: { user?: typeof MOCK_USER | null } = {}) {
+  const mockDb = makeMockDb();
+  mockDb.insert.mockResolvedValue(MOCK_SESSION);
+
+  const user = "user" in options ? options.user : MOCK_USER;
+  vi.doMock("@/lib/db", () => ({ getDb: vi.fn().mockReturnValue(mockDb) }));
+  vi.doMock("@/lib/auth", () => makeAuthMock(user));
+
+  const { POST } = await import("@/app/api/tarot/session/route");
+  return { POST, mockDb };
+}
+
+describe("POST /api/tarot/session", () => {
+  it("유효한 요청 → session 반환", async () => {
+    const { POST } = await setup();
+    const res = await POST(makePostRequest({ topic: "love", characterId: null }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({ session: MOCK_SESSION });
+  });
+
+  it("topic 누락 → 400", async () => {
+    const { POST } = await setup();
+    const res = await POST(makePostRequest({ characterId: null }));
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toBe("Invalid request");
+  });
+
+  it("유효하지 않은 topic → 400", async () => {
+    const { POST } = await setup();
+    const res = await POST(makePostRequest({ topic: "invalid-topic", characterId: null }));
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toBe("Invalid topic");
+  });
+
+  it("유효하지 않은 characterId → character_id: null로 저장", async () => {
+    const { POST, mockDb } = await setup();
+    await POST(makePostRequest({ topic: "love", characterId: "nonexistent-char" }));
+    expect(mockDb.insert).toHaveBeenCalledWith("sessions", expect.objectContaining({ character_id: null }));
+  });
+
+  it("유효한 characterId → character_id에 반영", async () => {
+    const { POST, mockDb } = await setup();
+    await POST(makePostRequest({ topic: "love", characterId: "arcana" }));
+    expect(mockDb.insert).toHaveBeenCalledWith("sessions", expect.objectContaining({ character_id: "arcana" }));
+  });
+
+  it("spreadType one-card → 그대로 사용", async () => {
+    const { POST, mockDb } = await setup();
+    await POST(makePostRequest({ topic: "love", spreadType: "one-card" }));
+    expect(mockDb.insert).toHaveBeenCalledWith("sessions", expect.objectContaining({ spread_type: "one-card" }));
+  });
+
+  it("spreadType three-card → 그대로 사용", async () => {
+    const { POST, mockDb } = await setup();
+    await POST(makePostRequest({ topic: "love", spreadType: "three-card" }));
+    expect(mockDb.insert).toHaveBeenCalledWith("sessions", expect.objectContaining({ spread_type: "three-card" }));
+  });
+
+  it("spreadType이 유효 3개 외 값이면 서비스 기본값 사용 (zodiac 등)", async () => {
+    const { POST, mockDb } = await setup();
+    await POST(makePostRequest({ topic: "love", spreadType: "zodiac" }));
+    const callArg = mockDb.insert.mock.calls[0][1] as Record<string, unknown>;
+    expect(callArg.spread_type).not.toBe("zodiac");
+    expect(callArg.spread_type).toBeTruthy();
+  });
+
+  it("spreadType 미지정 → sessionData.spreadType 사용", async () => {
+    const { POST, mockDb } = await setup();
+    await POST(makePostRequest({ topic: "love" }));
+    const callArg = mockDb.insert.mock.calls[0][1] as Record<string, unknown>;
+    expect(callArg.spread_type).toBeTruthy();
+  });
+
+  it("비로그인 사용자 → user_id: null", async () => {
+    const { POST, mockDb } = await setup({ user: null });
+    await POST(makePostRequest({ topic: "love" }));
+    expect(mockDb.insert).toHaveBeenCalledWith("sessions", expect.objectContaining({ user_id: null }));
+  });
+
+  it("로그인 사용자 → user_id에 userId 반영", async () => {
+    const { POST, mockDb } = await setup({ user: MOCK_USER });
+    await POST(makePostRequest({ topic: "love" }));
+    expect(mockDb.insert).toHaveBeenCalledWith("sessions", expect.objectContaining({ user_id: MOCK_USER.id }));
+  });
+
+  it("DB insert 실패 → 500", async () => {
+    const { POST, mockDb } = await setup();
+    mockDb.insert.mockRejectedValue(new Error("DB error"));
+    const res = await POST(makePostRequest({ topic: "love" }));
+    expect(res.status).toBe(500);
+  });
+
+  it("service_type이 tarot으로 설정", async () => {
+    const { POST, mockDb } = await setup();
+    await POST(makePostRequest({ topic: "finance" }));
+    expect(mockDb.insert).toHaveBeenCalledWith("sessions", expect.objectContaining({ service_type: "tarot" }));
+  });
+});

--- a/src/test-helpers/mock-auth.ts
+++ b/src/test-helpers/mock-auth.ts
@@ -1,0 +1,15 @@
+import { vi } from "vitest";
+import type { AuthUser } from "@/lib/auth";
+
+export const MOCK_USER: AuthUser = { id: "user-test-123", email: "test@example.com" };
+
+export function makeAuthMock(user: AuthUser | null = MOCK_USER) {
+  return {
+    getCurrentUser: vi.fn().mockResolvedValue(user),
+    requireUser: user
+      ? vi.fn().mockResolvedValue(user)
+      : vi.fn().mockRejectedValue(new Error("Unauthorized")),
+    assertReadingAccess: vi.fn().mockResolvedValue(null),
+    assertSessionOwnership: vi.fn().mockResolvedValue(null),
+  };
+}

--- a/src/test-helpers/mock-db.ts
+++ b/src/test-helpers/mock-db.ts
@@ -1,0 +1,16 @@
+import { vi } from "vitest";
+import type { DbClient } from "@/lib/db/types";
+
+type MockDbClient = { [K in keyof DbClient]: ReturnType<typeof vi.fn> };
+
+export function makeMockDb(overrides: Partial<MockDbClient> = {}): MockDbClient {
+  return {
+    findOne: vi.fn(),
+    findMany: vi.fn(),
+    insert: vi.fn(),
+    insertMany: vi.fn(),
+    update: vi.fn(),
+    upsert: vi.fn(),
+    ...overrides,
+  };
+}

--- a/src/test-helpers/mock-request.ts
+++ b/src/test-helpers/mock-request.ts
@@ -1,0 +1,9 @@
+import { NextRequest } from "next/server";
+
+export function makePostRequest(body: unknown, url = "http://localhost/api/test"): NextRequest {
+  return new NextRequest(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}

--- a/src/test-helpers/reset-modules.ts
+++ b/src/test-helpers/reset-modules.ts
@@ -1,0 +1,7 @@
+import { vi, beforeEach } from "vitest";
+
+export function setupDoMock() {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -28,6 +28,9 @@ export default defineConfig({
         "src/hooks/useSSEStream.ts",   // SSE 공통 유틸 — 테스트 있음
         "src/services/**/*.ts",        // 모든 서비스 계층 — 테스트 있음
         "src/lib/verum/**/*.ts",       // Verum SDK — 타임아웃·서킷·resolver 테스트 있음
+        "src/app/api/tarot/session/route.ts",    // 세션 라우트 — PR B 테스트 추가
+        "src/app/api/saju/session/route.ts",     // 세션 라우트 — PR B 테스트 추가
+        "src/app/api/shinjeom/session/route.ts", // 세션 라우트 — PR B 테스트 추가
       ],
       exclude: [
         "src/**/*.test.ts",


### PR DESCRIPTION
## Summary

- **`src/test-helpers/`** 신설 — `makeMockDb`, `makeAuthMock`, `makePostRequest`, `setupDoMock` 4개 재사용 헬퍼
- **`src/__tests__/api/`** 신설 — 타로/사주/신점 세션 라우트 각 테스트 파일 (총 35개 테스트)
- **`vitest.config.ts`** — `coverage.include`에 3개 `route.ts` 추가

## 배경

6-PR 테스트 개선 계획 중 **PR B**. API 라우트 `src/app/**`가 vitest에서 전면 제외되어 세션 생성 라우트 11개가 0% 테스트 상태였다. 이번 PR에서 세션 생성 3개 라우트부터 시작한다.

테스트 파일은 `src/app/**` exclude를 우회하기 위해 `src/__tests__/api/`에 배치하고 `@/app/api/.../route` 절대 경로로 import한다. `vi.doMock` + `beforeEach(vi.resetModules)` 패턴으로 각 테스트마다 모듈 캐시를 초기화해 독립성 보장.

## 커버리지 변화

| 지표 | 이전 | 이후 |
|------|------|------|
| 테스트 수 | 469 | 504 (+35) |
| tarot/session/route.ts | 0% | 100% |
| saju/session/route.ts | 0% | 100% |
| shinjeom/session/route.ts | 0% | 100% |
| 전체 statements | 89.46% | 94.92% |

## 주요 검증 항목

- 신점 라우트의 **DB 오류 → 200 유지** 동작 (신점은 세션 없이 계속 진행)
- `characterId` 유효성 검사 → null 처리
- `spreadType` 유효 목록 검사 (타로 전용)
- 비로그인/로그인 사용자 `user_id` 처리

## Test Plan

- [x] `pnpm test:coverage` — 504 passed, 임계값 통과
- [x] `pnpm type-check` — 오류 없음
- [x] `pnpm lint` — 오류 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)