### PR TITLE
feat(rate-limit): Upstash Redis 전환 + in-memory fallback 유지

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,7 @@
 | **인증·DB** | Supabase Auth / NextAuth.js v5 (DB_PROVIDER별 전환) |
 | **DB ORM** | Supabase PostgreSQL / Drizzle ORM (DB_PROVIDER별 전환) |
 | **상태·패키지** | Zustand v5.0, pnpm 10.33.0 |
-| **테스트** | Vitest 2.0 (577개, statements 60%), Playwright (3 디바이스) |
+| **테스트** | Vitest 2.0 (582개, statements 60%), Playwright (3 디바이스) |
 | **CI/CD·호스팅** | GitHub Actions → Railway |
 
 ## 프로젝트 구조

--- a/docs/operations/env-variables.md
+++ b/docs/operations/env-variables.md
@@ -54,6 +54,19 @@
 
 ---
 
+## Rate-Limit (선택 — Upstash Redis)
+
+미설정 시 서버 메모리 Map 기반 fallback 사용 (단일 인스턴스·로컬 개발 호환).
+
+| 변수 | 설명 | 비고 |
+|------|------|------|
+| `UPSTASH_REDIS_REST_URL` | Upstash Redis REST URL | `https://xxx.upstash.io` |
+| `UPSTASH_REDIS_REST_TOKEN` | Upstash Redis REST 토큰 | Upstash 콘솔에서 발급 |
+
+> 다중 서버 인스턴스 운영 시 Redis 전환 권장. 무료 티어 10K req/day.
+
+---
+
 ## Verum (선택 — AI 프롬프트 A/B 테스트)
 
 미설정 시 로컬 기본 프롬프트 사용 (안전한 기본값). 장애 시 서킷 브레이커가 자동 격리합니다.

--- a/docs/operations/known-issues.md
+++ b/docs/operations/known-issues.md
@@ -25,7 +25,7 @@
 |------|------|------|----------|
 | `useFavoriteCharacter` Supabase 직접 사용 | `hooks/useFavoriteCharacter.ts` | DB_PROVIDER 추상화 미적용 | postgres 모드 전환 시 처리 |
 | 커버리지 측정 범위 협소 | `vitest.config.ts` coverage.include | 전체 코드의 22.2%만 측정 대상 | PR E에서 include 확장 + 임계값 상향 |
-| rate-limit 메모리 저장 | `src/lib/rate-limit.ts` | 서버 재시작 시 초기화됨 | Redis 기반 전환 고려 (별도 기획) |
+| rate-limit Redis 미설정 | `src/lib/rate-limit.ts` | `UPSTASH_REDIS_REST_URL` 미설정 시 in-memory fallback 동작 | Railway에서 Upstash 연결 설정 시 분산 처리 활성화 |
 | SupabaseAdapter 통합 테스트 부재 | `src/lib/db/supabase-adapter.ts` | mock 체인이 자기충족적, 실제 Supabase 응답 미검증 | 통합 테스트 환경 구축 후 처리 |
 
 ---

--- a/src/app/api/saju/reading/route.ts
+++ b/src/app/api/saju/reading/route.ts
@@ -41,7 +41,7 @@ export async function POST(request: NextRequest) {
   try {
     // Rate limiting
     const ip = request.headers.get("x-forwarded-for") ?? request.headers.get("x-real-ip") ?? "anon";
-    if (!checkRateLimit(`saju:${ip}`, 10, 60_000)) return rateLimitResponse();
+    if (!(await checkRateLimit(`saju:${ip}`, 10, 60_000))) return rateLimitResponse();
 
     const rawBody = await request.json();
 

--- a/src/app/api/shinjeom/message/route.ts
+++ b/src/app/api/shinjeom/message/route.ts
@@ -22,7 +22,7 @@ export async function POST(request: NextRequest) {
   try {
     // Rate limiting
     const ip = request.headers.get("x-forwarded-for") ?? request.headers.get("x-real-ip") ?? "anon";
-    if (!checkRateLimit(`shinjeom:${ip}`, 20, 60_000)) return rateLimitResponse();
+    if (!(await checkRateLimit(`shinjeom:${ip}`, 20, 60_000))) return rateLimitResponse();
 
     const rawBody = await request.json();
 

--- a/src/app/api/tarot/reading/route.ts
+++ b/src/app/api/tarot/reading/route.ts
@@ -30,7 +30,7 @@ export async function POST(request: NextRequest) {
   try {
     // Rate limiting
     const ip = request.headers.get("x-forwarded-for") ?? request.headers.get("x-real-ip") ?? "anon";
-    if (!checkRateLimit(`tarot:${ip}`, 10, 60_000)) return rateLimitResponse();
+    if (!(await checkRateLimit(`tarot:${ip}`, 10, 60_000))) return rateLimitResponse();
 
     const rawBody = await request.json();
 

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -24,6 +24,10 @@ export function getAiAuthCooldownMs(): number { return parseInt(process.env.AI_A
 // DB
 export function getPostgresPoolSize(): number { return parseInt(process.env.POSTGRES_POOL_SIZE ?? "10", 10) }
 
+// Rate-limit (Upstash Redis)
+export function getUpstashRedisRestUrl(): string { return process.env.UPSTASH_REDIS_REST_URL ?? "" }
+export function getUpstashRedisRestToken(): string { return process.env.UPSTASH_REDIS_REST_TOKEN ?? "" }
+
 // Verum
 export function getVerumApiUrl(): string { return process.env.VERUM_API_URL ?? "" }
 export function getVerumApiKey(): string { return process.env.VERUM_API_KEY ?? "" }

--- a/src/lib/rate-limit.test.ts
+++ b/src/lib/rate-limit.test.ts
@@ -1,47 +1,109 @@
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { checkRateLimit } from "./rate-limit";
 
-describe("checkRateLimit", () => {
+// UPSTASH 환경변수 미설정 → in-memory fallback 경로 테스트
+describe("checkRateLimit (in-memory fallback)", () => {
   beforeEach(() => {
     vi.useFakeTimers();
+    delete process.env.UPSTASH_REDIS_REST_URL;
+    delete process.env.UPSTASH_REDIS_REST_TOKEN;
   });
 
-  it("첫 번째 요청은 항상 허용", () => {
-    expect(checkRateLimit("test-key-1", 5, 60_000)).toBe(true);
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
-  it("한도 내 요청은 허용", () => {
+  it("첫 번째 요청은 항상 허용", async () => {
+    expect(await checkRateLimit("test-key-1", 5, 60_000)).toBe(true);
+  });
+
+  it("한도 내 요청은 허용", async () => {
     const key = "test-key-2";
     for (let i = 0; i < 5; i++) {
-      expect(checkRateLimit(key, 5, 60_000)).toBe(true);
+      expect(await checkRateLimit(key, 5, 60_000)).toBe(true);
     }
   });
 
-  it("한도 초과 요청은 거부", () => {
+  it("한도 초과 요청은 거부", async () => {
     const key = "test-key-3";
-    for (let i = 0; i < 5; i++) checkRateLimit(key, 5, 60_000);
-    expect(checkRateLimit(key, 5, 60_000)).toBe(false);
+    for (let i = 0; i < 5; i++) await checkRateLimit(key, 5, 60_000);
+    expect(await checkRateLimit(key, 5, 60_000)).toBe(false);
   });
 
-  it("윈도우 만료 후 리셋", () => {
+  it("윈도우 만료 후 리셋", async () => {
     const key = "test-key-4";
-    for (let i = 0; i < 5; i++) checkRateLimit(key, 5, 60_000);
-    expect(checkRateLimit(key, 5, 60_000)).toBe(false);
+    for (let i = 0; i < 5; i++) await checkRateLimit(key, 5, 60_000);
+    expect(await checkRateLimit(key, 5, 60_000)).toBe(false);
     vi.advanceTimersByTime(61_000);
-    expect(checkRateLimit(key, 5, 60_000)).toBe(true);
+    expect(await checkRateLimit(key, 5, 60_000)).toBe(true);
   });
 
-  it("다른 키는 독립적으로 카운트", () => {
+  it("다른 키는 독립적으로 카운트", async () => {
     const keyA = "test-key-5a";
     const keyB = "test-key-5b";
-    for (let i = 0; i < 5; i++) checkRateLimit(keyA, 5, 60_000);
-    expect(checkRateLimit(keyA, 5, 60_000)).toBe(false);
-    expect(checkRateLimit(keyB, 5, 60_000)).toBe(true);
+    for (let i = 0; i < 5; i++) await checkRateLimit(keyA, 5, 60_000);
+    expect(await checkRateLimit(keyA, 5, 60_000)).toBe(false);
+    expect(await checkRateLimit(keyB, 5, 60_000)).toBe(true);
   });
 
-  it("limit=1이면 두 번째 요청부터 거부", () => {
+  it("limit=1이면 두 번째 요청부터 거부", async () => {
     const key = "test-key-6";
-    expect(checkRateLimit(key, 1, 60_000)).toBe(true);
-    expect(checkRateLimit(key, 1, 60_000)).toBe(false);
+    expect(await checkRateLimit(key, 1, 60_000)).toBe(true);
+    expect(await checkRateLimit(key, 1, 60_000)).toBe(false);
+  });
+});
+
+describe("checkRateLimit (Upstash Redis)", () => {
+  const mockFetch = vi.fn();
+
+  beforeEach(() => {
+    process.env.UPSTASH_REDIS_REST_URL = "https://upstash.test";
+    process.env.UPSTASH_REDIS_REST_TOKEN = "test-token";
+    vi.stubGlobal("fetch", mockFetch);
+    mockFetch.mockReset();
+  });
+
+  afterEach(() => {
+    delete process.env.UPSTASH_REDIS_REST_URL;
+    delete process.env.UPSTASH_REDIS_REST_TOKEN;
+    vi.unstubAllGlobals();
+  });
+
+  it("count <= limit → 허용", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => [{ result: 3 }, { result: 1 }],
+    });
+    expect(await checkRateLimit("upstash-key-1", 10, 60_000)).toBe(true);
+  });
+
+  it("count > limit → 거부", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => [{ result: 11 }, { result: 0 }],
+    });
+    expect(await checkRateLimit("upstash-key-2", 10, 60_000)).toBe(false);
+  });
+
+  it("Upstash 오류(4xx/5xx) → in-memory fallback 허용", async () => {
+    mockFetch.mockResolvedValue({ ok: false, status: 500 });
+    expect(await checkRateLimit("upstash-key-3", 10, 60_000)).toBe(true);
+  });
+
+  it("네트워크 오류 → in-memory fallback 허용", async () => {
+    mockFetch.mockRejectedValue(new Error("network error"));
+    expect(await checkRateLimit("upstash-key-4", 10, 60_000)).toBe(true);
+  });
+
+  it("pipeline endpoint로 요청", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => [{ result: 1 }, { result: 1 }],
+    });
+    await checkRateLimit("upstash-key-5", 10, 60_000);
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://upstash.test/pipeline",
+      expect.objectContaining({ method: "POST" })
+    );
   });
 });

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -1,11 +1,14 @@
+import { getUpstashRedisRestUrl, getUpstashRedisRestToken } from "@/lib/env";
+
 interface RateLimitEntry {
   count: number;
   resetAt: number;
 }
 
+// fallback: 모듈 전역 Map (UPSTASH_REDIS_REST_URL 미설정 시 — 로컬 개발·테스트 환경)
 const hits = new Map<string, RateLimitEntry>();
 
-export function checkRateLimit(key: string, limit: number, windowMs: number): boolean {
+function checkMemory(key: string, limit: number, windowMs: number): boolean {
   const now = Date.now();
   const entry = hits.get(key);
   if (!entry || entry.resetAt < now) {
@@ -15,6 +18,42 @@ export function checkRateLimit(key: string, limit: number, windowMs: number): bo
   if (entry.count >= limit) return false;
   entry.count++;
   return true;
+}
+
+async function checkUpstash(key: string, limit: number, windowMs: number): Promise<boolean> {
+  const url = getUpstashRedisRestUrl();
+  const token = getUpstashRedisRestToken();
+  const windowSec = Math.ceil(windowMs / 1000);
+
+  try {
+    // pipeline: [INCR key, EXPIRE key windowSec NX]
+    // NX = expiry를 첫 요청 시에만 설정 (이후 요청은 기존 TTL 유지)
+    const res = await fetch(`${url}/pipeline`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify([
+        ["INCR", key],
+        ["EXPIRE", key, windowSec, "NX"],
+      ]),
+    });
+
+    if (!res.ok) return checkMemory(key, limit, windowMs);
+
+    const data = (await res.json()) as [{ result: number }, unknown];
+    const count = data[0]?.result ?? 1;
+    return count <= limit;
+  } catch {
+    // 네트워크 오류 시 in-memory fallback
+    return checkMemory(key, limit, windowMs);
+  }
+}
+
+export async function checkRateLimit(key: string, limit: number, windowMs: number): Promise<boolean> {
+  if (!getUpstashRedisRestUrl()) return checkMemory(key, limit, windowMs);
+  return checkUpstash(key, limit, windowMs);
 }
 
 export function rateLimitResponse(): Response {


### PR DESCRIPTION
## Summary
- `checkRateLimit` 동기 → `async Promise<boolean>` 시그니처 전환
- `UPSTASH_REDIS_REST_URL` 설정 시 Upstash REST pipeline(`INCR` + `EXPIRE NX`) 사용
- 미설정·Redis 오류·네트워크 오류 시 기존 in-memory Map fallback 자동 전환
- tarot/saju/shinjeom reading 라우트 3개 `await checkRateLimit(...)` 적용
- `src/lib/env.ts` Upstash getter 2개 추가
- `docs/operations/env-variables.md` Rate-Limit 섹션 추가

## Test Plan
- [x] `pnpm type-check` 통과
- [x] `pnpm lint` 통과
- [x] rate-limit 테스트 11개 통과 (in-memory 6 + Upstash 5)
- [x] 전체 테스트 582 passed (34 files)
- [x] `pnpm exec tsx scripts/check-env-docs.ts` 통과

## Notes
- Upstash 무료 티어 10K req/day — Railway Variables에 `UPSTASH_REDIS_REST_URL`, `UPSTASH_REDIS_REST_TOKEN` 추가 시 즉시 활성화
- 미설정 상태에서도 in-memory fallback으로 정상 동작 (기존 동일)

🤖 Generated with [Claude Code](https://claude.com/claude-code)