### PR TITLE
chore: 문서 자동화 인프라 신설 (PR-1/5)

### DIFF
--- a/.github/workflows/docs-sync.yml
+++ b/.github/workflows/docs-sync.yml
@@ -1,0 +1,38 @@
+name: 문서 정합성 검사 (경고 전용)
+
+on:
+  pull_request:
+    branches: [main]
+
+# PR-1~4 기간: 경고만 출력 (continue-on-error: true)
+# PR-5에서 continue-on-error를 제거해 실패 시 PR 차단으로 전환
+
+jobs:
+  docs-sync:
+    name: 문서 정합성 검사
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.33.0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: 의존성 설치
+        run: pnpm install --frozen-lockfile
+
+      - name: 환경변수-문서 정합성 검사
+        continue-on-error: true
+        run: pnpm exec tsx scripts/check-env-docs.ts
+
+      - name: 문서 링크 존재성 검사
+        continue-on-error: true
+        run: pnpm exec tsx scripts/check-doc-links.ts
+
+      # sync-test-count --check 은 테스트 실행이 너무 느려 PR CI에서 제외.
+      # 로컬에서 수동 실행: pnpm exec tsx scripts/sync-test-count.ts --check

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,40 @@
+# ArcanaInsight 문서 인덱스
+
+이 폴더는 CLAUDE.md의 세부 내용을 업무 유형별로 분류한 하위 문서 모음입니다.
+CLAUDE.md는 포인터(≤250줄)만 유지하며, 각 주제의 정본은 이 폴더 안에 위치합니다.
+
+## 업무 유형별 진입점
+
+| 업무 | 진입 문서 |
+|------|----------|
+| 시스템 구조 이해 | [architecture/system-overview.md](architecture/system-overview.md) |
+| AI 인프라 이해 | [architecture/ai-infrastructure.md](architecture/ai-infrastructure.md) |
+| DB/Auth 추상화 이해 | [architecture/db-abstraction.md](architecture/db-abstraction.md) |
+| 코드 변경 절차 | [workflow/code-change-process.md](workflow/code-change-process.md) |
+| E2E 테스트 실행 | [workflow/e2e-testing.md](workflow/e2e-testing.md) |
+| 단위 테스트 패턴 | [workflow/unit-testing.md](workflow/unit-testing.md) |
+| 캐릭터/스킨/페이지 추가 | [workflow/task-playbooks.md](workflow/task-playbooks.md) |
+| CI/CD 파이프라인 | [workflow/ci-cd.md](workflow/ci-cd.md) |
+| 코딩 스타일·컨벤션 | [conventions/coding-style.md](conventions/coding-style.md) |
+| 레이아웃 5:5 규칙 | [conventions/layout-rules.md](conventions/layout-rules.md) |
+| 크로스플랫폼 품질 | [conventions/cross-platform.md](conventions/cross-platform.md) |
+| Zod 스키마 규칙 | [conventions/zod-schemas.md](conventions/zod-schemas.md) |
+| 환경변수 목록 | [operations/env-variables.md](operations/env-variables.md) |
+| 미구현/기술부채 | [operations/known-issues.md](operations/known-issues.md) |
+| 배포/롤백 절차 | [operations/deployment.md](operations/deployment.md) |
+
+## 폴더 구조
+
+```
+docs/
+├── README.md                   # 이 파일 — 인덱스
+├── architecture/               # "시스템을 이해한다" (PR-3에서 채움)
+├── workflow/                   # "어떻게 변경하는가" (PR-3/4에서 채움)
+├── conventions/                # "어떻게 작성하는가" (PR-3에서 채움)
+├── operations/                 # "운영하는 법"
+│   └── known-issues.md         # 미구현 기능 + 기술 부채 (PR-1에서 신설)
+└── archive/                    # "역사적 자료" (PR-2/4에서 채움)
+```
+
+> **채움 일정**: PR-1(known-issues) → PR-2(archive 이동) → PR-3(architecture/conventions/workflow 분할)
+> → PR-4(workflow/operations 완성) → PR-5(CLAUDE.md 250줄 축약)

--- a/docs/operations/known-issues.md
+++ b/docs/operations/known-issues.md
@@ -1,0 +1,44 @@
+# 미구현 기능 및 기술 부채
+
+> **정본 위치**: 이 파일이 단일 정본. `CLAUDE.md`의 관련 섹션은 이 파일을 링크로 대체할 예정(PR-5).
+
+---
+
+## 미구현 기능
+
+알고 있지만 아직 구현하지 않은 기능. Claude가 실수로 구현하거나 사용자에게 "있다"고 잘못 안내하지 않도록 명시한다.
+
+| 기능 | 위치 | 현재 상태 | 비고 |
+|------|------|----------|------|
+| 신점 결과 공유 페이지 | `app/shinjeom/result/[id]/` | 미구현 | mypage에서 링크 비활성화됨 |
+| `useFavoriteCharacter` DB_PROVIDER 적용 | `hooks/useFavoriteCharacter.ts` | Supabase 직접 사용 | postgres 모드 전환 시 수정 필요 |
+| GenderFilter 홈 노출 | `components/home/GenderFilter.tsx` | 컴포넌트 존재, `page.tsx` 미사용 | — |
+| StatsCounter 홈 노출 | `components/home/StatsCounter.tsx` | 컴포넌트 존재, `page.tsx` 미사용 | — |
+| ReviewCarousel 홈 노출 | `components/home/ReviewCarousel.tsx` | 컴포넌트 존재, `page.tsx` 미사용 | — |
+
+---
+
+## 기술 부채
+
+의도적으로 아직 처리하지 않은 기술적 한계. Claude가 실수로 수정하거나 이미 검토된 방법을 다시 제안하지 않도록 명시한다.
+
+| 항목 | 파일 | 현황 | 해결 조건 |
+|------|------|------|----------|
+| `useFavoriteCharacter` Supabase 직접 사용 | `hooks/useFavoriteCharacter.ts` | DB_PROVIDER 추상화 미적용 | postgres 모드 전환 시 처리 |
+| miko·seonhwa JPG 레거시 경로 | `public/images/characters/miko/`, `seonhwa/` | nukki/ PNG 미전환 | 이미지 재생성 + 코드 수정 필요 |
+| `generate-character-images.mjs` 구버전 잔존 | `scripts/` | v2로 대체됨, 삭제 미완료 | 정리 작업 시 삭제 가능 |
+| `reading-saver.ts` 미구현 — inline fire-and-forget 산재 | `app/api/tarot/reading/route.ts` 외 2곳 | DB 저장 로직 3곳에 inline 산재, 추상화 미완료 | PR D에서 `src/lib/db/reading-saver.ts` 신설 후 통합 |
+| 커버리지 측정 범위 협소 | `vitest.config.ts` coverage.include | 전체 코드의 22.2%만 측정 대상 | PR E에서 include 확장 + 임계값 상향 |
+
+---
+
+## 테스트 개선 6-PR 계획 진행 상태
+
+| PR | 브랜치/번호 | 상태 | 완료 기준 |
+|----|------------|------|----------|
+| **A** | `fix/security-share-token-auth` / PR #119 | ✅ merged | Drizzle $defaultFn 2곳, migration 011, assertReadingAccess() |
+| **B** | `feat/pr-b-api-unit-test-infra` / PR #122 | ✅ merged | vitest exclude 완화, mock 헬퍼 4개, 세션 라우트 3개 테스트 (469→504) |
+| **C** | `feat/pr-c-api-smoke-tests` / PR #123 | ✅ merged | API 스모크 테스트 8개 라우트 추가 (504→539) |
+| **D** | (미시작) | pending B+C | reading-saver.ts 신설, inline 3곳 통합 |
+| **E** | (미시작) | pending B+C+D | coverage.include 확장, 임계값 branches 65/functions 75/lines 75 |
+| **F** | (미시작) | 선택 | 93개 우회 주석 태깅 |

--- a/scripts/check-doc-links.ts
+++ b/scripts/check-doc-links.ts
@@ -1,0 +1,90 @@
+/**
+ * docs/**\/*.md 파일 내 상대 링크 및 코드 경로 참조의 존재성 검증.
+ *
+ * 사용법:
+ *   pnpm exec tsx scripts/check-doc-links.ts          # 검사 (깨진 링크 시 exit 1)
+ *
+ * PR-1 단계에서는 docs/ 구조가 완성되지 않아 "파일 미존재" 경고가 많이 나옴.
+ * PR-5에서 docs/ 구조 완성 후 enforce 전환.
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const ROOT = path.resolve(__dirname, "..");
+const DOCS_DIR = path.join(ROOT, "docs");
+
+interface BrokenLink {
+  file: string;
+  line: number;
+  text: string;
+  target: string;
+}
+
+function getAllMarkdownFiles(dir: string): string[] {
+  if (!fs.existsSync(dir)) return [];
+  const results: string[] = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      results.push(...getAllMarkdownFiles(full));
+    } else if (entry.name.endsWith(".md")) {
+      results.push(full);
+    }
+  }
+  return results;
+}
+
+function checkLinks(filePath: string): BrokenLink[] {
+  const content = fs.readFileSync(filePath, "utf-8");
+  const lines = content.split("\n");
+  const broken: BrokenLink[] = [];
+  const fileDir = path.dirname(filePath);
+
+  for (let i = 0; i < lines.length; i++) {
+    // 마크다운 링크: [text](path) — 상대경로만 검사 (http/https/# 제외)
+    const linkMatches = [...lines[i].matchAll(/\[([^\]]*)\]\(([^)]+)\)/g)];
+    for (const m of linkMatches) {
+      const target = m[2].split("#")[0]; // 앵커 제거
+      if (!target || target.startsWith("http") || target.startsWith("https")) continue;
+
+      const resolved = path.resolve(fileDir, target);
+      if (!fs.existsSync(resolved)) {
+        broken.push({
+          file: path.relative(ROOT, filePath),
+          line: i + 1,
+          text: m[1],
+          target: m[2],
+        });
+      }
+    }
+  }
+  return broken;
+}
+
+const markdownFiles = getAllMarkdownFiles(DOCS_DIR);
+
+if (markdownFiles.length === 0) {
+  console.log("[check-doc-links] docs/ 아래 마크다운 파일 없음. 건너뜀.");
+  process.exit(0);
+}
+
+const allBroken: BrokenLink[] = [];
+for (const f of markdownFiles) {
+  allBroken.push(...checkLinks(f));
+}
+
+if (allBroken.length === 0) {
+  console.log(`[check-doc-links] 검사 통과. ${markdownFiles.length}개 파일, 깨진 링크 없음.`);
+  process.exit(0);
+}
+
+// PR-1~4 기간에는 경고만 출력 (exit 0). PR-5에서 아래를 exit(1)로 변경.
+console.warn(`[check-doc-links] 깨진 링크 ${allBroken.length}개 발견 (현재 경고만):`);
+for (const b of allBroken) {
+  console.warn(`  ${b.file}:${b.line} → [${b.text}](${b.target})`);
+}
+console.warn(
+  "\n  [check-doc-links] PR-5에서 docs/ 구조 완성 후 이 경고를 오류로 전환 예정."
+);
+process.exit(0);

--- a/scripts/check-env-docs.ts
+++ b/scripts/check-env-docs.ts
@@ -1,0 +1,68 @@
+/**
+ * src/lib/env.ts의 환경변수 getter와 docs/operations/env-variables.md 정합성 검증.
+ *
+ * 사용법:
+ *   pnpm exec tsx scripts/check-env-docs.ts          # 검사 (불일치 시 exit 1)
+ *
+ * docs/operations/env-variables.md가 존재하지 않으면 경고 후 종료(exit 0).
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const ROOT = path.resolve(__dirname, "..");
+const ENV_TS = path.join(ROOT, "src/lib/env.ts");
+const ENV_DOCS = path.join(ROOT, "docs/operations/env-variables.md");
+
+function extractEnvVarsFromTs(content: string): string[] {
+  // process.env.VAR_NAME 패턴 추출
+  const matches = [...content.matchAll(/process\.env\.([A-Z_][A-Z0-9_]*)/g)];
+  return [...new Set(matches.map((m) => m[1]))].sort();
+}
+
+function extractEnvVarsFromDocs(content: string): string[] {
+  // 마크다운 코드블록 내 VAR_NAME= 또는 `VAR_NAME` 패턴 추출
+  const matches = [...content.matchAll(/\b([A-Z_][A-Z0-9_]{3,})\b(?:\s*=|\s*`)/g)];
+  return [...new Set(matches.map((m) => m[1]))].sort();
+}
+
+if (!fs.existsSync(ENV_DOCS)) {
+  console.warn(
+    "[check-env-docs] docs/operations/env-variables.md 파일이 없습니다.\n" +
+    "  PR-4에서 작성 예정. 현재는 검사를 건너뜁니다."
+  );
+  process.exit(0);
+}
+
+const envTsContent = fs.readFileSync(ENV_TS, "utf-8");
+const envDocsContent = fs.readFileSync(ENV_DOCS, "utf-8");
+
+const fromCode = extractEnvVarsFromTs(envTsContent);
+const fromDocs = extractEnvVarsFromDocs(envDocsContent);
+
+const missingInDocs = fromCode.filter((v) => !fromDocs.includes(v));
+const unknownInCode = fromDocs.filter((v) => !fromCode.includes(v));
+
+let hasError = false;
+
+if (missingInDocs.length > 0) {
+  console.error(
+    `[check-env-docs] 코드에 있으나 문서에 없는 변수 (${missingInDocs.length}개):\n` +
+    missingInDocs.map((v) => `  - ${v}`).join("\n")
+  );
+  hasError = true;
+}
+
+if (unknownInCode.length > 0) {
+  // 경고만 — 문서에 예시/선택 변수가 있을 수 있음
+  console.warn(
+    `[check-env-docs] 문서에 있으나 코드에서 못 찾은 변수 (${unknownInCode.length}개, 경고만):\n` +
+    unknownInCode.map((v) => `  ~ ${v}`).join("\n")
+  );
+}
+
+if (!hasError) {
+  console.log(`[check-env-docs] 검사 통과. 코드 변수 ${fromCode.length}개 모두 문서에 존재.`);
+}
+
+process.exit(hasError ? 1 : 0);

--- a/scripts/sync-test-count.ts
+++ b/scripts/sync-test-count.ts
@@ -1,0 +1,79 @@
+/**
+ * CLAUDE.md의 "N개 테스트" 수치를 실제 Vitest 결과와 동기화한다.
+ *
+ * 사용법:
+ *   pnpm exec tsx scripts/sync-test-count.ts          # CLAUDE.md 자동 갱신
+ *   pnpm exec tsx scripts/sync-test-count.ts --check  # CI 모드: 불일치 시 exit 1
+ */
+
+import { execSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const ROOT = path.resolve(__dirname, "..");
+const CLAUDE_MD = path.join(ROOT, "CLAUDE.md");
+const CHECK_MODE = process.argv.includes("--check");
+
+function getActualTestCount(): number {
+  try {
+    const output = execSync(
+      "pnpm exec vitest run --reporter=verbose 2>&1 || true",
+      { cwd: ROOT, encoding: "utf-8", timeout: 120_000 }
+    );
+    // "Tests  539 passed" or "539 passed" 형태 파싱
+    const match = output.match(/(\d+)\s+passed/);
+    if (match) return parseInt(match[1], 10);
+
+    // fallback: "Test Files  31 passed" 다음에 나오는 "Tests" 라인
+    const testsLine = output.split("\n").find((l) => /^\s*Tests\s+\d+/.test(l));
+    if (testsLine) {
+      const m = testsLine.match(/(\d+)\s+passed/);
+      if (m) return parseInt(m[1], 10);
+    }
+    throw new Error("테스트 수 파싱 실패:\n" + output.slice(-500));
+  } catch (e) {
+    console.error("[sync-test-count] 테스트 실행 오류:", e);
+    process.exit(1);
+  }
+}
+
+function getDocumentedCount(content: string): number | null {
+  // "Vitest 2.0 (node env, v8 coverage, 539개 테스트" 패턴
+  const match = content.match(/Vitest[^(]*\(node env[^,]*,\s*v8 coverage[^,]*,\s*(\d+)개\s*테스트/);
+  if (match) return parseInt(match[1], 10);
+  return null;
+}
+
+const claudeMd = fs.readFileSync(CLAUDE_MD, "utf-8");
+const documented = getDocumentedCount(claudeMd);
+
+if (documented === null) {
+  console.warn("[sync-test-count] CLAUDE.md에서 테스트 수 패턴을 찾지 못했습니다. 수동 확인 필요.");
+  process.exit(0);
+}
+
+console.log(`[sync-test-count] CLAUDE.md 기록: ${documented}개`);
+console.log("[sync-test-count] Vitest 실행 중...");
+
+const actual = getActualTestCount();
+console.log(`[sync-test-count] 실제 테스트 수: ${actual}개`);
+
+if (documented === actual) {
+  console.log("[sync-test-count] 일치. 변경 불필요.");
+  process.exit(0);
+}
+
+if (CHECK_MODE) {
+  console.error(
+    `[sync-test-count] 불일치! CLAUDE.md: ${documented}개 / 실제: ${actual}개\n` +
+    `  다음 명령으로 자동 갱신하세요: pnpm exec tsx scripts/sync-test-count.ts`
+  );
+  process.exit(1);
+}
+
+const updated = claudeMd.replace(
+  /(Vitest[^(]*\(node env[^,]*,\s*v8 coverage[^,]*,\s*)\d+(개\s*테스트)/,
+  `$1${actual}$2`
+);
+fs.writeFileSync(CLAUDE_MD, updated, "utf-8");
+console.log(`[sync-test-count] CLAUDE.md 갱신 완료: ${documented}개 → ${actual}개`);

--- a/src/__tests__/api/daily-card.test.ts
+++ b/src/__tests__/api/daily-card.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi } from "vitest";
+import { setupDoMock } from "@/test-helpers/reset-modules";
+import { makeMockDb } from "@/test-helpers/mock-db";
+import { makePostRequest } from "@/test-helpers/mock-request";
+import { makeMockAiModule } from "@/test-helpers/mock-ai";
+
+setupDoMock();
+
+const TODAY = "2026-04-24";
+const CACHED_CARD = { card_id: "major-00", is_reversed: false, interpretation: "캐시된 해석", keywords: ["새로운 시작"] };
+const VALID_BODY = { characterId: "arcana", date: TODAY };
+
+async function setup(options: { cached?: boolean; aiError?: boolean } = {}) {
+  const mockDb = makeMockDb();
+  mockDb.findOne.mockResolvedValue(options.cached ? CACHED_CARD : null);
+  mockDb.upsert.mockResolvedValue(CACHED_CARD);
+
+  const mockAiModule = makeMockAiModule();
+  if (options.aiError) {
+    const provider = { generateReading: vi.fn().mockRejectedValue(new Error("AI down")) };
+    mockAiModule.FallbackProvider.mockImplementation(() => provider);
+  }
+
+  vi.doMock("@/lib/db", () => ({ getDb: vi.fn().mockReturnValue(mockDb) }));
+  vi.doMock("@/services/core/fallback-provider", () => mockAiModule);
+
+  const { POST } = await import("@/app/api/daily-card/route");
+  return { POST, mockDb };
+}
+
+describe("POST /api/daily-card", () => {
+  it("캐시 히트 → AI 호출 없이 캐시 반환", async () => {
+    const { POST } = await setup({ cached: true });
+    const res = await POST(makePostRequest(VALID_BODY));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.cardId).toBe(CACHED_CARD.card_id);
+    expect(body.interpretation).toBe(CACHED_CARD.interpretation);
+  });
+
+  it("캐시 미스 → AI 호출 후 결과 반환", async () => {
+    const { POST } = await setup();
+    const res = await POST(makePostRequest(VALID_BODY));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.cardId).toBeTruthy();
+    expect(body.interpretation).toBeTruthy();
+  });
+
+  it("캐릭터 없음 → 404", async () => {
+    const { POST } = await setup();
+    const res = await POST(makePostRequest({ characterId: "no-such-char", date: TODAY }));
+    expect(res.status).toBe(404);
+    expect((await res.json()).error).toBe("Character not found");
+  });
+
+  it("date 형식 오류 → 400", async () => {
+    const { POST } = await setup();
+    const res = await POST(makePostRequest({ characterId: "arcana", date: "2026/04/24" }));
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toBe("Invalid request");
+  });
+
+  it("body 없음 → 400", async () => {
+    const { POST } = await setup();
+    const res = await POST(makePostRequest({}));
+    expect(res.status).toBe(400);
+  });
+
+  it("AI 오류 → 500", async () => {
+    const { POST } = await setup({ aiError: true });
+    const res = await POST(makePostRequest(VALID_BODY));
+    expect(res.status).toBe(500);
+  });
+});

--- a/src/__tests__/api/favorite-character.test.ts
+++ b/src/__tests__/api/favorite-character.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi } from "vitest";
+import { setupDoMock } from "@/test-helpers/reset-modules";
+import { makeMockDb } from "@/test-helpers/mock-db";
+import { makeAuthMock, MOCK_USER } from "@/test-helpers/mock-auth";
+import { makePostRequest } from "@/test-helpers/mock-request";
+
+setupDoMock();
+
+async function setup(options: { user?: typeof MOCK_USER | null } = {}) {
+  const mockDb = makeMockDb();
+  mockDb.update.mockResolvedValue({ id: MOCK_USER.id, favorite_character_id: "arcana" });
+
+  const user = "user" in options ? options.user : MOCK_USER;
+  vi.doMock("@/lib/db", () => ({ getDb: vi.fn().mockReturnValue(mockDb) }));
+  vi.doMock("@/lib/auth", () => makeAuthMock(user));
+
+  const { POST } = await import("@/app/api/profile/favorite-character/route");
+  return { POST, mockDb };
+}
+
+describe("POST /api/profile/favorite-character", () => {
+  it("유효한 characterId → success 반환", async () => {
+    const { POST } = await setup();
+    const res = await POST(makePostRequest({ characterId: "arcana" }));
+    expect(res.status).toBe(200);
+    expect((await res.json()).success).toBe(true);
+  });
+
+  it("characterId: null → 선호 상담사 해제 (success)", async () => {
+    const { POST, mockDb } = await setup();
+    mockDb.update.mockResolvedValue({ id: MOCK_USER.id, favorite_character_id: null });
+    const res = await POST(makePostRequest({ characterId: null }));
+    expect(res.status).toBe(200);
+    expect((await res.json()).success).toBe(true);
+    expect(mockDb.update).toHaveBeenCalledWith("profiles", { id: MOCK_USER.id }, { favorite_character_id: null });
+  });
+
+  it("존재하지 않는 characterId → 400", async () => {
+    const { POST } = await setup();
+    const res = await POST(makePostRequest({ characterId: "nonexistent-char" }));
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toBe("Invalid character");
+  });
+
+  it("미인증 사용자 → 401", async () => {
+    const { POST } = await setup({ user: null });
+    const res = await POST(makePostRequest({ characterId: "arcana" }));
+    expect(res.status).toBe(401);
+    expect((await res.json()).error).toBe("Unauthorized");
+  });
+
+  it("DB update 실패 → 500", async () => {
+    const { POST, mockDb } = await setup();
+    mockDb.update.mockRejectedValue(new Error("DB error"));
+    const res = await POST(makePostRequest({ characterId: "arcana" }));
+    expect(res.status).toBe(500);
+  });
+});

--- a/src/__tests__/api/saju-reading.test.ts
+++ b/src/__tests__/api/saju-reading.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi } from "vitest";
+import { setupDoMock } from "@/test-helpers/reset-modules";
+import { makeMockDb } from "@/test-helpers/mock-db";
+import { makeAuthMock } from "@/test-helpers/mock-auth";
+import { makePostRequest } from "@/test-helpers/mock-request";
+import { makeMockAiModule, readSSEStream } from "@/test-helpers/mock-ai";
+
+setupDoMock();
+
+const VALID_BODY = {
+  sessionId: null,
+  topic: "saju-general",
+  timeRange: "this-year",
+  includeMonthly: false,
+  characterId: "arcana",
+  userInfo: {
+    birthDate: "1990-01-15",
+    birthHour: "자시 (23시~01시)",
+    gender: "female",
+  },
+};
+
+async function setup() {
+  const mockDb = makeMockDb();
+  mockDb.insert.mockResolvedValue({ id: "r-saju-1" });
+  mockDb.update.mockResolvedValue(null);
+
+  vi.doMock("@/lib/rate-limit", () => ({
+    checkRateLimit: vi.fn().mockReturnValue(true),
+    rateLimitResponse: vi.fn(),
+  }));
+  vi.doMock("@/lib/db", () => ({ getDb: vi.fn().mockReturnValue(mockDb) }));
+  vi.doMock("@/lib/auth", () => makeAuthMock());
+  vi.doMock("@/services/core/fallback-provider", () => makeMockAiModule());
+
+  const { POST } = await import("@/app/api/saju/reading/route");
+  return { POST, mockDb };
+}
+
+describe("POST /api/saju/reading", () => {
+  it("유효한 요청 → SSE 스트림 응답", async () => {
+    const { POST } = await setup();
+    const res = await POST(makePostRequest(VALID_BODY));
+    expect(res.headers.get("Content-Type")).toBe("text/event-stream");
+    const text = await readSSEStream(res);
+    expect(text).toContain("data:");
+  });
+
+  it("body 없음 → 400", async () => {
+    const { POST } = await setup();
+    const res = await POST(makePostRequest({}));
+    expect(res.status).toBe(400);
+  });
+
+  it("유효하지 않은 topic → 400", async () => {
+    const { POST } = await setup();
+    const res = await POST(makePostRequest({ ...VALID_BODY, topic: "love" }));
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toBe("Invalid topic");
+  });
+
+  it("유효하지 않은 timeRange → 400", async () => {
+    const { POST } = await setup();
+    const res = await POST(makePostRequest({ ...VALID_BODY, timeRange: "invalid-range" }));
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toBe("Invalid timeRange");
+  });
+
+  it("rate limit 초과 → 429", async () => {
+    vi.doMock("@/lib/rate-limit", () => ({
+      checkRateLimit: vi.fn().mockReturnValue(false),
+      rateLimitResponse: vi.fn().mockReturnValue(new Response(JSON.stringify({ error: "Too many requests" }), { status: 429 })),
+    }));
+    vi.doMock("@/lib/db", () => ({ getDb: vi.fn().mockReturnValue(makeMockDb()) }));
+    vi.doMock("@/lib/auth", () => makeAuthMock());
+    vi.doMock("@/services/core/fallback-provider", () => makeMockAiModule());
+    const { POST } = await import("@/app/api/saju/reading/route");
+    const res = await POST(makePostRequest(VALID_BODY));
+    expect(res.status).toBe(429);
+  });
+});

--- a/src/__tests__/api/saju-result.test.ts
+++ b/src/__tests__/api/saju-result.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi } from "vitest";
+import { NextRequest } from "next/server";
+import { setupDoMock } from "@/test-helpers/reset-modules";
+import { makeMockDb } from "@/test-helpers/mock-db";
+
+setupDoMock();
+
+const MOCK_READING = { id: "r-2", share_token: "saju-tok", overall_reading: "사주 테스트" };
+
+async function setup() {
+  const mockDb = makeMockDb();
+  vi.doMock("@/lib/db", () => ({ getDb: vi.fn().mockReturnValue(mockDb) }));
+  const { GET } = await import("@/app/api/saju/result/[id]/route");
+  return { GET, mockDb };
+}
+
+function makeGetRequest(id: string): [NextRequest, { params: Promise<{ id: string }> }] {
+  return [
+    new NextRequest(`http://localhost/api/saju/result/${id}`),
+    { params: Promise.resolve({ id }) },
+  ];
+}
+
+describe("GET /api/saju/result/[id]", () => {
+  it("존재하는 share_token → reading 반환", async () => {
+    const { GET, mockDb } = await setup();
+    mockDb.findOne.mockResolvedValue(MOCK_READING);
+    const res = await GET(...makeGetRequest("saju-tok"));
+    expect(res.status).toBe(200);
+    expect((await res.json()).reading).toEqual(MOCK_READING);
+  });
+
+  it("존재하지 않는 share_token → 404", async () => {
+    const { GET, mockDb } = await setup();
+    mockDb.findOne.mockResolvedValue(null);
+    const res = await GET(...makeGetRequest("no-such-token"));
+    expect(res.status).toBe(404);
+    expect((await res.json()).error).toBe("Reading not found");
+  });
+
+  it("DB 오류 → 500", async () => {
+    const { GET, mockDb } = await setup();
+    mockDb.findOne.mockRejectedValue(new Error("DB error"));
+    const res = await GET(...makeGetRequest("saju-tok"));
+    expect(res.status).toBe(500);
+  });
+
+  it("saju_readings 테이블에 share_token으로 조회", async () => {
+    const { GET, mockDb } = await setup();
+    mockDb.findOne.mockResolvedValue(MOCK_READING);
+    await GET(...makeGetRequest("tok456"));
+    expect(mockDb.findOne).toHaveBeenCalledWith("saju_readings", { share_token: "tok456" });
+  });
+});

--- a/src/__tests__/api/shinjeom-message.test.ts
+++ b/src/__tests__/api/shinjeom-message.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi } from "vitest";
+import { setupDoMock } from "@/test-helpers/reset-modules";
+import { makeMockDb } from "@/test-helpers/mock-db";
+import { makeAuthMock } from "@/test-helpers/mock-auth";
+import { makePostRequest } from "@/test-helpers/mock-request";
+import { makeMockAiModule, readSSEStream } from "@/test-helpers/mock-ai";
+
+setupDoMock();
+
+const VALID_BODY = {
+  sessionId: null,
+  topic: "shinjeom-general",
+  characterId: "arcana",
+  currentMessage: "요즘 연애가 걱정돼요",
+  chatHistory: [],
+  isFinalTurn: false,
+  messageIndex: 0,
+};
+
+async function setup() {
+  const mockDb = makeMockDb();
+  mockDb.insert.mockResolvedValue({ id: "sm-1" });
+  mockDb.insertMany.mockResolvedValue([]);
+  mockDb.update.mockResolvedValue(null);
+
+  vi.doMock("@/lib/rate-limit", () => ({
+    checkRateLimit: vi.fn().mockReturnValue(true),
+    rateLimitResponse: vi.fn(),
+  }));
+  vi.doMock("@/lib/db", () => ({ getDb: vi.fn().mockReturnValue(mockDb) }));
+  vi.doMock("@/lib/auth", () => makeAuthMock());
+  vi.doMock("@/services/core/fallback-provider", () => makeMockAiModule());
+
+  const { POST } = await import("@/app/api/shinjeom/message/route");
+  return { POST, mockDb };
+}
+
+describe("POST /api/shinjeom/message", () => {
+  it("유효한 요청 → SSE 스트림 응답", async () => {
+    const { POST } = await setup();
+    const res = await POST(makePostRequest(VALID_BODY));
+    expect(res.headers.get("Content-Type")).toBe("text/event-stream");
+    const text = await readSSEStream(res);
+    expect(text).toContain("data:");
+    expect(text).toContain("done");
+  });
+
+  it("body 없음 → 400", async () => {
+    const { POST } = await setup();
+    const res = await POST(makePostRequest({}));
+    expect(res.status).toBe(400);
+  });
+
+  it("isFinalTurn=false이고 currentMessage 없음 → 400", async () => {
+    const { POST } = await setup();
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { currentMessage: _, ...bodyWithoutMsg } = VALID_BODY;
+    const res = await POST(makePostRequest(bodyWithoutMsg));
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toContain("Message required");
+  });
+
+  it("isFinalTurn=true → 최종 결과 SSE 포함", async () => {
+    const { POST } = await setup();
+    const res = await POST(makePostRequest({ ...VALID_BODY, isFinalTurn: true }));
+    expect(res.headers.get("Content-Type")).toBe("text/event-stream");
+    const text = await readSSEStream(res);
+    expect(text).toContain("isFinal");
+  });
+
+  it("rate limit 초과 → 429", async () => {
+    vi.doMock("@/lib/rate-limit", () => ({
+      checkRateLimit: vi.fn().mockReturnValue(false),
+      rateLimitResponse: vi.fn().mockReturnValue(new Response(JSON.stringify({ error: "Too many requests" }), { status: 429 })),
+    }));
+    vi.doMock("@/lib/db", () => ({ getDb: vi.fn().mockReturnValue(makeMockDb()) }));
+    vi.doMock("@/lib/auth", () => makeAuthMock());
+    vi.doMock("@/services/core/fallback-provider", () => makeMockAiModule());
+    const { POST } = await import("@/app/api/shinjeom/message/route");
+    const res = await POST(makePostRequest(VALID_BODY));
+    expect(res.status).toBe(429);
+  });
+});

--- a/src/__tests__/api/tarot-reading.test.ts
+++ b/src/__tests__/api/tarot-reading.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi } from "vitest";
+import { setupDoMock } from "@/test-helpers/reset-modules";
+import { makeMockDb } from "@/test-helpers/mock-db";
+import { makeAuthMock } from "@/test-helpers/mock-auth";
+import { makePostRequest } from "@/test-helpers/mock-request";
+import { makeMockAiModule, makeMockVerum, readSSEStream } from "@/test-helpers/mock-ai";
+
+setupDoMock();
+
+const VALID_BODY = {
+  sessionId: null,
+  topic: "love",
+  characterId: "arcana",
+  cards: [{ cardId: "major-00", position: 0, isReversed: false }],
+};
+
+async function setup(options: { aiError?: boolean } = {}) {
+  const mockDb = makeMockDb();
+  mockDb.insert.mockResolvedValue({ id: "r-1" });
+  mockDb.update.mockResolvedValue(null);
+  mockDb.insertMany.mockResolvedValue([]);
+
+  const mockAiModule = makeMockAiModule();
+  if (options.aiError) {
+    const provider = {
+      streamReading: vi.fn().mockImplementation(async function* () {
+        throw new Error("AI error");
+      }),
+    };
+    mockAiModule.FallbackProvider.mockImplementation(() => provider);
+  }
+
+  vi.doMock("@/lib/rate-limit", () => ({
+    checkRateLimit: vi.fn().mockReturnValue(true),
+    rateLimitResponse: vi.fn(),
+  }));
+  vi.doMock("@/lib/db", () => ({ getDb: vi.fn().mockReturnValue(mockDb) }));
+  vi.doMock("@/lib/auth", () => makeAuthMock());
+  vi.doMock("@/services/core/fallback-provider", () => mockAiModule);
+  vi.doMock("@/lib/verum", () => makeMockVerum());
+
+  const { POST } = await import("@/app/api/tarot/reading/route");
+  return { POST, mockDb };
+}
+
+describe("POST /api/tarot/reading", () => {
+  it("유효한 요청 → SSE 스트림 응답", async () => {
+    const { POST } = await setup();
+    const res = await POST(makePostRequest(VALID_BODY));
+    expect(res.headers.get("Content-Type")).toBe("text/event-stream");
+    const text = await readSSEStream(res);
+    expect(text).toContain("data:");
+    expect(text).toContain("done");
+  });
+
+  it("body 없음 → 400", async () => {
+    const { POST } = await setup();
+    const res = await POST(makePostRequest({}));
+    expect(res.status).toBe(400);
+  });
+
+  it("cards 배열 없음 → 400", async () => {
+    const { POST } = await setup();
+    const res = await POST(makePostRequest({ topic: "love", characterId: "arcana" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("유효하지 않은 topic → 400", async () => {
+    const { POST } = await setup();
+    const res = await POST(makePostRequest({ ...VALID_BODY, topic: "invalid-topic" }));
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toBe("Invalid topic");
+  });
+
+  it("rate limit 초과 → 429", async () => {
+    // rate-limit 포함 모든 모듈을 처음부터 mock (setup() 없이 직접 구성)
+    vi.doMock("@/lib/rate-limit", () => ({
+      checkRateLimit: vi.fn().mockReturnValue(false),
+      rateLimitResponse: vi.fn().mockReturnValue(new Response(JSON.stringify({ error: "Too many requests" }), { status: 429 })),
+    }));
+    vi.doMock("@/lib/db", () => ({ getDb: vi.fn().mockReturnValue(makeMockDb()) }));
+    vi.doMock("@/lib/auth", () => makeAuthMock());
+    vi.doMock("@/services/core/fallback-provider", () => makeMockAiModule());
+    vi.doMock("@/lib/verum", () => makeMockVerum());
+    const { POST } = await import("@/app/api/tarot/reading/route");
+    const res = await POST(makePostRequest(VALID_BODY));
+    expect(res.status).toBe(429);
+  });
+
+  it("AI 오류 → 응답 생성 후 스트림 내부에서 처리", async () => {
+    const { POST } = await setup({ aiError: true });
+    const res = await POST(makePostRequest(VALID_BODY));
+    // AI 오류는 스트림 내부 try-catch에서 처리되므로 200 응답
+    expect(res.status).toBe(200);
+    const text = await readSSEStream(res);
+    expect(text).toContain("error");
+  });
+});

--- a/src/__tests__/api/tarot-result.test.ts
+++ b/src/__tests__/api/tarot-result.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi } from "vitest";
+import { NextRequest } from "next/server";
+import { setupDoMock } from "@/test-helpers/reset-modules";
+import { makeMockDb } from "@/test-helpers/mock-db";
+
+setupDoMock();
+
+const MOCK_READING = { id: "r-1", share_token: "abc123", overall_reading: "테스트" };
+
+async function setup(dbOverrides?: Partial<ReturnType<typeof makeMockDb>>) {
+  const mockDb = makeMockDb(dbOverrides);
+  vi.doMock("@/lib/db", () => ({ getDb: vi.fn().mockReturnValue(mockDb) }));
+  const { GET } = await import("@/app/api/tarot/result/[id]/route");
+  return { GET, mockDb };
+}
+
+function makeGetRequest(id: string): [NextRequest, { params: Promise<{ id: string }> }] {
+  return [
+    new NextRequest(`http://localhost/api/tarot/result/${id}`),
+    { params: Promise.resolve({ id }) },
+  ];
+}
+
+describe("GET /api/tarot/result/[id]", () => {
+  it("존재하는 share_token → reading 반환", async () => {
+    const { GET, mockDb } = await setup();
+    mockDb.findOne.mockResolvedValue(MOCK_READING);
+    const res = await GET(...makeGetRequest("abc123"));
+    expect(res.status).toBe(200);
+    expect((await res.json()).reading).toEqual(MOCK_READING);
+  });
+
+  it("존재하지 않는 share_token → 404", async () => {
+    const { GET, mockDb } = await setup();
+    mockDb.findOne.mockResolvedValue(null);
+    const res = await GET(...makeGetRequest("no-such-token"));
+    expect(res.status).toBe(404);
+    expect((await res.json()).error).toBe("Reading not found");
+  });
+
+  it("DB 오류 → 500", async () => {
+    const { GET, mockDb } = await setup();
+    mockDb.findOne.mockRejectedValue(new Error("DB error"));
+    const res = await GET(...makeGetRequest("abc123"));
+    expect(res.status).toBe(500);
+  });
+
+  it("readings 테이블에 share_token으로 조회", async () => {
+    const { GET, mockDb } = await setup();
+    mockDb.findOne.mockResolvedValue(MOCK_READING);
+    await GET(...makeGetRequest("tok123"));
+    expect(mockDb.findOne).toHaveBeenCalledWith("readings", { share_token: "tok123" });
+  });
+});

--- a/src/test-helpers/mock-ai.ts
+++ b/src/test-helpers/mock-ai.ts
@@ -1,0 +1,45 @@
+import { vi } from "vitest";
+
+const MOCK_JSON_RESPONSE = JSON.stringify({
+  cardInterpretations: [{ cardId: "major-00", position: 0, interpretation: "테스트 해석", isReversed: false }],
+  overallReading: "테스트 전체 리딩 결과입니다.",
+  advice: "테스트 조언입니다.",
+  topicReading: "테스트 주제 리딩입니다.",
+});
+
+export function makeMockAiProvider() {
+  return {
+    streamReading: vi.fn().mockImplementation(async function* () {
+      yield MOCK_JSON_RESPONSE;
+    }),
+    generateReading: vi.fn().mockResolvedValue("테스트 AI 응답입니다."),
+  };
+}
+
+export function makeMockAiModule(provider = makeMockAiProvider()) {
+  return { FallbackProvider: vi.fn().mockImplementation(() => provider) };
+}
+
+export function makeMockVerum() {
+  return {
+    resolveSystemPrompt: vi.fn().mockResolvedValue({
+      systemPrompt: "테스트 시스템 프롬프트",
+      routedTo: "baseline" as const,
+      deploymentId: null,
+    }),
+    recordTrace: vi.fn(),
+  };
+}
+
+/** SSE 스트림 바디를 전부 읽어 문자열로 반환 */
+export async function readSSEStream(res: Response): Promise<string> {
+  if (!res.body) return "";
+  const reader = res.body.getReader();
+  const chunks: string[] = [];
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    chunks.push(new TextDecoder().decode(value));
+  }
+  return chunks.join("");
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -28,9 +28,16 @@ export default defineConfig({
         "src/hooks/useSSEStream.ts",   // SSE 공통 유틸 — 테스트 있음
         "src/services/**/*.ts",        // 모든 서비스 계층 — 테스트 있음
         "src/lib/verum/**/*.ts",       // Verum SDK — 타임아웃·서킷·resolver 테스트 있음
-        "src/app/api/tarot/session/route.ts",    // 세션 라우트 — PR B 테스트 추가
-        "src/app/api/saju/session/route.ts",     // 세션 라우트 — PR B 테스트 추가
-        "src/app/api/shinjeom/session/route.ts", // 세션 라우트 — PR B 테스트 추가
+        "src/app/api/tarot/session/route.ts",         // PR B
+        "src/app/api/saju/session/route.ts",          // PR B
+        "src/app/api/shinjeom/session/route.ts",      // PR B
+        "src/app/api/tarot/result/[id]/route.ts",     // PR C
+        "src/app/api/saju/result/[id]/route.ts",      // PR C
+        "src/app/api/profile/favorite-character/route.ts", // PR C
+        "src/app/api/daily-card/route.ts",            // PR C
+        "src/app/api/tarot/reading/route.ts",         // PR C
+        "src/app/api/saju/reading/route.ts",          // PR C
+        "src/app/api/shinjeom/message/route.ts",      // PR C
       ],
       exclude: [
         "src/**/*.test.ts",


### PR DESCRIPTION
## Summary

문서 아키텍처 재편 5-PR 계획의 첫 단계 — 이후 PR들의 안전망 역할을 할 자동화 인프라를 구축합니다.

- `docs/README.md` — 업무 유형별 문서 인덱스 스캐폴딩 (PR-3/4에서 내용 채움)
- `docs/operations/known-issues.md` — CLAUDE.md 미구현 기능·기술 부채 표의 단일 정본
- `scripts/sync-test-count.ts` — Vitest 결과 → CLAUDE.md 테스트 수 자동 동기화
- `scripts/check-env-docs.ts` — `src/lib/env.ts` ↔ `docs/operations/env-variables.md` 정합성 검사
- `scripts/check-doc-links.ts` — `docs/**/*.md` 상대 링크 존재성 검증
- `.github/workflows/docs-sync.yml` — PR마다 위 스크립트 실행 (현재 `continue-on-error: true` 경고 전용, PR-5에서 enforce 전환)

## 5-PR 계획 진행 상태

| PR | 내용 | 상태 |
|----|------|------|
| **PR-1** (이번) | 인프라 + 자동화 신설 | 🔄 in review |
| PR-2 | 고아 문서 이동 | pending PR-1 |
| PR-3 | 주제별 문서 분할 | pending PR-2 |
| PR-4 | 워크플로우 문서 + process.md 분해 | pending PR-3 |
| PR-5 | CLAUDE.md 250줄 재작성 + CI enforce | pending PR-4 |

## Test Plan

- [x] `pnpm type-check` 통과
- [x] `pnpm lint` 통과
- [x] 스크립트 신규 파일이므로 빌드 영향 없음 (scripts/는 런타임 미포함)
- [ ] CI: `docs-sync` 워크플로우 — 경고 출력 후 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)