### PR TITLE
docs: 워크플로우·운영 문서 완성 + process.md 분해 후 archive 이동 (PR-4/5)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -26,6 +26,8 @@ CLAUDE.md는 포인터(≤250줄)만 유지하며, 각 주제의 정본은 이 �
 | 운영자 가이드 | [operations/operation-guide.md](operations/operation-guide.md) |
 | 미구현/기술부채 | [operations/known-issues.md](operations/known-issues.md) |
 | 배포/롤백 절차 | [operations/deployment.md](operations/deployment.md) |
+| 모니터링·QA·n8n | [operations/monitoring.md](operations/monitoring.md) |
+| 내부 흐름도 아카이브 | [archive/process-diagrams.md](archive/process-diagrams.md) |
 
 ## 폴더 구조
 
@@ -38,20 +40,29 @@ docs/
 │   ├── db-abstraction.md
 │   ├── auth-abstraction.md
 │   └── data-model.md
-├── workflow/                   # "어떻게 변경하는가" (PR-3 일부, PR-4에서 완성)
-│   ├── e2e-testing.md          # ✅ PR-2
-│   ├── unit-testing.md         # ✅ PR-3
-│   └── task-playbooks.md       # ✅ PR-3
+├── workflow/                   # "어떻게 변경하는가" ✅ PR-4 완성
+│   ├── e2e-testing.md          # PR-2
+│   ├── unit-testing.md         # PR-3
+│   ├── task-playbooks.md       # PR-3
+│   ├── code-change-process.md  # PR-4
+│   └── ci-cd.md                # PR-4
 ├── conventions/                # "어떻게 작성하는가" ✅ PR-3 완성
 │   ├── coding-style.md
 │   ├── layout-rules.md
 │   ├── cross-platform.md
 │   ├── zod-schemas.md
 │   └── image-assets.md
-├── operations/                 # "운영하는 법"
-│   └── known-issues.md         # 미구현 기능 + 기술 부채 (PR-1에서 신설)
-└── archive/                    # "역사적 자료" (PR-2/4에서 채움)
+├── operations/                 # "운영하는 법" ✅ PR-4 완성
+│   ├── known-issues.md         # PR-1
+│   ├── operation-guide.md      # PR-2 (이동)
+│   ├── env-variables.md        # PR-4
+│   ├── deployment.md           # PR-4
+│   └── monitoring.md           # PR-4
+└── archive/                    # "역사적 자료" ✅ PR-4 완성
+    ├── skills-original.md      # PR-2 (이동)
+    ├── ai-quality-roadmap.md   # PR-2 (이동)
+    └── process-diagrams.md     # PR-4 (process.md 분해)
 ```
 
-> **채움 일정**: PR-1(known-issues) → PR-2(archive 이동) → PR-3(architecture/conventions/workflow 분할)
-> → PR-4(workflow/operations 완성) → PR-5(CLAUDE.md 250줄 축약)
+> **완성 현황**: PR-1(known-issues) → PR-2(archive 이동) → PR-3(architecture/conventions 분할)
+> → PR-4(workflow/operations 완성 + process.md 분해) → PR-5(CLAUDE.md 250줄 축약)

--- a/docs/archive/process-diagrams.md
+++ b/docs/archive/process-diagrams.md
@@ -1,4 +1,9 @@
-# ArcanaInsight — 내부 프로세스 흐름도
+# ArcanaInsight — 내부 프로세스 흐름도 (아카이브)
+
+> **원본 위치**: 프로젝트 루트 `process.md` (PR-4에서 분해 후 삭제됨)
+> **최신 아키텍처 설명**: [`../architecture/system-overview.md`](../architecture/system-overview.md), [`../architecture/ai-infrastructure.md`](../architecture/ai-infrastructure.md)
+
+---
 
 ## 전체 서비스 아키텍처
 
@@ -463,30 +468,7 @@ sequenceDiagram
 
 ---
 
-## 파일 구조 → 흐름 매핑
-
-| 흐름 단계 | 주요 파일 |
-|---|---|
-| **홈 페이지** | `src/app/page.tsx`, `src/components/home/*` |
-| **인증** | `src/app/auth/login/page.tsx`, `src/lib/supabase/*` |
-| **타로 선택** | `src/app/tarot/page.tsx` |
-| **타로 세션** | `src/app/tarot/session/page.tsx` |
-| **타로 API** | `src/app/api/tarot/session/route.ts`, `src/app/api/tarot/reading/route.ts` |
-| **타로 결과 공유** | `src/app/tarot/result/[id]/page.tsx` |
-| **사주 선택** | `src/app/saju/page.tsx` |
-| **사주 세션** | `src/app/saju/session/page.tsx` |
-| **사주 API** | `src/app/api/saju/session/route.ts`, `src/app/api/saju/reading/route.ts` |
-| **AI 프롬프트** | `src/services/core/prompt-builder.ts`, `src/services/saju/saju-service.ts` |
-| **AI 호출** | `src/services/core/grok-provider.ts` |
-| **응답 정리** | `src/services/core/text-cleaner.ts` |
-| **사주 계산** | `src/services/saju/saju-calculator.ts` |
-| **카드 데이터** | `src/data/cards/*`, `src/data/spreads/*` |
-| **캐릭터 데이터** | `src/data/characters/*` |
-| **상태 관리** | `src/hooks/useSession.ts`, `src/hooks/useSajuSession.ts`, `src/hooks/useCharacter.ts` |
-
----
-
-## 코드 변경 및 배포 프로세스 (표준)
+## 코드 변경 및 배포 프로세스
 
 ```mermaid
 flowchart TD
@@ -558,3 +540,26 @@ flowchart LR
     style Claude fill:#1a1a2e,stroke:#7c3aed,color:#fff
     style SPEC fill:#d97706,color:#fff
 ```
+
+---
+
+## 파일 구조 → 흐름 매핑
+
+| 흐름 단계 | 주요 파일 |
+|---|---|
+| **홈 페이지** | `src/app/page.tsx`, `src/components/home/*` |
+| **인증** | `src/app/auth/login/page.tsx`, `src/lib/supabase/*` |
+| **타로 선택** | `src/app/tarot/page.tsx` |
+| **타로 세션** | `src/app/tarot/session/page.tsx` |
+| **타로 API** | `src/app/api/tarot/session/route.ts`, `src/app/api/tarot/reading/route.ts` |
+| **타로 결과 공유** | `src/app/tarot/result/[id]/page.tsx` |
+| **사주 선택** | `src/app/saju/page.tsx` |
+| **사주 세션** | `src/app/saju/session/page.tsx` |
+| **사주 API** | `src/app/api/saju/session/route.ts`, `src/app/api/saju/reading/route.ts` |
+| **AI 프롬프트** | `src/services/core/prompt-builder.ts`, `src/services/saju/saju-service.ts` |
+| **AI 호출** | `src/services/core/grok-provider.ts` |
+| **응답 정리** | `src/services/core/text-cleaner.ts` |
+| **사주 계산** | `src/services/saju/saju-calculator.ts` |
+| **카드 데이터** | `src/data/cards/*`, `src/data/spreads/*` |
+| **캐릭터 데이터** | `src/data/characters/*` |
+| **상태 관리** | `src/hooks/useSession.ts`, `src/hooks/useSajuSession.ts`, `src/hooks/useCharacter.ts` |

--- a/docs/operations/deployment.md
+++ b/docs/operations/deployment.md
@@ -1,0 +1,88 @@
+# Railway 배포 가이드
+
+ArcanaInsight는 Railway를 사용하여 자동 배포됩니다.
+
+---
+
+## 자동 배포 흐름
+
+```
+PR 머지 → main push → Railway 자동 빌드 → 배포 완료 (약 2~3분)
+```
+
+Railway는 `main` 브랜치의 모든 push에 자동으로 반응합니다. 수동 배포 트리거는 필요하지 않습니다.
+
+---
+
+## 설정 파일
+
+- `railway.toml` — 빌드/배포 설정 (nixpacks 빌더)
+- `.github/workflows/deploy.yml` — PR CI 워크플로우 (Railway 배포 전 게이트)
+
+### GitHub Secrets (필수)
+
+| Secret | 설명 |
+|--------|------|
+| `RAILWAY_TOKEN` | Railway API 토큰 |
+| `RAILWAY_SERVICE_ID` | Railway 서비스 ID |
+
+---
+
+## 롤백 방법
+
+### 즉시 롤백 (이전 빌드)
+
+Railway 대시보드 → 서비스 선택 → Deployments 탭 → 이전 배포 클릭 → "Redeploy"
+
+### DB_PROVIDER 롤백 (재배포 불필요)
+
+PostgreSQL → Supabase 즉시 전환:
+```
+Railway 환경변수: DB_PROVIDER=supabase (또는 변수 삭제)
+→ 저장 즉시 적용 (재배포 없이 즉시 동작)
+```
+
+### 코드 롤백 (git revert)
+
+```bash
+git revert <commit-hash>
+git push origin main
+# → Railway 자동 재배포
+```
+
+---
+
+## 환경변수 관리
+
+- 모든 환경변수는 Railway 대시보드에서 관리
+- `.env` 파일은 절대 커밋하지 않음
+- 전체 환경변수 목록: [`env-variables.md`](env-variables.md)
+
+---
+
+## 빌드 실패 대응
+
+1. Railway 대시보드 → Build Logs 확인
+2. 로컬에서 `pnpm build` 재현 시도
+3. 주요 원인:
+   - TypeScript 타입 오류 (PR CI에서 차단되어야 하나 누락 시)
+   - 환경변수 누락 (`src/lib/env.ts` getter가 런타임에 throw)
+   - Next.js 빌드 타임 API 호출 실패
+
+---
+
+## 서비스 헬스 체크
+
+```bash
+# 배포 상태 확인 (Railway CLI)
+railway status
+
+# 로그 스트리밍
+railway logs --tail
+```
+
+---
+
+## CI/CD 파이프라인 상세
+
+→ [`../workflow/ci-cd.md`](../workflow/ci-cd.md)

--- a/docs/operations/env-variables.md
+++ b/docs/operations/env-variables.md
@@ -1,0 +1,116 @@
+# 환경변수 목록
+
+`src/lib/env.ts`의 getter 함수와 대응하는 전체 환경변수 목록입니다.
+환경변수는 코드에 하드코딩 금지 — 반드시 `src/lib/env.ts`의 getter 함수를 통해 접근합니다.
+
+---
+
+## Supabase 모드 (현재 기본값)
+
+`DB_PROVIDER=supabase` 또는 미설정 시 Supabase가 기본값입니다.
+
+### 필수 변수
+
+| 변수 | 설명 | 예시 |
+|------|------|------|
+| `GROK_API_KEY` | xAI Grok API 키 (1순위 AI) | `xai-...` |
+| `NEXT_PUBLIC_SUPABASE_URL` | Supabase 프로젝트 URL | `https://xxx.supabase.co` |
+| `NEXT_PUBLIC_SUPABASE_ANON_KEY` | Supabase 익명 키 | `eyJ...` |
+| `SUPABASE_SERVICE_ROLE_KEY` | Supabase 서비스 키 (서버 전용) | `eyJ...` |
+| `NEXT_PUBLIC_SITE_URL` | 사이트 URL | `https://arcana.example.com` |
+
+### 선택 변수
+
+| 변수 | 설명 | 기본값 |
+|------|------|--------|
+| `DB_PROVIDER` | DB 공급자 선택 | `supabase` |
+| `GROK_MODEL` | Grok 텍스트 생성 모델 | `grok-3` |
+| `ANTHROPIC_API_KEY` | Anthropic Claude API 키 (Grok 장애 시 자동 fallback) | 미설정 시 Grok 단독 사용 |
+
+---
+
+## PostgreSQL 모드 (온프레미스 전환 시)
+
+`DB_PROVIDER=postgres` 설정 시 활성화됩니다.
+
+### 필수 변수 (postgres 모드 전용)
+
+| 변수 | 설명 | 예시 |
+|------|------|------|
+| `DB_PROVIDER` | DB 공급자 선택 | `postgres` |
+| `POSTGRES_URL` | PostgreSQL 연결 문자열 | `postgresql://user:pass@host:5432/arcana` |
+| `NEXTAUTH_SECRET` | NextAuth.js 세션 암호화 키 | `openssl rand -base64 32` |
+| `NEXTAUTH_URL` | 프로덕션 사이트 URL | `https://arcana.example.com` |
+| `GOOGLE_CLIENT_ID` | Google OAuth 클라이언트 ID | 기존 Supabase OAuth 재사용 가능 |
+| `GOOGLE_CLIENT_SECRET` | Google OAuth 클라이언트 시크릿 | 기존 Supabase OAuth 재사용 가능 |
+
+### 선택 변수 (postgres 모드)
+
+| 변수 | 설명 | 기본값 |
+|------|------|--------|
+| `POSTGRES_POOL_SIZE` | DB 커넥션 풀 크기 | `10` |
+
+> **Google Cloud Console**: PostgreSQL 모드 사용 시 Authorized redirect URI에 `{NEXTAUTH_URL}/api/auth/callback/google` 추가 필요.
+
+---
+
+## Verum (선택 — AI 프롬프트 A/B 테스트)
+
+미설정 시 로컬 기본 프롬프트 사용 (안전한 기본값). 장애 시 서킷 브레이커가 자동 격리합니다.
+
+| 변수 | 설명 | 예시/기본값 |
+|------|------|-------------|
+| `VERUM_API_URL` | Verum 서버 URL | `https://verum-production.up.railway.app` |
+| `VERUM_API_KEY` | Verum 대시보드 DEPLOY 후 발급 | — |
+| `VERUM_DEPLOYMENT_ID` | Verum 대시보드 DEPLOY 후 발급 | — |
+| `VERUM_TIMEOUT_MS` | config 조회 타임아웃 | `3000` |
+| `VERUM_RECORD_TIMEOUT_MS` | trace 기록 타임아웃 | `5000` |
+| `VERUM_FAILURE_COOLDOWN_MS` | 5xx/timeout 후 서킷 쿨다운 | `60000` |
+| `VERUM_AUTH_COOLDOWN_MS` | 401/403 후 서킷 쿨다운 | `1800000` (30분) |
+
+---
+
+## AI 공급자 튜닝 (선택)
+
+미설정 시 기본값을 사용합니다.
+
+| 변수 | 설명 | 기본값 |
+|------|------|--------|
+| `GROK_BASE_URL` | Grok API 엔드포인트 | `https://api.x.ai/v1` |
+| `CLAUDE_MODEL` | Claude 모델 ID | `claude-opus-4-5` |
+| `CLAUDE_BASE_URL` | Claude API 엔드포인트 오버라이드 | SDK 내장값 |
+| `AI_TIMEOUT_MS` | AI 스트림 타임아웃 | `30000` |
+| `AI_DEFAULT_MAX_TOKENS` | AI 응답 최대 토큰 | `16000` |
+| `AI_TEMPERATURE` | AI 온도 파라미터 | `0.7` |
+| `AI_FALLBACK_COOLDOWN_MS` | Fallback 쿨다운 — 5xx/network | `300000` (5분) |
+| `AI_AUTH_COOLDOWN_MS` | Fallback 쿨다운 — 401/403 | `1800000` (30분) |
+
+---
+
+## 전환 방법
+
+```bash
+# Supabase → PostgreSQL 전환 (Railway 환경변수에서)
+DB_PROVIDER=postgres
+POSTGRES_URL=postgresql://...
+NEXTAUTH_SECRET=...
+NEXTAUTH_URL=...
+GOOGLE_CLIENT_ID=...
+GOOGLE_CLIENT_SECRET=...
+# 저장 후 즉시 적용 (재배포 불필요)
+
+# PostgreSQL → Supabase 롤백
+DB_PROVIDER=supabase
+# 또는 DB_PROVIDER 변수 삭제
+```
+
+---
+
+## 관련 파일
+
+- `src/lib/env.ts` — 모든 getter 함수 정의 (16개)
+- `src/lib/auth/index.ts` — DB_PROVIDER 기반 auth 전환
+- `src/lib/db/index.ts` — DB_PROVIDER 기반 DB 전환
+- `src/lib/storage/index.ts` — DB_PROVIDER 기반 이미지 URL 전환
+- [`../architecture/db-abstraction.md`](../architecture/db-abstraction.md) — DB 추상화 상세
+- [`../architecture/auth-abstraction.md`](../architecture/auth-abstraction.md) — Auth 추상화 상세

--- a/docs/operations/monitoring.md
+++ b/docs/operations/monitoring.md
@@ -1,0 +1,89 @@
+# 모니터링 및 자동화
+
+주간 QA 루프와 n8n 자동화 파이프라인 설명입니다.
+
+---
+
+## 주간 QA 자동 루프
+
+### 흐름
+
+```
+매주 토요일 09:00 KST (weekly-qa.yml)
+  └─ E2E 3개 디바이스: Desktop Chrome + Mobile Android + Mobile iOS
+       ├─ 전체 통과: 정상 종료
+       └─ 일부 실패: GitHub Issue 자동 생성 (title: "🚨 Weekly QA Failed", label: qa-failure)
+            └─ main push 감지 시 (qa-recheck.yml 자동 트리거)
+                 └─ E2E 재실행 (동일 3개 디바이스)
+                      ├─ 전체 통과: Issue 자동 닫기 + 코멘트
+                      └─ 일부 실패: Issue 유지 (수동 조치 필요)
+```
+
+### QA 실패 시 대응 절차
+
+1. 자동 생성된 GitHub Issue 확인
+2. 실패한 spec 파일 + 디바이스 조합 파악
+3. 로컬에서 재현: `pnpm test:e2e --grep "실패한 테스트명"`
+4. 수정 후 `fix/*` 브랜치에서 PR 생성
+5. PR 머지 → `qa-recheck.yml` 자동 재실행 → Issue 자동 닫기
+
+### Artifact 보존
+
+- PR CI: E2E 실패 시 스크린샷·비디오 90일 보존
+- 주간 QA: 전체 결과 30일 보존
+
+---
+
+## n8n 자동화 파이프라인
+
+### 현황
+
+n8n Cloud 운영 중: `https://xzawed.app.n8n.cloud`
+
+| 워크플로우 | 파일 | 방식 | 상태 |
+|-----------|------|------|------|
+| Spec Tracker | `n8n/workflow-spec-tracker.json` | GitHub Webhook (실시간) | ✅ 운영 중 |
+| Quality Monitor | `n8n/workflow-quality-monitor.json` | Cron 매일 09:00 | ✅ 운영 중 |
+| Weekly Report | `n8n/workflow-weekly-report.json` | Cron 금요일 18:00 | ✅ 운영 중 |
+
+### Spec Tracker
+
+- GitHub Webhook: `https://xzawed.app.n8n.cloud/webhook/arcana-spec`
+- `spec` 라벨이 붙은 Issue = SuperGrok에서 확정된 기능 스펙
+- Issue 생성/수정 시 Slack/알림으로 통지
+
+### Quality Monitor
+
+- Supabase 직접 조회 (Grok 미사용) — 리딩 통계 모니터링
+- 이상 패턴 감지 시 알림 발송
+- AI 응답 품질 지표 수집
+
+### Weekly Report
+
+- 주간 리딩 통계 집계 및 리포트 생성
+- 금요일 18:00 KST 자동 발송
+
+### n8n 워크플로우 상세
+
+→ `n8n/README.md`
+
+---
+
+## CI/CD 파이프라인 모니터링
+
+→ [`../workflow/ci-cd.md`](../workflow/ci-cd.md)
+
+---
+
+## SonarCloud 코드 품질 분석
+
+PR마다 자동 실행:
+- 정적 코드 분석 (버그, 취약점, 코드 스멜)
+- 커버리지 추적 (lcov 포맷, `sonar.javascript.lcov.reportPaths`)
+- **테스트 리포트 주의**: `sonar.testExecutionReportPaths`는 SonarCloud 전용 `<testExecutions version="1">` XML 형식만 허용 — Vitest/Playwright의 JUnit `<testsuites>` 포맷과 비호환
+
+## Codecov 커버리지 추적
+
+- PR마다 커버리지 변화 코멘트 자동 게시
+- `unit` flag로 단위 테스트 커버리지만 추적
+- 임계값: statements 60% (PR E에서 상향 예정)

--- a/docs/workflow/ci-cd.md
+++ b/docs/workflow/ci-cd.md
@@ -1,0 +1,122 @@
+# CI/CD 파이프라인
+
+GitHub Actions → Railway 자동 배포 파이프라인 설명입니다.
+
+---
+
+## CI 워크플로우 4개
+
+### 1. `deploy.yml` — PR CI (lint → build → E2E)
+
+**트리거**: PR → main
+
+```
+jobs:
+  1. Lint & Type Check  (pnpm type-check && pnpm lint)
+  2. Build              (pnpm build)
+  3. E2E Tests          (Desktop Chrome + Mobile Android, Playwright v1.59.1)
+```
+
+- 3개 job이 모두 통과해야 PR 머지 가능 (branch protection rule)
+- E2E 실패 → 스크린샷·비디오 artifact 90일 보존
+- **GitHub Free 플랜**: 월 2,000분 한도, 예상 사용 ~100분
+
+### 2. `weekly-qa.yml` — 주간 QA
+
+**트리거**: 매주 토요일 09:00 KST (Cron)
+
+```
+- 3개 디바이스: Desktop Chrome + Mobile Android + Mobile iOS (WebKit)
+- artifact 30일 보존
+- 실패 시 GitHub Issue 자동 생성 (QA Failure 라벨)
+```
+
+### 3. `qa-recheck.yml` — QA 자동 재검증
+
+**트리거**: main push 시 열린 QA Issue 감지
+
+```
+흐름:
+  main push → QA Issue 열려있는지 확인
+    → 있으면: E2E 3개 디바이스 재실행
+      → 통과: Issue 자동 닫기
+      → 실패: Issue 유지 (수동 조치 필요)
+```
+
+### 4. `docs-sync.yml` — 문서 정합성
+
+**트리거**: PR마다 실행
+
+```
+pnpm exec tsx scripts/sync-test-count.ts --check   # CLAUDE.md 테스트 수
+pnpm exec tsx scripts/check-env-docs.ts             # env-variables.md 정합성
+pnpm exec tsx scripts/check-doc-links.ts            # docs 상대 링크 검증
+```
+
+> **현재 상태**: 경고 전용 (실패해도 PR 차단 안 함). PR-5에서 차단 모드로 전환 예정.
+
+---
+
+## Railway 자동 배포
+
+**트리거**: main 브랜치 push → Railway 자동 빌드+배포
+
+```
+설정 파일: railway.toml (nixpacks 빌더)
+GitHub Secrets 필요:
+  RAILWAY_TOKEN       Railway API 토큰
+  RAILWAY_SERVICE_ID  Railway 서비스 ID
+```
+
+### 롤백 방법
+
+Railway 대시보드 → Deployments → 이전 배포 클릭 → "Redeploy"
+
+또는 DB_PROVIDER 전환 롤백 (재배포 불필요):
+```
+Railway 환경변수: DB_PROVIDER=supabase (즉시 적용)
+```
+
+---
+
+## Branch Protection (GitHub Settings 수동 설정)
+
+`main` 브랜치에 branch protection rule 적용:
+
+| 설정 | 값 |
+|------|-----|
+| Required status checks | `Lint & Type Check`, `Build`, `E2E Tests` |
+| Require branches to be up to date | ✓ |
+| Restrict pushes | main에 직접 push 금지 (PR만 허용) |
+
+→ CI 실패 시 main 머지 자체가 차단되어 Railway 배포도 자동으로 방어됨
+
+---
+
+## E2E 상세 실행 가이드
+
+E2E 실행 방법, Docker 스크립트, 디바이스 프로필:
+→ [`e2e-testing.md`](e2e-testing.md)
+
+---
+
+## QA 자동 루프 흐름도
+
+```
+토요일 09:00 KST
+  └─ weekly-qa.yml 실행 (3개 디바이스)
+       ├─ 통과: 정상 종료
+       └─ 실패: GitHub Issue 자동 생성 (QA Failure 라벨)
+            └─ main push 감지 시 (qa-recheck.yml)
+                 └─ E2E 재실행
+                      ├─ 통과: Issue 자동 닫기
+                      └─ 실패: Issue 유지 → 수동 조치
+```
+
+---
+
+## n8n 자동화 (Phase 3)
+
+워크플로우 JSON 파일 및 상세 가이드: `n8n/README.md`
+
+→ 모니터링·알림 자동화 상세: [`../operations/monitoring.md`](../operations/monitoring.md)

--- a/docs/workflow/code-change-process.md
+++ b/docs/workflow/code-change-process.md
@@ -1,0 +1,140 @@
+# 코드 변경 프로세스
+
+모든 코드 변경에 적용되는 7단계 프로세스입니다. 진입점은 항상 **Claude CLI에 대한 사용자의 직접 지시**이며, Claude CLI가 기획/구현/검토를 모두 수행합니다.
+
+---
+
+## 7단계 프로세스
+
+### 1단계: 코드 변경
+- 사용자가 Claude CLI에 직접 지시 → Claude CLI가 기획 + 구현
+- `fix/*`, `feat/*`, `docs/*`, `chore/*` 기능 브랜치에서 수정 (main 직접 push 금지)
+
+### 2단계: 로컬 검증
+
+```bash
+pnpm type-check        # TypeScript 타입 체크
+pnpm lint              # ESLint 코드 품질 검사
+pnpm test:coverage     # 단위 테스트 + 커버리지 임계값 확인 (statements 60%)
+pnpm build             # 프로덕션 빌드 확인
+```
+
+- 4가지 모두 통과해야 다음 단계로 진행
+- 커버리지 임계값 변경 시 PR 설명에 근거 명시 필수
+- **Windows 환경 주의**: Google Fonts CDN(`fonts.gstatic.com`) 차단으로 `pnpm build`가 로컬에서 실패하는 경우가 있음. CI(GitHub Actions)는 정상 통과 → 문서만 변경하는 PR에서는 `type-check + lint`만 로컬 검증 후 CI에 위임 가능
+
+### 3단계: 변경 사항 리뷰
+- Claude CLI가 자체 검토: 스펙 준수, 코드 품질, 레이아웃 규칙 점검
+- [`../conventions/layout-rules.md`](../conventions/layout-rules.md) — 5:5 비율 + CSS mask 표준값 확인
+- [`../conventions/zod-schemas.md`](../conventions/zod-schemas.md) — API 스키마 `null`/`undefined` 규칙 확인
+
+### 4단계: 커밋 + PR 생성
+
+아래 prefix 규칙에 맞는 커밋 메시지 작성 후 PR 생성.
+
+**커밋 메시지 prefix 규칙**:
+
+| prefix | 용도 |
+|--------|------|
+| `feat:` | 새 기능 추가 |
+| `fix:` | 버그 수정 |
+| `docs:` | 문서 변경 (CLAUDE.md, README 등) |
+| `chore:` | 빌드·설정·스크립트 변경 |
+| `refactor:` | 기능 변경 없는 코드 구조 개선 |
+| `style:` | UI/스타일 변경 (기능 무관) |
+| `test:` | 테스트 추가·수정 |
+| `merge:` | 브랜치 머지 커밋 |
+
+```bash
+git push origin <branch-name>
+gh pr create --title "..." --body "..."
+```
+
+### 5단계: CI 자동 검증 (PR → main)
+- GitHub Actions 자동 실행: `lint → build → e2e` (Chromium)
+- 상세: [`ci-cd.md`](ci-cd.md)
+- CI 실패 → 1단계로 복귀
+- CI 통과 → 6단계로 진행
+
+### 6단계: 머지 + 자동 배포 + QA 재검증
+- PR 머지 → main push → Railway 자동 배포
+- QA 실패 Issue가 열려있으면 자동 재검증 트리거 (`qa-recheck.yml`)
+- 재검증 통과 시 QA Issue 자동 닫힘
+
+### 7단계: CLAUDE.md 최신화 + 최적화 (필수, 예외 없음)
+
+머지 완료 후 CLAUDE.md를 업데이트하고 main에 직접 커밋:
+
+**최신화 항목 (구현 내용 반영)**
+- 신규 파일/컴포넌트/훅/API 라우트 → 프로젝트 구조 트리에 추가
+- 신규 아키텍처 패턴 → 핵심 아키텍처 패턴 섹션에 추가
+- 미구현/제거된 기능 → 관련 설명 수정 또는 주의사항(`⚠️`) 표기
+- DB 마이그레이션 추가 시 → migrations 목록 업데이트
+
+```bash
+git add CLAUDE.md
+git commit -m "docs: CLAUDE.md 최신화 — [작업 내용 한 줄 요약]"
+git push origin main
+```
+
+---
+
+## 전체 흐름도
+
+```
+사용자 → Claude CLI (직접 지시)
+  └─ 1단계: 코드 변경 (기획 + 구현)
+       └─ 2단계: 로컬 검증 (type-check + lint + build)
+            ├─ 실패 → 수정 → 재검증 반복
+            └─ 통과 → 3단계: 리뷰
+                 └─ 4단계: 커밋 + PR 생성
+                      └─ 5단계: CI 자동 검증
+                           ├─ 실패 → 1단계로 복귀
+                           └─ 통과 → 6단계: 머지 + 배포 + QA 재검증
+                                └─ 7단계: CLAUDE.md 최신화 (필수)
+```
+
+---
+
+## 자동화 (Claude Code 전용)
+
+`.claude/settings.json`의 PreToolUse 훅으로 `git push` 시 자동 검증:
+
+- `scripts/pre-push-checks.sh` 실행: type-check → lint → build 순서
+- 하나라도 실패하면 push 차단
+
+`.scamanager/install-hook.sh`로 설치된 `pre-push` 훅:
+- Claude CLI로 AI 코드리뷰 수행 후 SCAManager 서버에 전송
+- 초기 설치: `git pull && bash .scamanager/install-hook.sh` (1회)
+- `claude`, `python3`, `curl` 미설치 시 훅 스킵 (push 차단 없음)
+
+---
+
+## Git 브랜치 전략
+
+```
+main        ← 프로덕션 (Railway 자동 배포 트리거, master 미사용)
+feat/*      ← 기능 개발
+fix/*       ← 버그 수정
+docs/*      ← 문서 변경
+chore/*     ← 설정/정리
+```
+
+### 브랜치 일괄 정리
+
+```bash
+# 원격 브랜치 전체 삭제 (main 제외) — sed 앞 공백 2개 주의
+git branch -r | grep -v 'origin/main' | grep -v 'origin/HEAD' | sed 's|  origin/||' | xargs -I{} git push origin --delete {}
+
+# 로컬 브랜치 전체 삭제 (main 제외)
+git branch | grep -v '^\* main' | xargs git branch -D
+```
+
+---
+
+## 의존성 버전 관리
+
+- **메이저 버전 업그레이드 금지**: Next.js, React, Framer Motion, Tailwind CSS, Zustand — 사용자 명시적 승인 없이 변경 불가
+- **마이너·패치는 허용**: 보안 패치, 버그 픽스 수준의 업데이트는 자율 적용 가능
+- **pnpm 버전 고정**: `pnpm@10.33.0` — `pnpm-lock.yaml`과 Docker 실행 스크립트에 고정됨, 임의 변경 금지
+- **Playwright 버전 고정**: Docker 이미지 `mcr.microsoft.com/playwright:v1.59.1-noble` — CI와 로컬 동기화를 위해 임의 변경 금지


### PR DESCRIPTION
## Summary

- `docs/workflow/code-change-process.md` 신설 — 7단계 프로세스, 커밋 prefix 규칙, 자동화(pre-push 훅), 브랜치 전략 + 의존성 버전 관리 규칙
- `docs/workflow/ci-cd.md` 신설 — GitHub Actions 4개 워크플로우(deploy/weekly-qa/qa-recheck/docs-sync), Railway 자동 배포, QA 자동 루프 흐름도
- `docs/operations/env-variables.md` 신설 — 전체 환경변수 목록 (Supabase/PostgreSQL/Verum/AI 공급자 튜닝), DB 전환 방법
- `docs/operations/deployment.md` 신설 — Railway 배포·롤백 절차(대시보드/git revert/DB_PROVIDER)
- `docs/operations/monitoring.md` 신설 — 주간 QA 루프, n8n 자동화 3개 워크플로우, SonarCloud/Codecov
- `process.md` → `docs/archive/process-diagrams.md` — Mermaid 다이어그램 8개 보존 후 루트 파일 삭제
- `docs/README.md` — 폴더 구조 PR-4 완성 반영 (21개 문서 인덱스, archive 파일 목록 명시)

## Test Plan

- [x] `check-doc-links` — 45개 파일, 깨진 링크 없음
- [x] `check-env-docs` — 코드 변수 19개 모두 문서에 존재 (통과)
- [x] `pnpm type-check` 통과
- [x] `pnpm lint` 통과
- [ ] CI (docs-sync 경고 확인)

🤖 Generated with [Claude Code](https://claude.com/claude-code)