### PR TITLE
fix: 코드 리뷰 발견사항 일괄 수정 — Claude Opus 4.7 상향, SSR·보안·테스트 강화

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,7 @@
 | **인증·DB** | Supabase Auth / NextAuth.js v5 (DB_PROVIDER별 전환) |
 | **DB ORM** | Supabase PostgreSQL / Drizzle ORM (DB_PROVIDER별 전환) |
 | **상태·패키지** | Zustand v5.0, pnpm 10.33.0 |
-| **테스트** | Vitest 2.0 (539개, 95%+ 커버리지), Playwright (3 디바이스) |
+| **테스트** | Vitest 2.0 (556개, statements 60%), Playwright (3 디바이스) |
 | **CI/CD·호스팅** | GitHub Actions → Railway |
 
 ## 프로젝트 구조

--- a/docs/operations/env-variables.md
+++ b/docs/operations/env-variables.md
@@ -77,9 +77,9 @@
 | 변수 | 설명 | 기본값 |
 |------|------|--------|
 | `GROK_BASE_URL` | Grok API 엔드포인트 | `https://api.x.ai/v1` |
-| `CLAUDE_MODEL` | Claude 모델 ID | `claude-opus-4-5` |
+| `CLAUDE_MODEL` | Claude 모델 ID | `claude-opus-4-7` |
 | `CLAUDE_BASE_URL` | Claude API 엔드포인트 오버라이드 | SDK 내장값 |
-| `AI_TIMEOUT_MS` | AI 스트림 타임아웃 | `30000` |
+| `AI_TIMEOUT_MS` | AI 스트림 타임아웃 | `60000` |
 | `AI_DEFAULT_MAX_TOKENS` | AI 응답 최대 토큰 | `16000` |
 | `AI_TEMPERATURE` | AI 온도 파라미터 | `0.7` |
 | `AI_FALLBACK_COOLDOWN_MS` | Fallback 쿨다운 — 5xx/network | `300000` (5분) |

--- a/docs/workflow/ci-cd.md
+++ b/docs/workflow/ci-cd.md
@@ -48,12 +48,11 @@ jobs:
 **트리거**: PR마다 실행
 
 ```
-pnpm exec tsx scripts/sync-test-count.ts --check   # CLAUDE.md 테스트 수
-pnpm exec tsx scripts/check-env-docs.ts             # env-variables.md 정합성
-pnpm exec tsx scripts/check-doc-links.ts            # docs 상대 링크 검증
+pnpm exec tsx scripts/check-env-docs.ts   # env-variables.md 정합성
+pnpm exec tsx scripts/check-doc-links.ts  # docs 상대 링크 검증
 ```
 
-> **현재 상태**: 경고 전용 (실패해도 PR 차단 안 함). PR-5에서 차단 모드로 전환 예정.
+> **sync-test-count**: 테스트 실행이 너무 느려 PR CI에서 제외. 로컬 수동 실행만: `pnpm exec tsx scripts/sync-test-count.ts --check`
 
 ---
 

--- a/src/__tests__/api/tarot-reading.test.ts
+++ b/src/__tests__/api/tarot-reading.test.ts
@@ -95,4 +95,26 @@ describe("POST /api/tarot/reading", () => {
     const text = await readSSEStream(res);
     expect(text).toContain("error");
   });
+
+  it("타인 세션에 reading 요청 → 403 (IDOR 차단)", async () => {
+    vi.doMock("@/lib/rate-limit", () => ({
+      checkRateLimit: vi.fn().mockReturnValue(true),
+      rateLimitResponse: vi.fn(),
+    }));
+    vi.doMock("@/lib/db", () => ({ getDb: vi.fn().mockReturnValue(makeMockDb()) }));
+    vi.doMock("@/lib/auth", () => ({
+      ...makeAuthMock(),
+      assertSessionOwnership: vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ error: "Forbidden" }), {
+          status: 403,
+          headers: { "Content-Type": "application/json" },
+        })
+      ),
+    }));
+    vi.doMock("@/services/core/fallback-provider", () => makeMockAiModule());
+    vi.doMock("@/lib/verum", () => makeMockVerum());
+    const { POST } = await import("@/app/api/tarot/reading/route");
+    const res = await POST(makePostRequest({ ...VALID_BODY, sessionId: "session-other-user" }));
+    expect(res.status).toBe(403);
+  });
 });

--- a/src/components/home/DailyCard.tsx
+++ b/src/components/home/DailyCard.tsx
@@ -26,16 +26,18 @@ export function DailyCard() {
   const [data, setData] = useState<Record<string, DailyCardData>>({});
   const [loading, setLoading] = useState<string | null>(null);
   const [flipped, setFlipped] = useState<Record<string, boolean>>({});
+  const [today, setToday] = useState("");
   const [todayLabel, setTodayLabel] = useState("");
 
-  const today = new Date().toISOString().split("T")[0];
-
   useEffect(() => {
+    const d = new Date();
     // eslint-disable-next-line react-hooks/set-state-in-effect
-    setTodayLabel(new Date().toLocaleDateString("ko-KR", { year: "numeric", month: "long", day: "numeric", weekday: "long" }));
+    setToday(d.toISOString().split("T")[0]);
+    setTodayLabel(d.toLocaleDateString("ko-KR", { year: "numeric", month: "long", day: "numeric", weekday: "long" }));
   }, []);
 
   const fetchDailyCard = useCallback(async (characterId: string) => {
+    if (!today) return;
     if (data[characterId]) return;
     setLoading(characterId);
     try {

--- a/src/lib/db/postgres-adapter.test.ts
+++ b/src/lib/db/postgres-adapter.test.ts
@@ -1,0 +1,224 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// POSTGRES_URL 필수 환경변수 설정
+process.env.POSTGRES_URL = "postgresql://test:test@localhost:5432/test_db";
+
+// postgres 클라이언트 mock (실제 DB 연결 방지)
+vi.mock("postgres", () => ({
+  default: vi.fn(() => ({})),
+}));
+
+// drizzle mock — select/insert/update 플루언트 체인을 테스트별 재구성
+const mockDb = {
+  select: vi.fn(),
+  insert: vi.fn(),
+  update: vi.fn(),
+};
+
+vi.mock("drizzle-orm/postgres-js", () => ({
+  drizzle: vi.fn(() => mockDb),
+}));
+
+// ─── 헬퍼: 플루언트 체인 구성 ─────────────────────────────────────────────
+
+/** select().from(t)[.where(...)][.limit(1)] 체인을 rows로 응답 */
+function mockSelectWith(rows: Record<string, unknown>[]) {
+  const thenable = {
+    then: (resolve: (v: unknown) => unknown) => Promise.resolve(rows).then(resolve),
+    catch: (onRejected: (e: unknown) => unknown) => Promise.resolve(rows).catch(onRejected),
+    where: vi.fn().mockReturnThis(),
+    limit: vi.fn().mockResolvedValue(rows),
+  };
+  mockDb.select = vi.fn().mockReturnValue({ from: vi.fn().mockReturnValue(thenable) });
+}
+
+/** insert(t).values(d).returning() 체인을 rows로 응답 */
+function mockInsertWith(rows: Record<string, unknown>[]) {
+  const returning = vi.fn().mockResolvedValue(rows);
+  const onConflictDoUpdate = vi.fn().mockReturnValue({ returning });
+  const values = vi.fn().mockReturnValue({ returning, onConflictDoUpdate });
+  mockDb.insert = vi.fn().mockReturnValue({ values });
+  return { returning, onConflictDoUpdate };
+}
+
+/** update(t).set(d).where(...).returning() 체인을 rows로 응답 */
+function mockUpdateWith(rows: Record<string, unknown>[]) {
+  const returning = vi.fn().mockResolvedValue(rows);
+  const where = vi.fn().mockReturnValue({ returning });
+  const set = vi.fn().mockReturnValue({ where });
+  mockDb.update = vi.fn().mockReturnValue({ set });
+}
+
+// ─── import (mock 설정 이후) ──────────────────────────────────────────────
+import { PostgresAdapter } from "./postgres-adapter";
+
+describe("PostgresAdapter", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // ── findOne ──────────────────────────────────────────────────────────────
+
+  describe("findOne", () => {
+    it("행 존재 시 camelCase→snake_case 변환 후 반환", async () => {
+      mockSelectWith([{ userId: "u-1", shareToken: "tok-abc", createdAt: new Date("2024-01-01") }]);
+      const adapter = new PostgresAdapter();
+      const result = await adapter.findOne<{ user_id: string; share_token: string; created_at: Date }>(
+        "sessions", { id: "s-1" }
+      );
+      expect(result).not.toBeNull();
+      expect(result!.user_id).toBe("u-1");
+      expect(result!.share_token).toBe("tok-abc");
+      expect(result!.created_at).toBeInstanceOf(Date);
+    });
+
+    it("행 없음 → null 반환", async () => {
+      mockSelectWith([]);
+      const adapter = new PostgresAdapter();
+      const result = await adapter.findOne("sessions", { id: "ghost" });
+      expect(result).toBeNull();
+    });
+
+    it("존재하지 않는 테이블 → Unknown table 예외", async () => {
+      const adapter = new PostgresAdapter();
+      await expect(adapter.findOne("no_such_table", { id: "1" })).rejects.toThrow("Unknown table: no_such_table");
+    });
+
+    it("존재하지 않는 컬럼 → Unknown column 예외", async () => {
+      mockSelectWith([]);
+      const adapter = new PostgresAdapter();
+      await expect(adapter.findOne("sessions", { no_such_col: "x" })).rejects.toThrow("Unknown column");
+    });
+  });
+
+  // ── findMany ─────────────────────────────────────────────────────────────
+
+  describe("findMany", () => {
+    it("where 없이 전체 행 반환", async () => {
+      mockSelectWith([{ id: "1" }, { id: "2" }]);
+      const adapter = new PostgresAdapter();
+      const result = await adapter.findMany("sessions");
+      expect(result).toHaveLength(2);
+    });
+
+    it("where 있는 경우 조건 적용 후 반환", async () => {
+      mockSelectWith([{ id: "s-1", userId: "u-1" }]);
+      const adapter = new PostgresAdapter();
+      const result = await adapter.findMany<{ id: string; user_id: string }>("sessions", { user_id: "u-1" });
+      expect(result[0]).toMatchObject({ id: "s-1", user_id: "u-1" });
+    });
+
+    it("결과 없음 → 빈 배열 반환", async () => {
+      mockSelectWith([]);
+      const adapter = new PostgresAdapter();
+      const result = await adapter.findMany("sessions", { user_id: "nobody" });
+      expect(result).toEqual([]);
+    });
+  });
+
+  // ── insert ───────────────────────────────────────────────────────────────
+
+  describe("insert", () => {
+    it("삽입 성공 → normalizeRow 후 반환", async () => {
+      mockInsertWith([{ id: "r-1", shareToken: "tok-xyz", serviceType: "tarot" }]);
+      const adapter = new PostgresAdapter();
+      const result = await adapter.insert<{ id: string; share_token: string; service_type: string }>(
+        "readings", { share_token: "tok-xyz", service_type: "tarot" }
+      );
+      expect(result.id).toBe("r-1");
+      expect(result.share_token).toBe("tok-xyz");
+      expect(result.service_type).toBe("tarot");
+    });
+
+    it("returning 결과 없음 → Insert failed 예외", async () => {
+      mockInsertWith([]);
+      const adapter = new PostgresAdapter();
+      await expect(adapter.insert("readings", { data: "x" })).rejects.toThrow("Insert failed for table: readings");
+    });
+  });
+
+  // ── insertMany ───────────────────────────────────────────────────────────
+
+  describe("insertMany", () => {
+    it("다건 삽입 → 배열 반환 (normalizeRow 적용)", async () => {
+      mockInsertWith([{ id: "c-1", cardId: "major-00" }, { id: "c-2", cardId: "major-01" }]);
+      const adapter = new PostgresAdapter();
+      const result = await adapter.insertMany<{ id: string; card_id: string }>(
+        "session_cards", [{ card_id: "major-00" }, { card_id: "major-01" }]
+      );
+      expect(result).toHaveLength(2);
+      expect(result[0].card_id).toBe("major-00");
+      expect(result[1].card_id).toBe("major-01");
+    });
+
+    it("빈 배열 삽입 → 빈 배열 반환", async () => {
+      mockInsertWith([]);
+      const adapter = new PostgresAdapter();
+      const result = await adapter.insertMany("session_cards", []);
+      expect(result).toEqual([]);
+    });
+  });
+
+  // ── update ───────────────────────────────────────────────────────────────
+
+  describe("update", () => {
+    it("업데이트 성공 → normalizeRow 후 반환", async () => {
+      mockUpdateWith([{ id: "s-1", serviceType: "tarot", status: "completed" }]);
+      const adapter = new PostgresAdapter();
+      const result = await adapter.update<{ id: string; service_type: string; status: string }>(
+        "sessions", { id: "s-1" }, { status: "completed" }
+      );
+      expect(result).not.toBeNull();
+      expect(result!.service_type).toBe("tarot");
+      expect(result!.status).toBe("completed");
+    });
+
+    it("매칭 행 없음 → null 반환", async () => {
+      mockUpdateWith([]);
+      const adapter = new PostgresAdapter();
+      const result = await adapter.update("sessions", { id: "ghost" }, { status: "done" });
+      expect(result).toBeNull();
+    });
+  });
+
+  // ── upsert ───────────────────────────────────────────────────────────────
+
+  describe("upsert", () => {
+    it("upsert 성공 → normalizeRow 후 반환", async () => {
+      const returning = vi.fn().mockResolvedValue([{ date: "2024-01-01", characterId: "arcana", cardId: "major-00" }]);
+      const onConflictDoUpdate = vi.fn().mockReturnValue({ returning });
+      const values = vi.fn().mockReturnValue({ onConflictDoUpdate, returning });
+      mockDb.insert = vi.fn().mockReturnValue({ values });
+
+      const adapter = new PostgresAdapter();
+      const result = await adapter.upsert<{ date: string; character_id: string; card_id: string }>(
+        "daily_cards",
+        { date: "2024-01-01", character_id: "arcana", card_id: "major-00" },
+        "date,character_id"
+      );
+      expect(result.date).toBe("2024-01-01");
+      expect(result.character_id).toBe("arcana");
+      expect(result.card_id).toBe("major-00");
+    });
+
+    it("unknown conflict column → 예외 발생", async () => {
+      mockInsertWith([]);
+      const adapter = new PostgresAdapter();
+      await expect(
+        adapter.upsert("daily_cards", { date: "2024-01-01" }, "no_such_col")
+      ).rejects.toThrow("Unknown conflict column");
+    });
+
+    it("returning 결과 없음 → Upsert failed 예외", async () => {
+      const returning = vi.fn().mockResolvedValue([]);
+      const onConflictDoUpdate = vi.fn().mockReturnValue({ returning });
+      const values = vi.fn().mockReturnValue({ onConflictDoUpdate, returning });
+      mockDb.insert = vi.fn().mockReturnValue({ values });
+
+      const adapter = new PostgresAdapter();
+      await expect(
+        adapter.upsert("daily_cards", { date: "2024-01-01", character_id: "arcana" }, "date,character_id")
+      ).rejects.toThrow("Upsert failed for table: daily_cards");
+    });
+  });
+});

--- a/src/lib/env.test.ts
+++ b/src/lib/env.test.ts
@@ -98,8 +98,8 @@ describe("getAnthropicApiKey", () => {
 });
 
 describe("getClaudeModel", () => {
-  it("env 미설정 시 기본값 'claude-sonnet-4-20250514'을 반환한다", () => {
-    expect(getClaudeModel()).toBe("claude-sonnet-4-20250514");
+  it("env 미설정 시 기본값 'claude-opus-4-7'을 반환한다", () => {
+    expect(getClaudeModel()).toBe("claude-opus-4-7");
   });
 
   it("env 설정 시 해당 값을 반환한다", () => {

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -4,7 +4,7 @@
 export function getGrokApiKey(): string { return process.env.GROK_API_KEY ?? "" }
 export function getGrokModel(): string { return process.env.GROK_MODEL ?? "grok-3" }
 export function getAnthropicApiKey(): string { return process.env.ANTHROPIC_API_KEY ?? "" }
-export function getClaudeModel(): string { return process.env.CLAUDE_MODEL ?? "claude-sonnet-4-20250514" }
+export function getClaudeModel(): string { return process.env.CLAUDE_MODEL ?? "claude-opus-4-7" }
 export function getClaudeBaseUrl(): string { return process.env.CLAUDE_BASE_URL ?? "https://api.anthropic.com/v1" }
 export function getGrokBaseUrl(): string { return process.env.GROK_BASE_URL ?? "https://api.x.ai/v1" }
 

--- a/src/services/core/prompt-builder.ts
+++ b/src/services/core/prompt-builder.ts
@@ -122,9 +122,18 @@ ${cardDescriptions}
 - 종합 해석에서 카드 간 상호작용과 전체 흐름을 분석하세요.`;
 }
 
+/** 사용자 입력값에서 줄바꿈 문자를 제거해 프롬프트 인젝션 차단 */
+function sanitizeField(value: string, maxLength = 100): string {
+  return value.replace(/[\r\n]/g, " ").slice(0, maxLength);
+}
+
 export function buildUserInfoPrompt(userInfo?: { name: string; birthDate: string; gender: string; birthHour: string } | null): string {
   if (!userInfo) return "";
   const genderMap: Record<string, string> = { male: "남성", female: "여성", other: "기타" };
   const birthHourMap: Record<string, string> = { unknown: "모름" };
-  return `\n\n상담자 정보:\n- 이름: ${userInfo.name}\n- 생년월일: ${userInfo.birthDate}\n- 성별: ${genderMap[userInfo.gender] || userInfo.gender}\n- 태어난 시: ${birthHourMap[userInfo.birthHour] || userInfo.birthHour}\n\n이 정보를 참고하여 더 개인화된 리딩을 제공해주세요.`;
+  const name = sanitizeField(userInfo.name, 50);
+  const birthDate = sanitizeField(userInfo.birthDate, 20);
+  const gender = sanitizeField(genderMap[userInfo.gender] || userInfo.gender, 10);
+  const birthHour = sanitizeField(birthHourMap[userInfo.birthHour] || userInfo.birthHour, 20);
+  return `\n\n상담자 정보:\n- 이름: ${name}\n- 생년월일: ${birthDate}\n- 성별: ${gender}\n- 태어난 시: ${birthHour}\n\n이 정보를 참고하여 더 개인화된 리딩을 제공해주세요.`;
 }


### PR DESCRIPTION
## Summary

멀티 에이전트 코드 분석(5개 도메인)에서 발견된 Critical/High/Medium 항목 일괄 수정.

- **Claude 모델 상향**: fallback 모델 `claude-sonnet-4-20250514` → `claude-opus-4-7` (사용자 요청 Opus 4.7)
- **SSR 버그 수정**: `DailyCard.tsx`에서 컴포넌트 최상위의 `new Date()` 호출을 `useEffect`+`useState`로 이동 — React Hydration mismatch(#418) 방지
- **프롬프트 인젝션 방어**: `buildUserInfoPrompt`에서 사용자 이름·생년월일 등 입력값의 줄바꿈 문자 제거
- **IDOR 테스트 추가**: 타인 세션에 reading 요청 시 403 반환 검증 케이스 신설
- **PostgresAdapter 테스트 신설**: Drizzle 경로(DB_PROVIDER=postgres) 16개 테스트 케이스 — findOne·findMany·insert·insertMany·update·upsert 전체 커버
- **문서 오기 수정**: CLAUDE.md 테스트 수(539→556), 커버리지(95%+→statements 60%), `env-variables.md` Claude 모델·AI 타임아웃 실제값 반영
- **ci-cd.md 정정**: sync-test-count가 PR CI에서 제외되어 있음을 명시

## Test Plan

- [x] `pnpm type-check` 통과
- [x] `pnpm lint` 통과
- [x] `pnpm test:coverage` 556개 전체 통과 (신규 17개 포함)
- [ ] CI (lint → build → E2E) 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)