### PR TITLE
docs: CLAUDE.md 섹션을 architecture·conventions·workflow 로 분할 (PR-3/5)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -9,7 +9,9 @@ CLAUDE.md는 포인터(≤250줄)만 유지하며, 각 주제의 정본은 이 �
 |------|----------|
 | 시스템 구조 이해 | [architecture/system-overview.md](architecture/system-overview.md) |
 | AI 인프라 이해 | [architecture/ai-infrastructure.md](architecture/ai-infrastructure.md) |
-| DB/Auth 추상화 이해 | [architecture/db-abstraction.md](architecture/db-abstraction.md) |
+| DB 추상화 이해 | [architecture/db-abstraction.md](architecture/db-abstraction.md) |
+| Auth 추상화·API 보안 | [architecture/auth-abstraction.md](architecture/auth-abstraction.md) |
+| 캐릭터·카드·스킨 데이터 모델 | [architecture/data-model.md](architecture/data-model.md) |
 | 코드 변경 절차 | [workflow/code-change-process.md](workflow/code-change-process.md) |
 | E2E 테스트 실행 | [workflow/e2e-testing.md](workflow/e2e-testing.md) |
 | 단위 테스트 패턴 | [workflow/unit-testing.md](workflow/unit-testing.md) |
@@ -18,8 +20,10 @@ CLAUDE.md는 포인터(≤250줄)만 유지하며, 각 주제의 정본은 이 �
 | 코딩 스타일·컨벤션 | [conventions/coding-style.md](conventions/coding-style.md) |
 | 레이아웃 5:5 규칙 | [conventions/layout-rules.md](conventions/layout-rules.md) |
 | 크로스플랫폼 품질 | [conventions/cross-platform.md](conventions/cross-platform.md) |
-| Zod 스키마 규칙 | [conventions/zod-schemas.md](conventions/zod-schemas.md) |
+| Zod 스키마·API 입력 검증 | [conventions/zod-schemas.md](conventions/zod-schemas.md) |
+| 이미지 에셋 규칙 | [conventions/image-assets.md](conventions/image-assets.md) |
 | 환경변수 목록 | [operations/env-variables.md](operations/env-variables.md) |
+| 운영자 가이드 | [operations/operation-guide.md](operations/operation-guide.md) |
 | 미구현/기술부채 | [operations/known-issues.md](operations/known-issues.md) |
 | 배포/롤백 절차 | [operations/deployment.md](operations/deployment.md) |
 
@@ -28,9 +32,22 @@ CLAUDE.md는 포인터(≤250줄)만 유지하며, 각 주제의 정본은 이 �
 ```
 docs/
 ├── README.md                   # 이 파일 — 인덱스
-├── architecture/               # "시스템을 이해한다" (PR-3에서 채움)
-├── workflow/                   # "어떻게 변경하는가" (PR-3/4에서 채움)
-├── conventions/                # "어떻게 작성하는가" (PR-3에서 채움)
+├── architecture/               # "시스템을 이해한다" ✅ PR-3 완성
+│   ├── system-overview.md
+│   ├── ai-infrastructure.md
+│   ├── db-abstraction.md
+│   ├── auth-abstraction.md
+│   └── data-model.md
+├── workflow/                   # "어떻게 변경하는가" (PR-3 일부, PR-4에서 완성)
+│   ├── e2e-testing.md          # ✅ PR-2
+│   ├── unit-testing.md         # ✅ PR-3
+│   └── task-playbooks.md       # ✅ PR-3
+├── conventions/                # "어떻게 작성하는가" ✅ PR-3 완성
+│   ├── coding-style.md
+│   ├── layout-rules.md
+│   ├── cross-platform.md
+│   ├── zod-schemas.md
+│   └── image-assets.md
 ├── operations/                 # "운영하는 법"
 │   └── known-issues.md         # 미구현 기능 + 기술 부채 (PR-1에서 신설)
 └── archive/                    # "역사적 자료" (PR-2/4에서 채움)

--- a/docs/architecture/ai-infrastructure.md
+++ b/docs/architecture/ai-infrastructure.md
@@ -1,0 +1,109 @@
+# AI/LLM 인프라 구조
+
+ArcanaInsight의 AI 관련 코드는 **두 개의 독립된 레이어**로 분리됩니다.
+
+---
+
+## 1. 2단 레이어 구조
+
+```
+API Route (route.ts)
+    │
+    ├─ [1단계] 어떤 프롬프트를 쓸까? ─── src/lib/verum/
+    │   resolveSystemPrompt(fallback)       A/B 테스트 라우팅
+    │       ├─ variant  → Verum 실험 프롬프트    서킷 브레이커
+    │       └─ baseline → 로컬 기본 프롬프트     TTL 캐시
+    │
+    ├─ [2단계] 어떤 AI를 쓸까? ────────── src/services/core/
+    │   FallbackProvider.streamReading()    Grok 우선
+    │       ├─ GrokProvider (X.ai)          장애 시 Claude로 자동 전환
+    │       └─ ClaudeProvider (Anthropic)   쿨다운 관리
+    │
+    └─ [3단계] 결과 메트릭 기록 ─────────  src/lib/verum/
+        recordTrace(...)                    fire-and-forget
+```
+
+**레이어 구분 원칙**:
+- `lib/verum/` = **"무엇을 말할까"** — 프롬프트 내용·품질 (A/B 테스트)
+- `services/core/` = **"누가 말할까"** — AI 공급자 선택·신뢰성 (Fallback)
+
+두 레이어는 완전히 독립적으로 실패해도 서비스에 영향을 주지 않습니다.
+
+---
+
+## 2. FallbackProvider — Grok→Claude 자동 전환
+
+`src/services/core/fallback-provider.ts`
+
+| 오류 | 동작 | 쿨다운 |
+|------|------|--------|
+| 429 Rate Limit | Claude로 전환 | Retry-After 기반 (기본 30초) |
+| 500 서버 에러 / 네트워크 오류 | Claude로 전환 | 5분 (`AI_FALLBACK_COOLDOWN_MS`) |
+| 401/403 인증 실패 | Claude로 전환 | 30분 (`AI_AUTH_COOLDOWN_MS`) |
+| Grok + Claude 둘 다 실패 | 에러 메시지 표시 | — |
+
+- `ANTHROPIC_API_KEY` 미설정 시 Grok 단독 사용 (fallback 없음)
+- 쿨다운 중 새 요청은 즉시 Claude로 라우팅 (retry 없음)
+
+---
+
+## 3. Verum — A/B 프롬프트 라우팅
+
+`src/lib/verum/` — 타로 리딩에만 적용 (2026-04-24 기준)
+
+### 공개 API
+
+```ts
+// src/lib/verum/resolver.ts
+resolveSystemPrompt(fallback: string): Promise<string>
+recordTrace(data: TraceData): Promise<void>
+resetVerumClientForTests(): void  // 테스트 전용
+```
+
+### 격리 원칙
+
+- Verum 실패 → `fallback` 프롬프트 반환 (서비스 무중단)
+- 서킷 오픈 시 → 즉시 baseline 반환 (타임아웃 없음)
+- 예외는 절대 API 스트림 밖으로 새지 않음
+
+### 타임아웃·쿨다운
+
+| 항목 | 환경변수 | 기본값 |
+|------|---------|--------|
+| config 조회 타임아웃 | `VERUM_TIMEOUT_MS` | 3000ms |
+| trace 기록 타임아웃 | `VERUM_RECORD_TIMEOUT_MS` | 5000ms |
+| 5xx/timeout 쿨다운 | `VERUM_FAILURE_COOLDOWN_MS` | 60000ms |
+| 401/403 쿨다운 | `VERUM_AUTH_COOLDOWN_MS` | 1800000ms (30분) |
+
+### stampede 방지
+
+`cache.getOrFetch()` — 동시 캐시 미스 시 fetcher 1회 호출 (thundering herd 방지)
+
+상세: [`src/lib/verum/README.md`](../../src/lib/verum/README.md)
+
+---
+
+## 4. SSE 스트리밍 패턴
+
+| 라우트 | 방식 | 유틸 |
+|--------|------|------|
+| `/api/tarot/reading` | SSE 스트리밍 | `fetchSSEStream()` |
+| `/api/saju/reading` | SSE 스트리밍 | `fetchSSEStream()` |
+| `/api/shinjeom/message` | SSE 스트리밍 | `fetchSSEStream()` |
+| `/api/daily-card` | JSON 단일 응답 | `NextResponse.json()` |
+
+클라이언트 공통 유틸: `src/hooks/useSSEStream.ts` — `fetchSSEStream()`
+
+---
+
+## 5. AI 인프라 폴더 로드맵
+
+현재는 `src/lib/verum/`에 단독 위치. 사용 범위 확장에 따라 점진적으로 이전:
+
+| Phase | 기준 | 구조 |
+|---|---|---|
+| **Phase 1 (현재)** | 타로만 A/B 테스트 | `src/lib/verum/` |
+| **Phase 2** | 사주·신점으로 Verum 확장 | `src/lib/ai/experiment/verum/` |
+| **Phase 3** | 복수 실험 도구 추가 시 | `src/platform/experiment/` |
+
+상세: [`docs/archive/ai-quality-roadmap.md`](../archive/ai-quality-roadmap.md)

--- a/docs/architecture/auth-abstraction.md
+++ b/docs/architecture/auth-abstraction.md
@@ -1,0 +1,85 @@
+# Auth 추상화 레이어
+
+`DB_PROVIDER`에 따라 Supabase Auth ↔ NextAuth.js v5를 자동으로 선택합니다.
+
+---
+
+## 1. 공통 Auth 함수 (`src/lib/auth/index.ts`)
+
+| 함수 | 설명 |
+|------|------|
+| `getCurrentUser()` | 현재 로그인 사용자 반환. 비로그인 시 `null` |
+| `requireUser()` | 로그인 필수. 비로그인 시 401 반환 |
+| `assertSessionOwnership(sessionId, userId)` | 세션 소유자 확인. 불일치 시 403 |
+| `assertReadingAccess(mode)` | `"public"` = 항상 허용, `"owner"` = 소유자만 허용 |
+
+---
+
+## 2. DB_PROVIDER별 구현
+
+| 함수 | `supabase` 모드 | `postgres` 모드 |
+|------|----------------|-----------------|
+| `getCurrentUser()` | `supabase.auth.getUser()` | NextAuth.js v5 `auth()` |
+| `requireUser()` | Supabase Auth Helpers | NextAuth.js session |
+
+구현 파일:
+- `src/lib/auth/supabase-auth.ts` — Supabase 래핑
+- `src/lib/auth/nextauth.ts` — NextAuth.js v5 Google Provider 설정
+
+---
+
+## 3. API 보안 패턴 (3개 AI API 라우트 공통)
+
+모든 AI API 라우트(`/api/tarot/reading`, `/api/saju/reading`, `/api/shinjeom/message`)에 동일하게 적용:
+
+```
+요청 수신
+  │
+  ├─ 1. Rate Limiting — checkRateLimit() (src/lib/rate-limit.ts)
+  │      타로/사주: 10 req/min / 신점: 20 req/min / 초과 시 429
+  │
+  ├─ 2. 입력 검증 — Zod safeParse() (src/lib/validation/api-schemas.ts)
+  │      실패 시 400
+  │
+  ├─ 3. 인증 — requireUser() / getCurrentUser()
+  │      비로그인 시 401
+  │
+  ├─ 4. IDOR 방어 — assertSessionOwnership()
+  │      세션 소유자 불일치 시 403
+  │
+  └─ 5. AI 처리 → SSE 스트리밍 응답
+```
+
+---
+
+## 4. 공유 결과 열람
+
+`share_token`을 가진 누구나 결과 열람 가능 (`assertReadingAccess("public")`):
+
+```ts
+// 공유 결과 조회 라우트 패턴
+await assertReadingAccess("public");  // 항상 통과
+const result = await getDb().findOne("readings", { share_token });
+```
+
+소유자 전용 쓰기·삭제:
+```ts
+await assertReadingAccess("owner");   // 소유자만 통과
+```
+
+---
+
+## 5. NextAuth.js 설정 (PostgreSQL 모드)
+
+`src/lib/auth/nextauth.ts` — Google Provider 설정
+
+```
+NEXTAUTH_SECRET=    # openssl rand -base64 32
+NEXTAUTH_URL=       # 프로덕션 URL
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=
+```
+
+Google Cloud Console에서 Authorized redirect URI에 `{NEXTAUTH_URL}/api/auth/callback/google` 추가 필요.
+
+API 라우트: `src/app/api/auth/[...nextauth]/` — PostgreSQL 모드 전용

--- a/docs/architecture/data-model.md
+++ b/docs/architecture/data-model.md
@@ -1,0 +1,121 @@
+# 데이터 모델 — 캐릭터·카드·스킨
+
+ArcanaInsight의 정적 데이터(캐릭터, 카드, 스프레드, 스킨) 모델을 정의합니다.
+
+---
+
+## 1. 캐릭터 시스템
+
+12명의 캐릭터, 각자 다른 성격과 말투로 모든 운세 서비스 제공 가능:
+
+| ID | 이름 | 성별 | 말투 | 특기 |
+|---|---|---|---|---|
+| `arcana` | 아르카나 | 여 | ~네요/~해요, 신비로운 톤 | 직관적·감성 리딩 |
+| `miko` | 미코 | 여 | ~입니다/~합니다, 엄숙한 톤 | 영적·깊이 있는 해석 |
+| `seonhwa` | 선화 | 여 | ~세요/~랍니다, 우아한 톤 | 지혜로운 동양적 해석 |
+| `hoshi` | 호시 | 여 | ~야/~지, 반말+이모지 | 밝고 캐주얼 리딩 |
+| `luna` | 루나 | 여 | ~요/~네요, 다정·신비로운 톤 | 포근한 힐링 리딩 |
+| `rei` | 레이 | 여 | ~야/~지, 건조하고 핵심적인 톤 | 냉철한 분석 리딩 |
+| `cairn` | 카이른 | 남 | ~습니다/~ㅂ니다, 격식 있는 톤 | 우아한 젠틀 리딩 |
+| `zero` | 제로 | 남 | ~다/~지, 시적인 저음 톤 | 어둡고 로맨틱 리딩 |
+| `haru` | 하루 | 남 | ~요/~세요, 친근하고 따뜻한 톤 | 응원하는 힐링 리딩 |
+| `ren` | 렌 | 남 | ~오/~하오, 고풍스러운 문어체 | 고요한 선인 리딩 |
+| `lix` | 릭스 | 남 | ~는데/~ㄹ까, 장난스러운 톤 | 위트 있는 트릭스터 리딩 |
+| `ethan` | 에단 | 남 | ~요/~거든요, 상세하고 친절한 톤 | 학구적 분석 리딩 |
+
+각 캐릭터는 6가지 표정(Mood): `default`, `smile`, `serious`, `surprised`, `wink`, `mystical`
+
+---
+
+## 2. 세션 중 캐릭터 표정 규칙
+
+캐릭터는 부수적 요소이므로 표정 변경을 최소화하여 타로·사주 콘텐츠에 집중시킨다. **3단계만** 사용:
+
+| 장면 | 표정 | 설명 |
+|------|------|------|
+| 세션 진입 + 카드 선택 대기 | `default` | 차분한 기본 표정 |
+| 카드 선택 순간 + 리딩/분석 대기 | `mystical` | 신비로운 톤, 카드를 읽는 느낌 |
+| 결과 도착 | `smile` | 따뜻한 미소로 결과 전달 |
+
+- 에러 발생 시: `default`로 복귀
+- 대기 대사 중: 표정 변경 없음 (`mystical` 유지)
+
+---
+
+## 3. 캐릭터 이미지 경로 규칙
+
+`public/images/characters/[id]/`
+
+| 구분 | 형식 | 경로 패턴 | 해당 캐릭터 |
+|------|------|---------|------------|
+| nukki PNG | PNG (투명 배경) | `[id]/nukki/[mood].png` | arcana, hoshi, luna, rei, cairn, zero, haru, ren, lix, ethan (10명) |
+| 레거시 JPG | JPG (배경 포함) | `[id]/[mood].jpg` | miko, seonhwa (2명) |
+
+- 이미지 규격: **1408×768** (grok-imagine-image-pro API 기본 출력)
+- 예: `/images/characters/arcana/nukki/default.png`
+- 예: `/images/characters/miko/default.jpg`
+
+> ⚠️ miko·seonhwa JPG 레거시 — nukki PNG 미전환 (재생성 + 코드 수정 필요)
+
+---
+
+## 4. 타로 카드 데이터
+
+`src/data/cards/`
+
+| 파일 | 내용 |
+|------|------|
+| `major-arcana.ts` | 메이저 아르카나 22장 (이름, 의미, 정/역방향 해석) |
+| `minor-arcana.ts` | 마이너 아르카나 56장 (4 수트 × 14장) |
+| `symbols.ts` | 카드 심볼 정의 |
+
+카드 이미지: `public/images/cards/` — SVG 포맷
+- `major/` — 00-fool ~ 21-world
+- `cups/`, `wands/`, `swords/`, `pentacles/` — 마이너 아르카나 슈트별
+- `card-back.svg` — 카드 뒷면
+
+---
+
+## 5. 스프레드 목록
+
+`src/data/spreads/` — 10종 정의
+
+| 이름 | 카드 수 |
+|------|--------|
+| 원카드 | 1장 |
+| 쓰리카드 | 3장 |
+| 5장 켈틱 | 5장 |
+| 관계 스프레드 | 5장 |
+| 말굽 | 7장 |
+| 의사결정 | 6장 |
+| 한 주 전망 | 7장 |
+| 조디악 휠 | 12장 |
+| 생명의 나무 | 10장 |
+| 10장 켈틱 | 10장 |
+
+---
+
+## 6. 카드 스킨
+
+`src/data/skins/index.ts` — 6종 정의
+
+이미지 경로 로직: `src/lib/storage/index.ts` — `getCardImageUrl()`
+- `supabase` 모드: Supabase Storage URL
+- `postgres` 모드: `/images/skins/...` 정적 파일
+
+---
+
+## 7. 정적 데이터 파일 위치
+
+| 데이터 | 파일 |
+|--------|------|
+| 캐릭터 메타데이터 | `src/data/characters/index.ts` |
+| 대기 대사 | `src/data/characters/waiting-lines.ts` |
+| 타로 토픽 | `src/data/topics.ts` |
+| 스프레드 | `src/data/spreads/` |
+| 사주 상수 (천간·지지·오행) | `src/data/saju/constants.ts` |
+| 사주 카테고리 | `src/data/saju/categories.ts` |
+| 스킨 | `src/data/skins/index.ts` |
+| 출생시간(12시진) | `src/data/birth-hours.ts` |
+| 홈 페이지 정적 데이터 | `src/data/home/` (faq.ts, reviews.ts, stats.ts) |
+| 에러 메시지 상수 | `src/data/error-messages.ts` |

--- a/docs/architecture/db-abstraction.md
+++ b/docs/architecture/db-abstraction.md
@@ -1,0 +1,109 @@
+# DB 추상화 레이어
+
+`DB_PROVIDER` 환경변수 하나로 Supabase ↔ 온프레미스 PostgreSQL을 즉시 전환합니다.
+
+---
+
+## 1. 추상화 구조
+
+```
+API Route
+    │
+    ├─ getDb()           → src/lib/db/index.ts
+    │   ├─ DB_PROVIDER=postgres  → PostgresAdapter (Drizzle ORM)
+    │   └─ 그 외          → SupabaseAdapter
+    │
+    ├─ getCurrentUser()  → src/lib/auth/index.ts
+    │   ├─ postgres 모드 → NextAuth.js v5 auth()
+    │   └─ supabase 모드 → supabase.auth.getUser()
+    │
+    └─ getCardImageUrl() → src/lib/storage/index.ts
+        ├─ postgres 모드 → /images/skins/... (정적 파일)
+        └─ supabase 모드 → Supabase Storage URL
+```
+
+---
+
+## 2. 핵심 규칙
+
+- **모든 API 라우트**는 `createClient()` 대신 `getDb()` + `getCurrentUser()` 사용
+  - 로직 변경 없이 DB 전환 가능
+- **롤백**: Railway 환경변수 `DB_PROVIDER=supabase`로 변경 → 즉시 복귀 (재배포 불필요)
+
+---
+
+## 3. DB 파일 구조
+
+```
+src/lib/db/
+├── index.ts            # getDb() 팩토리
+├── types.ts            # DbClient 공통 인터페이스
+├── supabase-adapter.ts # Supabase 구현체
+├── postgres-adapter.ts # Drizzle ORM 구현체
+└── schema/index.ts     # Drizzle 스키마 (supabase/migrations/ 동기화 대상)
+```
+
+---
+
+## 4. Supabase 마이그레이션 목록
+
+`supabase/migrations/` — 번호 순서 유지, **002는 결번**
+
+| 파일 | 내용 |
+|------|------|
+| `001_initial_schema.sql` | 초기 스키마 (sessions, readings 등) |
+| `003_daily_cards.sql` | daily_cards + profiles.favorite_character_id |
+| `004_user_info.sql` | 사용자 정보 (생년월일, 성별, 혈액형 등) |
+| `005_session_character_and_topics.sql` | sessions 캐릭터/토픽 확장 |
+| `006_saju_readings.sql` | saju_readings 테이블 |
+| `007_skin_selection.sql` | 스킨 선택 컬럼 |
+| `008_shinjeom.sql` | shinjeom_messages, shinjeom_readings |
+| `009_shinjeom_topics_expand.sql` | 신점 직장/이직 + 택일 토픽 |
+| `010_share_token_default_fix.sql` | readings share_token NULL 백필 |
+| `011_saju_shinjeom_share_token_defaults.sql` | saju/shinjeom share_token NULL 백필 |
+
+PostgreSQL 모드: `src/lib/db/schema/index.ts` (Drizzle)에 동일 스키마 정의됨
+
+---
+
+## 5. share_token 공개 정책
+
+- 타로/사주 결과 페이지(`/*/result/[id]`)는 `share_token` URL 기반 공개 공유 링크
+- share_token 보유자 = 공개 열람 허용 (공유 링크 생성 = 공개 의도)
+- 소유자 전용 쓰기/삭제: `assertReadingAccess("owner")` 사용
+- share_token NULL 방지: Drizzle `$defaultFn(() => crypto.randomUUID())` + DB DEFAULT `gen_random_uuid()` 이중 보장
+
+---
+
+## 6. DB 저장 패턴
+
+현재: tarot/saju/shinjeom reading 라우트에 **fire-and-forget inline 구현** (3곳 산재)
+
+예정: `src/lib/db/reading-saver.ts`(`saveReadingAsync`)로 통합 — PR D
+
+---
+
+## 7. 환경 변수
+
+### Supabase 모드
+
+```
+DB_PROVIDER=supabase          # 또는 미설정
+NEXT_PUBLIC_SUPABASE_URL=
+NEXT_PUBLIC_SUPABASE_ANON_KEY=
+SUPABASE_SERVICE_ROLE_KEY=
+```
+
+### PostgreSQL 모드
+
+```
+DB_PROVIDER=postgres
+POSTGRES_URL=postgresql://user:password@host:5432/arcana
+POSTGRES_POOL_SIZE=           # 기본 10
+NEXTAUTH_SECRET=              # openssl rand -base64 32
+NEXTAUTH_URL=                 # 프로덕션 URL
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=
+```
+
+> Google Cloud Console: PostgreSQL 모드 사용 시 Authorized redirect URI에 `{NEXTAUTH_URL}/api/auth/callback/google` 추가 필요

--- a/docs/architecture/system-overview.md
+++ b/docs/architecture/system-overview.md
@@ -1,0 +1,119 @@
+# 서비스 아키텍처 — 전체 흐름 개요
+
+ArcanaInsight의 3개 운세 서비스(타로·사주·신점) 사용자 흐름 및 데이터 모델을 정의합니다.
+
+---
+
+## 1. 서비스별 사용자 흐름
+
+### 타로 (4단계)
+
+1. **캐릭터 선택** → 12명 중 선택 (성별 필터 지원). 선호 상담사 설정 시 자동 스킵
+2. **개인정보 입력** → 생년월일, 출생시간(12시진), 성별, 혈액형 + 제3자 제공 동의
+3. **주제 선택 + 카드 뽑기** → 주제 선택 → 스프레드 선택 → 카드 선택
+4. **AI 리딩 결과** → Grok AI가 SSE 스트리밍으로 해석 → 결과 공유(share_token URL)
+
+### 사주 (4단계)
+
+1. **캐릭터 선택** → 12명 중 선택 (성별 필터 지원). 선호 상담사 설정 시 자동 스킵
+2. **개인정보 입력** → 생년월일, 출생시간(12시진), 성별, 혈액형 + 제3자 제공 동의
+3. **시간단위 × 분석영역 선택** → 시간단위(7) + 분석영역(8) 동시 선택, 년단위 시 "월별 상세" 토글
+4. **AI 리딩 결과** → Grok AI가 SSE 스트리밍으로 해석 → 결과 공유
+
+### 신점 (3단계)
+
+1. **캐릭터 선택** → 12명 중 선택. 선호 상담사 설정 시 자동 스킵
+2. **주제 선택** → 신수(종합운), 연애/궁합, 재물/사업운, 직장/이직, 건강/액막이, 택일
+3. **대화형 상담** → 무제한 문답 → "신점 결과 받기" 버튼으로 종료 (1턴 이상 후 활성화)
+
+> ⚠️ 신점 결과 공유 페이지(`/shinjeom/result/[id]`) 미구현 — mypage에서 링크 비활성화
+
+---
+
+## 2. 주제(Topic) 목록 — 총 21개
+
+| 구분 | Topic 값 | 한국어 |
+|------|---------|--------|
+| 타로 | `love` | 연애 (전체) |
+| 타로 | `love-single` | 연애 (솔로) |
+| 타로 | `love-couple` | 연애 (커플) |
+| 타로 | `finance` | 재물 |
+| 타로 | `career` | 직업/직장 |
+| 타로 | `health` | 건강 |
+| 타로 | `general` | 종합 |
+| 사주 분석영역 | `saju-general` | 종합운 |
+| 사주 분석영역 | `saju-love-single` | 연애운 (솔로) |
+| 사주 분석영역 | `saju-love-couple` | 연애운 (커플) |
+| 사주 분석영역 | `saju-career` | 직장·재물운 |
+| 사주 분석영역 | `saju-health` | 건강운 |
+| 사주 분석영역 | `saju-personality` | 성격·적성 |
+| 사주 분석영역 | `saju-compatibility` | 궁합 |
+| 사주 분석영역 | `saju-auspicious-date` | 택일 |
+| 신점 | `shinjeom-general` | 신수 (종합운) |
+| 신점 | `shinjeom-love` | 연애/궁합 |
+| 신점 | `shinjeom-wealth` | 재물/사업운 |
+| 신점 | `shinjeom-career` | 직장/이직 |
+| 신점 | `shinjeom-health` | 건강/액막이 |
+| 신점 | `shinjeom-auspicious` | 택일 (날짜 선택) |
+
+정본 코드: `src/data/topics.ts` — `TAROT_TOPICS`, `SAJU_TOPICS`, `SHINJEOM_TOPICS`, `ALL_TOPICS`
+
+---
+
+## 3. 사주 시간단위(`SajuTimeRange`) — 7개
+
+`src/types/session.ts` 정의:
+
+| 값 | 한국어 | 월별 상세 토글 |
+|----|--------|--------------|
+| `this-week` | 이번 주 | ✗ |
+| `this-month` | 이번 달 | ✗ |
+| `this-year` | 올해 | ✓ |
+| `next-year` | 내년 | ✓ |
+| `three-year` | 3년 | ✓ |
+| `five-year` | 5년 | ✓ |
+| `full-fortune` | 전체 대운 | ✗ |
+
+---
+
+## 4. 타로 스프레드 × 주제 노출 규칙
+
+`src/app/tarot/page.tsx`의 `topicSpreads`에서 주제별로 노출할 스프레드를 제한합니다:
+
+| 주제 | 노출 스프레드 |
+|------|-------------|
+| 연애 (솔로) | 원카드, 쓰리카드, 5장 켈틱, 10장 켈틱 |
+| 연애 (커플) | 원카드, 쓰리카드, 관계 스프레드, 10장 켈틱 |
+| 직장/진로 | 원카드, 쓰리카드, 5장 켈틱, 말굽, 10장 켈틱 |
+| 재정/금전 | 원카드, 쓰리카드, 말굽, 의사결정, 10장 켈틱 |
+| 건강 | 원카드, 쓰리카드, 5장 켈틱 |
+| 일반 상담 | 원카드, 쓰리카드, 5장 켈틱, 10장 켈틱, 한 주 전망, 조디악 휠, 생명의 나무 (7종) |
+
+전체 스프레드 정의: `src/data/spreads/` — 10종
+
+---
+
+## 5. 선호 상담사 자동 선택
+
+- 마이페이지에서 선호 상담사를 설정하면 이후 서비스 진입 시 캐릭터 선택 단계 자동 스킵
+- `useFavoriteCharacter(skip)` 훅이 Supabase에서 `profiles.favorite_character_id` 조회
+- 캐릭터 상세 페이지 진입: `?character=xxx` URL 파라미터로 스킵 (타로·사주·신점 모두 지원)
+- 홈 직접 접속: `useEffect` fallback으로 자동 선택. `skip=true`이면 fetch 생략
+
+> ⚠️ 현재 `useFavoriteCharacter`는 Supabase 직접 사용 — `DB_PROVIDER` 추상화 미적용
+
+---
+
+## 6. 홈 페이지 구성 (`src/app/page.tsx`)
+
+7개 섹션을 순서대로 조합:
+
+1. **HeroSection** — 풀스크린 히어로 (캐릭터 + 카피 + CTA)
+2. **CharacterGallery** — 12캐릭터 갤러리 (카드형, 성별 필터 내장)
+3. **DailyCard** — 캐릭터별 일일 운세 (탭 전환 + 카드 뒤집기 + 공유)
+4. **SkinGallery** — 카드 스킨 갤러리 (6종)
+5. **ServiceFlow** — 서비스 이용 흐름 소개
+6. **FAQ** — 아코디언 FAQ
+7. **BottomCTA** — 하단 행동 유도
+
+> GenderFilter, StatsCounter, ReviewCarousel 컴포넌트는 `components/home/`에 존재하지만 현재 `page.tsx`에서 미사용

--- a/docs/conventions/coding-style.md
+++ b/docs/conventions/coding-style.md
@@ -1,0 +1,93 @@
+# 코딩 컨벤션
+
+ArcanaInsight 코드 작성 시 반드시 준수해야 하는 스타일 규칙입니다.
+
+---
+
+## 1. 일반 규칙
+
+- **주석·커밋 메시지**: 한국어 사용
+- **함수·변수명**: 영어 camelCase
+- **컴포넌트명**: PascalCase
+- **파일명**: kebab-case (컴포넌트 파일은 PascalCase)
+
+---
+
+## 2. TypeScript
+
+- `any` 타입 사용 금지 — 명시적 타입 정의 필수
+- `interface` 우선 사용 (`type alias`는 유니온/인터섹션에만)
+- `strict` 모드 활성화
+
+---
+
+## 3. React / Next.js
+
+- **서버 컴포넌트 기본** — 클라이언트 상태·이벤트가 필요할 때만 `'use client'` 명시
+- **named export** 사용 (default export 지양)
+- **Props**: `interface`로 정의
+
+---
+
+## 4. 스타일링
+
+- Tailwind CSS 유틸리티 클래스 우선
+- 복잡한 애니메이션: Framer Motion 사용
+- **다크 모드 기본** (점술/타로의 신비로운 분위기)
+- **커스텀 컬러** (`globals.css` `@theme` 블록):
+  - `arcana-bg`, `arcana-surface`, `arcana-card`, `arcana-border`
+  - `arcana-purple`, `arcana-indigo`, `arcana-gold`
+  - `arcana-text`, `arcana-muted`
+
+---
+
+## 5. 의존성 버전 관리
+
+| 규칙 | 대상 |
+|------|------|
+| **메이저 업그레이드 금지** (사용자 승인 필요) | Next.js, React, Framer Motion, Tailwind CSS, Zustand |
+| **마이너·패치 허용** | 보안 패치, 버그 픽스 |
+| **버전 고정** | `pnpm@10.33.0` — lock 파일 및 Docker 스크립트 동기화 |
+| **버전 고정** | `playwright:v1.59.1-noble` — CI Docker 이미지 동기화 |
+
+---
+
+## 6. 커밋 메시지 Prefix 규칙
+
+| prefix | 용도 |
+|--------|------|
+| `feat:` | 새 기능 추가 |
+| `fix:` | 버그 수정 |
+| `docs:` | 문서 변경 (CLAUDE.md, README 등) |
+| `chore:` | 빌드·설정·스크립트 변경 |
+| `refactor:` | 기능 변경 없는 코드 구조 개선 |
+| `style:` | UI/스타일 변경 (기능 무관) |
+| `test:` | 테스트 추가·수정 |
+| `merge:` | 브랜치 머지 커밋 |
+
+---
+
+## 7. Git 브랜치 전략
+
+- `main`: 프로덕션 브랜치 (Railway 자동 배포, `master` 미사용)
+- `feat/*`: 기능 개발
+- `fix/*`: 버그 수정
+- `docs/*`: 문서 변경
+- `chore/*`: 설정·정리
+
+**`main` 직접 push 금지** — PR을 통해 머지
+
+---
+
+## 8. Path Alias
+
+`@/*` → `./src/*` (`tsconfig.json`)
+
+---
+
+## 9. 작업 시 추가 주의사항
+
+- 타로 카드 데이터: `src/data/` 정적 관리 (DB 조회 금지)
+- 홈 페이지 데이터: `src/data/home/` 정적 관리
+- `.env` 파일 절대 커밋 금지 (Railway 환경변수로 관리)
+- DB 마이그레이션: `supabase/migrations/` 번호 순서 유지 (002 결번)

--- a/docs/conventions/cross-platform.md
+++ b/docs/conventions/cross-platform.md
@@ -1,0 +1,93 @@
+# 크로스 플랫폼 품질 규칙 (필수 준수)
+
+모든 UI 변경 시 데스크탑(Chrome), 모바일(iOS Safari, Android Chrome) 동일 품질을 보장해야 합니다.
+
+---
+
+## 1. 뷰포트 높이
+
+| 규칙 | 이유 |
+|------|------|
+| **`100vh` 사용 금지** | iOS Safari에서 주소창/하단바 포함 높이 계산 → 콘텐츠 가려짐 |
+| **`100dvh` 사용** | Dynamic Viewport Height — 실제 보이는 영역에 정확히 맞춤 |
+| `min-h-screen` 허용 | 페이지 전체 최소 높이 용도만 허용 |
+
+패턴:
+```css
+h-[calc(100dvh-7rem)]        /* 모바일 */
+md:h-[calc(100dvh-3.5rem)]   /* 데스크탑 */
+```
+
+---
+
+## 2. Safe Area (노치/홈바 대응)
+
+`src/app/layout.tsx`:
+```ts
+viewport: { viewportFit: "cover" }
+```
+
+`src/app/globals.css`:
+```css
+body { padding-top: env(safe-area-inset-top); }
+```
+
+- **하단 고정 요소**(MobileNav 등): 반드시 `pb-[env(safe-area-inset-bottom)]` 적용
+- 새로운 `position: fixed` bottom 요소 추가 시 safe area 패딩 필수
+
+---
+
+## 3. 터치 인터랙션
+
+`globals.css`에 전역 적용 (수정 금지):
+
+```css
+* { -webkit-tap-highlight-color: transparent; }
+button, a, input { touch-action: manipulation; }   /* 더블탭 줌 방지 */
+```
+
+- `overflow-x: clip` 사용 (`overflow-x: hidden` 대신 — iOS 스크롤 바운스 호환)
+
+---
+
+## 4. 포커스 관리
+
+```css
+:focus { outline: none; }
+:focus-visible { outline: 2px solid ...; }   /* 키보드만 표시 */
+```
+
+- `FocusReset` 컴포넌트가 페이지 전환 시 포커스 해제 + 스크롤 초기화 자동 처리
+- `<Link>`, `<button>` 클릭 후 포커스 잔류 → CSS 전역 처리로 해결됨
+
+---
+
+## 5. 스크롤 컨테이너
+
+`globals.css`에 전역 적용:
+```css
+.overflow-y-auto { -webkit-overflow-scrolling: touch; }
+```
+
+- `FocusReset`이 페이지 전환 시 내부 스크롤 컨테이너 `scrollTop = 0` 자동 초기화
+
+---
+
+## 6. 폼 입력 (iOS 대응)
+
+| 요소 | 규칙 |
+|------|------|
+| `input[type="date"]` | iOS Safari 네이티브 피커 호환, 텍스트 좌측 정렬 유지 |
+| `<select>` | `appearance-none` 사용 시 반드시 커스텀 화살표 아이콘(▼) 추가 |
+| 모든 입력 폼 | 키보드 올라올 때 `position: fixed` 요소가 가리지 않는지 확인 |
+
+---
+
+## 7. 검증 (E2E)
+
+크로스 플랫폼 규칙 위반은 `e2e/cross-platform.spec.ts`에서 자동 감지됩니다:
+- 콘솔 에러 (pageerror)
+- 이미지 로드 실패
+- 주요 링크 200 응답
+
+→ E2E 실행 가이드: [`docs/workflow/e2e-testing.md`](../workflow/e2e-testing.md)

--- a/docs/conventions/image-assets.md
+++ b/docs/conventions/image-assets.md
@@ -1,0 +1,82 @@
+# 이미지 에셋 규칙
+
+`public/images/` 하위 모든 이미지 에셋의 형식·생성·배치 규칙입니다.
+
+---
+
+## 1. 이미지 형식 요약
+
+| 유형 | 형식 | 위치 | 규격 |
+|------|------|------|------|
+| 캐릭터 (10명) | PNG 누끼 (투명 배경) | `characters/[id]/nukki/[mood].png` | 1408×768 |
+| 캐릭터 레거시 (2명) | JPG | `characters/[id]/[mood].jpg` | 1408×768 |
+| 카드 | SVG | `cards/major/`, `cards/cups/` 등 | — |
+| 배경 | JPG | `backgrounds/` | — |
+| 아이콘 | PNG RGBA (투명 배경) | `images/icons/` | 콘텐츠 크롭 |
+| 카드 스킨 | PNG/JPG | `images/skins/` | — |
+
+---
+
+## 2. 캐릭터 이미지 상세
+
+**10캐릭터** (arcana, hoshi, luna, rei, cairn, zero, haru, ren, lix, ethan):
+- PNG 누끼, `nukki/` 폴더 경로
+- 예: `/images/characters/arcana/nukki/default.png`
+- 6가지 mood: `default`, `smile`, `serious`, `surprised`, `wink`, `mystical`
+
+**2캐릭터 레거시** (miko, seonhwa):
+- JPG 루트 경로 (코드에서 직접 참조)
+- 예: `/images/characters/miko/default.jpg`
+- ⚠️ nukki PNG 미전환 — 이미지 재생성 + 코드 수정 필요
+
+---
+
+## 3. 아이콘 이미지 처리
+
+`public/images/icons/` — PNG RGBA (투명 배경)
+
+처리 방식:
+1. BFS 플러드 필로 어두운 배경 제거
+2. 콘텐츠 영역 크롭
+
+새 아이콘 추가 시 동일하게 처리: `scripts/generate-icons.ts`
+
+---
+
+## 4. Next.js `<Image>` sizes prop 필수 ⚠️
+
+`<Image fill>` 속성 사용 시 `sizes` prop 미설정 → 기본값 `100vw` → Mobile Android CI에서 이미지 로드 타임아웃 발생.
+
+```tsx
+// ❌ 금지
+<Image fill src={src} alt={alt} />
+
+// ✅ 올바른 패턴
+<Image
+  fill
+  src={src}
+  alt={alt}
+  sizes="(max-width: 640px) 50vw, (max-width: 1024px) 33vw, 25vw"
+/>
+```
+
+그리드 내 이미지, 캐릭터 이미지 등 `fill` 모드를 사용하는 모든 `<Image>`에 적용.
+
+---
+
+## 5. 이미지 생성 스크립트
+
+| 스크립트 | 용도 |
+|---------|------|
+| `scripts/generate-character-images-v2.mjs` | 신규 캐릭터 이미지 생성 (Grok 이미지 API) |
+| `scripts/generate-nukki-images.mjs` | 누끼(배경제거) 이미지 생성 |
+| `scripts/regenerate-all-nukki.mjs` | 전체 캐릭터 누끼 재생성 |
+| `scripts/generate-skin-images.ts` | 카드 스킨 이미지 생성 |
+| `scripts/upload-skin-images.ts` | 생성된 스킨 → Supabase Storage 업로드 |
+| `scripts/download-skin-images.ts` | Supabase Storage → `public/images/skins/` 다운로드 |
+| `scripts/generate-card-images.ts` | 카드 이미지 생성 |
+| `scripts/generate-backgrounds.ts` | 배경 이미지 생성 |
+| `scripts/generate-icons.ts` | 아이콘 이미지 생성 (BFS 배경 제거 + 크롭) |
+| `scripts/generate-placeholders.sh` | 플레이스홀더 이미지 생성 |
+
+> `scripts/generate-character-images.mjs` — 구버전, v2로 대체됨 (삭제 예정)

--- a/docs/conventions/layout-rules.md
+++ b/docs/conventions/layout-rules.md
@@ -1,0 +1,86 @@
+# 레이아웃 규칙 (필수 준수)
+
+캐릭터가 등장하는 **모든 페이지**에서 반드시 지켜야 하는 공통 레이아웃 규칙입니다.
+타로/사주 주제 선택 · 세션 · 결과 페이지, 캐릭터 상세 페이지, 향후 추가되는 모든 캐릭터 등장 페이지에 동일 적용됩니다.
+
+---
+
+## 1. 5:5 비율 레이아웃
+
+| 화면 | 구조 |
+|------|------|
+| **데스크탑(md 이상)** | 좌측 캐릭터 `md:w-1/2` + 우측 콘텐츠 `md:w-1/2` — 가로 5:5 flex |
+| **모바일(md 미만)** | `flex-col` 세로 배치 — 캐릭터 → 콘텐츠 순서 |
+
+---
+
+## 2. 캐릭터 이미지 블렌딩 (CSS mask 표준값)
+
+배경과 자연스럽게 블렌딩하기 위해 아래 표준값을 **반드시 그대로** 사용합니다. 수치 임의 변경 금지.
+
+```
+top:          transparent 0% → black 14%
+bottom:       transparent 0% → black 18%
+left / right: transparent 0% → black 10%
+```
+
+구현 패턴 (`CharacterDisplay.tsx` 기준):
+
+```tsx
+style={{
+  WebkitMaskImage: [
+    "linear-gradient(to bottom, transparent 0%, black 14%, black 100%)",
+    "linear-gradient(to top,    transparent 0%, black 18%, black 100%)",
+    "linear-gradient(to right,  transparent 0%, black 10%, black 100%)",
+    "linear-gradient(to left,   transparent 0%, black 10%, black 100%)",
+  ].join(", "),
+  WebkitMaskComposite: "destination-in, destination-in, destination-in",
+  maskImage: "...(동일)",
+  maskComposite: "intersect, intersect, intersect",
+}}
+```
+
+- `CharacterDisplay` 컴포넌트 사용 시 자동 적용됨
+- 직접 `<Image>`를 쓸 때: 이 스타일을 래퍼 `div`에 직접 적용
+
+---
+
+## 3. 컴포넌트 조합
+
+캐릭터 등장 UI의 표준 조합:
+
+```tsx
+<CharacterDisplay character={character} mood={mood} />
+<TypingDialogue text={dialogue} />
+```
+
+- `CharacterDisplay`: 이미지 + 블렌딩 처리 일체화
+- `TypingDialogue`: 한 글자씩 타이핑 효과 + SSE 스트리밍 연동
+
+---
+
+## 4. 모바일 캐릭터 영역 높이
+
+캐릭터 등장 페이지의 모바일 캐릭터 영역: **`h-[25%]`** 통일
+
+콘텐츠 영역: **`overflow-y-auto`** 필수 (뷰포트 내 스크롤 보장)
+
+```tsx
+// 모바일 캐릭터 영역
+<div className="h-[25%] md:h-auto md:w-1/2">
+  <CharacterDisplay ... />
+</div>
+
+// 콘텐츠 영역
+<div className="flex-1 overflow-y-auto md:w-1/2">
+  {/* 콘텐츠 */}
+</div>
+```
+
+---
+
+## 5. 위반 시 영향
+
+- 5:5 비율 미준수 → 데스크탑에서 캐릭터/콘텐츠 불균형
+- CSS mask 수치 변경 → 배경 블렌딩 이질감 (Mobile iOS에서 더 눈에 띔)
+- `overflow-y-auto` 누락 → 모바일에서 콘텐츠 잘림

--- a/docs/conventions/zod-schemas.md
+++ b/docs/conventions/zod-schemas.md
@@ -1,0 +1,84 @@
+# Zod 스키마 컨벤션 및 API 입력 검증
+
+---
+
+## 1. `null` vs `undefined` 규칙 ⚠️ 중요
+
+> 2026-04-24 타로 리딩 전체 불능 장애의 원인이었습니다.
+
+`JSON.stringify`의 동작 차이:
+- `null` → 직렬화됨 (`{"field": null}`)
+- `undefined` → 제거됨 (`{}`)
+
+| 상황 | Zod 규칙 |
+|------|---------|
+| Zustand store 초기값이 `null`인 필드 | `.nullish()` 사용 |
+| `undefined`만 올 수 있는 필드 | `.optional()` 사용 |
+| 둘 다 올 수 있는 필드 | `.nullish()` 사용 |
+
+잘못 사용하면 프로덕션에서만 400 오류 발생 (로컬 빌드·lint·tsc는 모두 통과).
+
+---
+
+## 2. API 스키마 필수 적용
+
+새 API 라우트 추가 시:
+1. `src/lib/validation/api-schemas.ts`에 Zod 스키마 먼저 정의
+2. `safeParse()` 검증 후 로직 진행
+3. **타입 단언 (`as { ... }`) 사용 금지**
+
+```ts
+// ✅ 올바른 패턴
+const result = schema.safeParse(await request.json());
+if (!result.success) {
+  return NextResponse.json({ error: "Invalid input" }, { status: 400 });
+}
+const { field1, field2 } = result.data;
+
+// ❌ 금지 패턴
+const body = await request.json() as { field1: string };
+```
+
+---
+
+## 3. 기존 스키마 목록
+
+`src/lib/validation/api-schemas.ts` — 7종:
+
+| 스키마 | 용도 |
+|--------|------|
+| `TarotReadingSchema` | 타로 리딩 요청 |
+| `SajuReadingSchema` | 사주 리딩 요청 |
+| `ShinjeomMessageSchema` | 신점 메시지 요청 |
+| `TarotSessionSchema` | 타로 세션 생성 |
+| `SajuSessionSchema` | 사주 세션 생성 |
+| `ShinjeomSessionSchema` | 신점 세션 생성 |
+| `DailyCardSchema` | 일일 카드 요청 |
+
+---
+
+## 4. SSR 비결정 값 금지
+
+`"use client"` 컴포넌트에서 React error #418(hydration mismatch) 방지:
+
+```ts
+// ❌ 금지 — SSR·CSR 불일치
+const [date, setDate] = useState(new Date());
+return <div>{date.toLocaleDateString()}</div>;
+
+// ✅ 올바른 패턴
+const [date, setDate] = useState<Date | null>(null);
+useEffect(() => setDate(new Date()), []);
+return <div>{date?.toLocaleDateString() ?? ""}</div>;
+```
+
+`new Date()`, `Math.random()` 등 비결정 값은 반드시 `useEffect` 내에서만 호출.
+초기값은 `""` / `0` / `[]` / `null` 등 안전한 상수로 설정.
+
+---
+
+## 5. SonarCloud 테스트 리포트 주의
+
+`sonar.testExecutionReportPaths`는 SonarCloud 전용 `<testExecutions version="1">` XML 형식만 허용 — Vitest/Playwright의 표준 JUnit `<testsuites>` 포맷과 **비호환**.
+
+커버리지: `sonar.javascript.lcov.reportPaths` (lcov 포맷만 사용)

--- a/docs/workflow/task-playbooks.md
+++ b/docs/workflow/task-playbooks.md
@@ -1,0 +1,118 @@
+# 업무 유형별 파일 가이드 (Task Playbooks)
+
+반복 업무 시 불필요한 탐색 없이 바로 시작할 수 있도록 유형별 필수 파일을 정리합니다.
+에이전트가 있는 경우 에이전트를 **우선 활용**합니다.
+
+---
+
+## 새 캐릭터 추가
+
+1. `src/data/characters/index.ts` — 캐릭터 메타데이터 추가
+2. `src/data/characters/waiting-lines.ts` — 대기 대사 추가
+3. `src/types/character.ts` — 타입 확인
+4. `public/images/characters/[id]/nukki/` — 이미지 6종 배치
+5. → `.claude/agents/character-add.md` 에이전트 활용
+
+참고: [`docs/architecture/data-model.md`](../architecture/data-model.md) — 캐릭터 이미지 경로 규칙
+
+---
+
+## 새 운세 서비스(DivinationService) 추가
+
+1. `src/services/core/ai-provider.ts` — 인터페이스 확인
+2. `src/services/tarot/tarot-service.ts` — 기존 구현체 참조 패턴
+3. `src/app/api/tarot/` — API 라우트 구조 참조
+4. → `.claude/agents/divination-scaffold.md` 에이전트 활용
+
+---
+
+## 새 페이지 추가
+
+1. `src/app/layout.tsx` — 루트 레이아웃 확인
+2. `src/components/layout/Header.tsx` — 네비게이션 링크 추가
+3. `src/components/layout/MobileNav.tsx` — 모바일 탭 추가 여부 확인
+4. [`docs/conventions/layout-rules.md`](../conventions/layout-rules.md) — 5:5 규칙 준수
+5. → `.claude/agents/page-builder.md` 에이전트 활용
+
+---
+
+## 테마·스타일 변경
+
+1. `src/app/globals.css` — `@theme` 블록, `arcana-*` 커스텀 컬러
+2. `src/hooks/useTheme.ts` — 7종 테마 로직
+3. → `.claude/agents/theme-creator.md` 에이전트 활용
+
+---
+
+## 카드 스킨 추가·변경
+
+1. `src/data/skins/index.ts` — 스킨 정의
+2. `src/lib/storage/index.ts` — `getCardImageUrl()` 경로 로직
+3. `scripts/generate-skin-images.ts` → `scripts/upload-skin-images.ts`
+4. → `.claude/agents/skin-manager.md` 에이전트 활용
+
+---
+
+## AI 프롬프트 수정
+
+1. `src/services/core/prompt-builder.ts` — 공통 프롬프트 빌더
+2. `src/services/[service]/[service]-service.ts` — 서비스별 프롬프트
+3. `src/services/core/fallback-provider.ts` — Grok→Claude fallback 동작 확인
+
+참고: [`docs/architecture/ai-infrastructure.md`](../architecture/ai-infrastructure.md)
+
+---
+
+## DB 스키마 변경
+
+1. `supabase/migrations/` — 마지막 번호 확인 후 다음 번호로 신규 파일 생성
+2. `src/lib/db/schema/index.ts` — Drizzle 스키마 동기화 (PostgreSQL 모드)
+3. `src/lib/db/types.ts` — DbClient 인터페이스 수정 여부 확인
+
+참고: [`docs/architecture/db-abstraction.md`](../architecture/db-abstraction.md)
+
+---
+
+## 코드 품질 검증
+
+```bash
+pnpm type-check && pnpm lint && pnpm build
+```
+
+→ `.claude/agents/quality-gate.md` 에이전트 활용
+
+---
+
+## E2E 테스트 추가·수정
+
+1. `e2e/` — 관련 spec 파일
+2. `playwright.config.ts` — 디바이스 프로필 확인
+3. [`docs/workflow/e2e-testing.md`](e2e-testing.md) — 실행 방법 + 셀렉터 패턴
+
+**Mobile Android 셀렉터 주의사항** (오탐 패턴):
+
+| 패턴 | 문제 | 해결 |
+|------|------|------|
+| `page.locator("img").first()` | Header 아이콘(hidden) 먼저 resolve | `img[src*="keyword"]` 사용 |
+| `text=타로` (짧은 텍스트) | Header/MobileNav hidden 링크 먼저 resolve | `h1`, `h2` 또는 전체 레이블 사용 |
+| `overflow-y-auto` 내 요소 | 스크롤 밖이면 `toBeVisible()` hidden 판정 | 상단 헤딩 체크 또는 `scrollIntoViewIfNeeded()` |
+| `<Image fill>` lazy-loaded 이미지 | off-viewport → `naturalWidth === 0` | `getBoundingClientRect`으로 교차 여부 확인 |
+
+Next.js `<Image>` DOM 렌더링: `/_next/image?url=%2Fpath` → `src*="/path/"` 슬래시 포함 매칭 불가, `src*="keyword"`로 한정.
+
+---
+
+## 새 API 라우트 추가
+
+1. [`docs/conventions/zod-schemas.md`](../conventions/zod-schemas.md) — Zod 스키마 먼저 정의 필수
+2. [`docs/architecture/auth-abstraction.md`](../architecture/auth-abstraction.md) — API 보안 패턴 (Rate Limit → Zod → Auth → IDOR)
+3. `src/lib/validation/api-schemas.ts` — 스키마 추가
+4. `src/__tests__/api/` — 단위 테스트 배치 (주의: `src/app/api/` 내 테스트 파일은 수집 불가)
+
+---
+
+## 환경변수 추가
+
+1. `src/lib/env.ts` — getter 함수 추가 (하드코딩 금지)
+2. `docs/operations/env-variables.md` — 문서화 (미생성 시 PR-4에서 생성 예정)
+3. `scripts/check-env-docs.ts` — 정합성 자동 검증

--- a/docs/workflow/unit-testing.md
+++ b/docs/workflow/unit-testing.md
@@ -1,0 +1,143 @@
+# 단위 테스트 가이드
+
+Vitest 기반 단위 테스트 작성 패턴과 주의사항입니다.
+
+---
+
+## 1. 테스트 현황
+
+- **539개 테스트** / 95%+ 커버리지
+- **Vitest 2.0** (node env, v8 coverage)
+- 임계값: `statements 60%` (PR E에서 상향 예정)
+
+```bash
+pnpm test:coverage    # 테스트 실행 + 커버리지 리포트
+```
+
+---
+
+## 2. 테스트 파일 배치 규칙
+
+### 일반 모듈 테스트
+
+`*.test.ts` 파일은 소스 파일 옆에 배치:
+```
+src/lib/env.ts
+src/lib/env.test.ts       ← 같은 디렉토리
+```
+
+### API 라우트 테스트 ⚠️ 중요
+
+`vitest.config.ts`의 `exclude: ["src/app/**"]` 설정이 테스트 파일도 제외합니다.
+
+```
+src/app/api/tarot/reading/route.test.ts  ← ❌ 수집 불가
+src/__tests__/api/tarot-reading.test.ts  ← ✅ 여기에 배치
+```
+
+import 방식:
+```ts
+// ✅ 절대 경로로 import
+import { POST } from "@/app/api/tarot/reading/route";
+```
+
+현재 `src/__tests__/api/` 파일 목록 (10개):
+- `tarot-session.test.ts` (13개), `saju-session.test.ts` (11개), `shinjeom-session.test.ts` (11개)
+- `tarot-result.test.ts` (4개), `saju-result.test.ts` (4개)
+- `tarot-reading.test.ts` (6개), `saju-reading.test.ts` (5개), `shinjeom-message.test.ts` (5개)
+- `favorite-character.test.ts` (5개), `daily-card.test.ts` (6개)
+
+---
+
+## 3. `vi.doMock` factory 누출 방지 ⚠️
+
+`vi.doMock`으로 등록한 mock factory는 `vi.resetModules()` 후에도 **유지됩니다**.
+
+문제: 이전 테스트가 rate-limit mock을 `false`로 설정하면 다음 테스트로 누출됨.
+
+해결: `setup()` 내부에 rate-limit 통과 mock을 반드시 포함:
+
+```ts
+// ❌ 위험 — rate-limit mock 누락 시 이전 테스트의 false 값이 누출
+async function setup() {
+  vi.doMock("@/lib/auth/index", () => makeAuthMock());
+  await vi.importActual("@/app/api/tarot/reading/route");
+}
+
+// ✅ 안전 — setup마다 rate-limit 통과 mock 명시
+async function setup() {
+  vi.doMock("@/lib/rate-limit", () => ({
+    checkRateLimit: vi.fn().mockReturnValue({ allowed: true }),
+  }));
+  vi.doMock("@/lib/auth/index", () => makeAuthMock());
+  await vi.importActual("@/app/api/tarot/reading/route");
+}
+```
+
+---
+
+## 4. 테스트 헬퍼 (`src/test-helpers/`)
+
+| 파일 | 제공 함수 |
+|------|---------|
+| `mock-db.ts` | `makeMockDb()` — DbClient mock 팩토리 |
+| `mock-auth.ts` | `makeAuthMock()` — getCurrentUser/requireUser/assertReadingAccess mock |
+| `mock-request.ts` | `makePostRequest()` — NextRequest POST 헬퍼 |
+| `mock-ai.ts` | `makeMockAiModule()`, `makeMockVerum()`, `readSSEStream()` |
+| `reset-modules.ts` | `setupDoMock()` — `beforeEach(vi.resetModules)` 등록 유틸 |
+
+### setupDoMock() 패턴
+
+```ts
+import { setupDoMock } from "@/test-helpers/reset-modules";
+
+describe("API 테스트", () => {
+  setupDoMock();  // beforeEach(vi.resetModules) 자동 등록
+
+  it("성공 케이스", async () => {
+    // setup() 호출 → 각 테스트마다 깨끗한 mock
+    const { POST } = await setup();
+    ...
+  });
+});
+```
+
+---
+
+## 5. Verum 테스트 격리
+
+`src/lib/verum/` 테스트에서는 반드시 `beforeEach`에서 `resetVerumClientForTests()` 호출:
+
+```ts
+import { resetVerumClientForTests } from "@/lib/verum/resolver";
+
+beforeEach(() => {
+  resetVerumClientForTests();
+});
+```
+
+---
+
+## 6. 커버리지 임계값
+
+`vitest.config.ts`:
+```ts
+coverage: {
+  thresholds: {
+    statements: 60,  // PR E에서 branches 65/functions 75/lines 75로 상향 예정
+  }
+}
+```
+
+임계값 변경 시 PR 설명에 근거 명시 필수.
+
+---
+
+## 7. CLAUDE.md 테스트 수 동기화
+
+테스트가 추가/삭제될 때마다 CLAUDE.md의 테스트 수를 동기화합니다:
+
+```bash
+pnpm exec tsx scripts/sync-test-count.ts          # CLAUDE.md 자동 갱신
+pnpm exec tsx scripts/sync-test-count.ts --check  # CI 모드: 불일치 시 exit 1
+```


### PR DESCRIPTION
## Summary

문서 아키텍처 재편 5-PR 계획의 **PR-3** — CLAUDE.md 각 섹션을 카테고리별 독립 문서로 분리합니다.

### 신설 파일 (12개)

**`docs/architecture/`** (5개):
- `system-overview.md` — 서비스 흐름(타로/사주/신점 단계별), 주제 21개, 홈 구성
- `ai-infrastructure.md` — Verum + FallbackProvider 2단 레이어, SSE, 폴더 로드맵
- `db-abstraction.md` — DB_PROVIDER 추상화, 마이그레이션 목록, share_token 정책
- `auth-abstraction.md` — Auth 공통 함수, API 보안 패턴(Rate→Zod→Auth→IDOR)
- `data-model.md` — 캐릭터 12명, 표정 규칙, 이미지 경로 규칙, 카드·스프레드·스킨

**`docs/conventions/`** (5개):
- `coding-style.md` — TS/React 컨벤션, 의존성 버전 관리, 커밋 prefix
- `layout-rules.md` — 5:5 레이아웃, CSS mask 표준값
- `cross-platform.md` — 100dvh, safe-area, 터치/포커스, iOS 대응
- `zod-schemas.md` — null vs undefined 규칙, API 스키마 필수 적용
- `image-assets.md` — 형식·규격, Image fill sizes prop 필수

**`docs/workflow/`** (2개):
- `task-playbooks.md` — 업무 유형별 필수 파일 가이드 (8가지 패턴)
- `unit-testing.md` — vi.doMock 누출 방지, API 라우트 테스트 경로

**`docs/README.md`** 인덱스 테이블 + 폴더 트리 업데이트 (19행 → 새 파일 모두 포함)

### CLAUDE.md는 이번 PR에서 변경 없음

내용 중복은 허용 (PR-5에서 250줄로 압축 시 정리 예정)

## Test Plan

- [x] `pnpm type-check` — 통과
- [x] `pnpm lint` — 통과
- [x] `scripts/check-doc-links.ts` — 경고 14개 → 4개 (나머지 4개는 PR-4 예정 파일, 의도된 상태)
- [x] 새 파일 내 상대 링크 수동 확인

## 연관 PR

- PR-1 (#124) ✅ — docs 인덱스·known-issues·3개 스크립트
- PR-2 (#125) ✅ — 고아 문서 이동
- **PR-3 (이 PR)** — 아키텍처·컨벤션·워크플로우 문서 분할
- PR-4 (pending) — 워크플로우 완성 + process.md 분해
- PR-5 (pending) — CLAUDE.md 250줄 재작성 + CI enforce

🤖 Generated with [Claude Code](https://claude.com/claude-code)