### PR TITLE
feat(shinjeom): 결과 공유 페이지 구현 + mypage 링크 활성화

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,7 @@
 | **인증·DB** | Supabase Auth / NextAuth.js v5 (DB_PROVIDER별 전환) |
 | **DB ORM** | Supabase PostgreSQL / Drizzle ORM (DB_PROVIDER별 전환) |
 | **상태·패키지** | Zustand v5.0, pnpm 10.33.0 |
-| **테스트** | Vitest 2.0 (572개, statements 60%), Playwright (3 디바이스) |
+| **테스트** | Vitest 2.0 (577개, statements 60%), Playwright (3 디바이스) |
 | **CI/CD·호스팅** | GitHub Actions → Railway |
 
 ## 프로젝트 구조

--- a/docs/operations/known-issues.md
+++ b/docs/operations/known-issues.md
@@ -10,7 +10,6 @@
 
 | 기능 | 위치 | 현재 상태 | 비고 |
 |------|------|----------|------|
-| 신점 결과 공유 페이지 | `app/shinjeom/result/[id]/` | 미구현 | mypage에서 링크 비활성화됨 |
 | `useFavoriteCharacter` DB_PROVIDER 적용 | `hooks/useFavoriteCharacter.ts` | Supabase 직접 사용 | postgres 모드 전환 시 수정 필요 |
 | GenderFilter 홈 노출 | `components/home/GenderFilter.tsx` | 컴포넌트 존재, `page.tsx` 미사용 | — |
 | StatsCounter 홈 노출 | `components/home/StatsCounter.tsx` | 컴포넌트 존재, `page.tsx` 미사용 | — |

--- a/src/__tests__/api/shinjeom-result.test.ts
+++ b/src/__tests__/api/shinjeom-result.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi } from "vitest";
+import { NextRequest } from "next/server";
+import { setupDoMock } from "@/test-helpers/reset-modules";
+import { makeMockDb } from "@/test-helpers/mock-db";
+
+setupDoMock();
+
+const MOCK_READING = {
+  id: "r-3",
+  share_token: "shinjeom-tok",
+  overall_reading: "신점 테스트 결과",
+  topic_reading: "주제 해석",
+  advice: "조언",
+};
+
+async function setup() {
+  const mockDb = makeMockDb();
+  vi.doMock("@/lib/db", () => ({ getDb: vi.fn().mockReturnValue(mockDb) }));
+  const { GET } = await import("@/app/api/shinjeom/result/[id]/route");
+  return { GET, mockDb };
+}
+
+function makeGetRequest(id: string): [NextRequest, { params: Promise<{ id: string }> }] {
+  return [
+    new NextRequest(`http://localhost/api/shinjeom/result/${id}`),
+    { params: Promise.resolve({ id }) },
+  ];
+}
+
+describe("GET /api/shinjeom/result/[id]", () => {
+  it("존재하는 share_token → reading 반환", async () => {
+    const { GET, mockDb } = await setup();
+    mockDb.findOne.mockResolvedValue(MOCK_READING);
+    const res = await GET(...makeGetRequest("shinjeom-tok"));
+    expect(res.status).toBe(200);
+    expect((await res.json()).reading).toEqual(MOCK_READING);
+  });
+
+  it("존재하지 않는 share_token → 404", async () => {
+    const { GET, mockDb } = await setup();
+    mockDb.findOne.mockResolvedValue(null);
+    const res = await GET(...makeGetRequest("no-such-token"));
+    expect(res.status).toBe(404);
+    expect((await res.json()).error).toBe("Reading not found");
+  });
+
+  it("DB 오류 → 500", async () => {
+    const { GET, mockDb } = await setup();
+    mockDb.findOne.mockRejectedValue(new Error("DB error"));
+    const res = await GET(...makeGetRequest("shinjeom-tok"));
+    expect(res.status).toBe(500);
+  });
+
+  it("shinjeom_readings 테이블에 share_token으로 조회", async () => {
+    const { GET, mockDb } = await setup();
+    mockDb.findOne.mockResolvedValue(MOCK_READING);
+    await GET(...makeGetRequest("tok789"));
+    expect(mockDb.findOne).toHaveBeenCalledWith("shinjeom_readings", { share_token: "tok789" });
+  });
+
+  it("session_id 필드 응답에서 제거", async () => {
+    const { GET, mockDb } = await setup();
+    mockDb.findOne.mockResolvedValue({ ...MOCK_READING, session_id: "private-session-id" });
+    const res = await GET(...makeGetRequest("shinjeom-tok"));
+    const body = await res.json();
+    expect(body.reading.session_id).toBeUndefined();
+  });
+});

--- a/src/app/api/shinjeom/result/[id]/route.ts
+++ b/src/app/api/shinjeom/result/[id]/route.ts
@@ -1,0 +1,17 @@
+import { NextRequest, NextResponse } from "next/server"
+import { getDb } from "@/lib/db"
+
+export async function GET(_request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  try {
+    const { id } = await params
+    const db = getDb()
+    const reading = await db.findOne<Record<string, unknown>>("shinjeom_readings", { share_token: id })
+    if (!reading) return NextResponse.json({ error: "Reading not found" }, { status: 404 })
+    const safeReading = { ...reading }
+    delete safeReading.sessionId
+    delete safeReading.session_id
+    return NextResponse.json({ reading: safeReading })
+  } catch {
+    return NextResponse.json({ error: "Failed to fetch reading" }, { status: 500 })
+  }
+}

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -287,7 +287,7 @@ export default async function MyPage() {
               const resultPath = session.service_type === "saju"
                 ? `/saju/result/${shareToken}`
                 : session.service_type === "shinjeom"
-                ? null
+                ? `/shinjeom/result/${shareToken}`
                 : `/tarot/result/${shareToken}`;
 
               const content = (

--- a/src/app/shinjeom/result/[id]/ShinjeomResultShareButton.tsx
+++ b/src/app/shinjeom/result/[id]/ShinjeomResultShareButton.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { useState } from "react";
+
+interface ShinjeomResultShareButtonProps {
+  shareToken: string;
+}
+
+export function ShinjeomResultShareButton({ shareToken }: ShinjeomResultShareButtonProps) {
+  const [copied, setCopied] = useState(false);
+
+  const handleShare = async () => {
+    const url = `${window.location.origin}/shinjeom/result/${shareToken}`;
+    const text = "🔮 신점 결과를 확인해보세요!\n\n- ArcanaInsight";
+
+    if (navigator.share) {
+      try {
+        await navigator.share({ title: "신점 결과 - ArcanaInsight", text, url });
+      } catch {
+        /* 사용자가 공유 취소 */
+      }
+    } else {
+      try {
+        await navigator.clipboard.writeText(`${text}\n${url}`);
+        setCopied(true);
+        setTimeout(() => setCopied(false), 2000);
+      } catch {
+        /* 클립보드 접근 실패 */
+      }
+    }
+  };
+
+  return (
+    <button
+      onClick={handleShare}
+      className="px-8 py-3 rounded-full border border-arcana-purple text-arcana-purple font-serif font-bold text-sm hover:bg-arcana-purple/10 transition-colors"
+    >
+      {copied ? "링크 복사됨!" : "결과 공유하기"}
+    </button>
+  );
+}

--- a/src/app/shinjeom/result/[id]/page.tsx
+++ b/src/app/shinjeom/result/[id]/page.tsx
@@ -1,0 +1,86 @@
+import { notFound } from "next/navigation";
+import Image from "next/image";
+import { getDb } from "@/lib/db";
+import { cleanReadingText } from "@/services/core/text-cleaner";
+import { ReadingText } from "@/components/common/ReadingText";
+import { ShinjeomResultShareButton } from "./ShinjeomResultShareButton";
+
+interface ShinjeomReadingRow {
+  id: string;
+  session_id: string;
+  share_token: string | null;
+  overall_reading: string;
+  topic_reading: string;
+  advice: string;
+  created_at: string;
+}
+
+export default async function ShinjeomResultPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  const db = getDb();
+  const reading = await db.findOne<ShinjeomReadingRow>("shinjeom_readings", { share_token: id });
+
+  if (!reading) notFound();
+
+  const overallReading = cleanReadingText(reading.overall_reading || "");
+  const topicReading = cleanReadingText(reading.topic_reading || "");
+  const advice = cleanReadingText(reading.advice || "");
+
+  return (
+    <div className="relative min-h-screen overflow-hidden">
+      <div className="fixed inset-0 -z-10">
+        <Image src="/images/backgrounds/result-bg.jpg" alt="" fill className="object-cover" sizes="100vw" />
+        <div className="absolute inset-0 bg-arcana-bg/60" />
+      </div>
+
+      <div className="max-w-5xl mx-auto px-4 py-8 relative">
+        <div className="text-center mb-8">
+          <h1 className="text-2xl md:text-3xl font-serif font-bold text-arcana-purple mb-2 drop-shadow-md">신점 결과</h1>
+          <p className="text-arcana-muted text-sm">{new Date(reading.created_at).toLocaleDateString("ko-KR")}</p>
+        </div>
+
+        <div className="space-y-4 md:space-y-5">
+          {overallReading && (
+            <div className="bg-arcana-purple/10 backdrop-blur-sm border border-arcana-purple/30 rounded-2xl p-4 md:p-6">
+              <div className="flex items-center gap-2 mb-3">
+                <span className="text-lg">🔮</span>
+                <h2 className="text-arcana-purple font-serif font-bold text-base md:text-lg">종합 해석</h2>
+              </div>
+              <ReadingText text={overallReading} />
+            </div>
+          )}
+
+          {topicReading && (
+            <div className="bg-arcana-card/70 backdrop-blur-sm border border-arcana-border rounded-2xl p-4 md:p-6">
+              <div className="flex items-center gap-2 mb-3">
+                <span className="text-lg">🌿</span>
+                <h2 className="text-arcana-gold font-serif font-bold text-base md:text-lg">주제별 해석</h2>
+              </div>
+              <ReadingText text={topicReading} />
+            </div>
+          )}
+
+          {advice && (
+            <div className="bg-arcana-gold/5 backdrop-blur-sm border border-arcana-gold/30 rounded-2xl p-4 md:p-6">
+              <div className="flex items-center gap-2 mb-3">
+                <span className="text-lg">✨</span>
+                <h2 className="text-arcana-gold font-serif font-bold text-base md:text-lg">조언</h2>
+              </div>
+              <ReadingText text={advice} />
+            </div>
+          )}
+        </div>
+
+        <div className="flex justify-center gap-4 mt-8">
+          <a
+            href="/shinjeom"
+            className="px-8 py-3 rounded-full bg-gradient-to-r from-arcana-purple to-arcana-indigo text-white font-serif font-bold text-sm hover:opacity-90 transition-opacity shadow-lg shadow-arcana-purple/20"
+          >
+            나도 신점 상담 받기
+          </a>
+          <ShinjeomResultShareButton shareToken={id} />
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- `src/app/api/shinjeom/result/[id]/route.ts` 신설 — saju/tarot 동일 패턴, `shinjeom_readings` 조회
- `src/app/shinjeom/result/[id]/page.tsx` + `ShinjeomResultShareButton.tsx` 신설
- `src/app/mypage/page.tsx` shinjeom 결과 링크 비활성화 해제 (`null` → `/shinjeom/result/${shareToken}`)
- `src/__tests__/api/shinjeom-result.test.ts` 신설 (5개 테스트: 200/404/500/테이블명/session_id 제거)
- `docs/operations/known-issues.md` 미구현 기능 항목 제거
- CLAUDE.md 테스트 수 572 → 577

## Notes
- `share_token` 컬럼 및 DB 기본값은 migration 011에서 이미 처리 완료 — 신규 마이그레이션 불필요
- 결과 표현: 마지막 최종 메시지(overall_reading, topic_reading, advice) 표시 — saju 패턴과 동일

## Test Plan
- [x] `pnpm type-check` 통과
- [x] `pnpm lint` 통과
- [x] `pnpm exec vitest run src/__tests__/api/shinjeom-result.test.ts` — 5/5 통과
- [x] 전체 테스트 577 passed (34 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)