### PR TITLE
test(coverage): 임계값 상향 branches 75 / functions 85 / lines·statements 88

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,7 @@
 | **인증·DB** | Supabase Auth / NextAuth.js v5 (DB_PROVIDER별 전환) |
 | **DB ORM** | Supabase PostgreSQL / Drizzle ORM (DB_PROVIDER별 전환) |
 | **상태·패키지** | Zustand v5.0, pnpm 10.33.0 |
-| **테스트** | Vitest 2.0 (582개, statements 60%), Playwright (3 디바이스) |
+| **테스트** | Vitest 2.0 (582개, statements 88%), Playwright (3 디바이스) |
 | **CI/CD·호스팅** | GitHub Actions → Railway |
 
 ## 프로젝트 구조
@@ -98,7 +98,7 @@ pnpm dev           # 개발 서버
 pnpm build         # 프로덕션 빌드
 pnpm lint          # ESLint
 pnpm type-check    # tsc --noEmit
-pnpm test:coverage # Vitest + 커버리지 (statements 60%)
+pnpm test:coverage # Vitest + 커버리지 (statements 88%)
 pnpm test:e2e      # Playwright (3 디바이스)
 pnpm exec tsx scripts/sync-test-count.ts       # CLAUDE.md 테스트 수 동기화
 pnpm exec tsx scripts/check-env-docs.ts        # env.ts ↔ env-variables.md 정합성
@@ -174,10 +174,8 @@ pnpm exec tsx scripts/check-doc-links.ts       # docs 링크 검증
 
 → **정본**: [`docs/operations/known-issues.md`](docs/operations/known-issues.md)
 
-- `app/shinjeom/result/[id]/` 결과 공유 페이지 미구현 (mypage 링크 비활성화)
 - `useFavoriteCharacter` DB_PROVIDER 추상화 미적용 (Supabase 직접)
-- 커버리지 임계값 상향 미완료 (branches 65/functions 75/lines 75 — 별도 PR 예정)
-- rate-limit 메모리 저장 — 서버 재시작 시 초기화됨 (Redis 기반 전환 고려)
+- rate-limit: UPSTASH_REDIS_REST_URL 미설정 시 in-memory fallback (분산 처리 미활성화)
 
 ## Claude 자율 관리 규칙
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -38,6 +38,7 @@ export default defineConfig({
         "src/app/api/tarot/reading/route.ts",         // PR C
         "src/app/api/saju/reading/route.ts",          // PR C
         "src/app/api/shinjeom/message/route.ts",      // PR C
+        "src/app/api/shinjeom/result/[id]/route.ts",  // PR-L
       ],
       exclude: [
         "src/**/*.test.ts",
@@ -75,10 +76,10 @@ export default defineConfig({
         "src/services/saju/saju-types.ts",    // 타입 정의만
       ],
       thresholds: {
-        branches: 50,
-        functions: 60,
-        lines: 60,
-        statements: 60,
+        branches: 75,
+        functions: 85,
+        lines: 88,
+        statements: 88,
       },
     },
   },


### PR DESCRIPTION
## Summary
- `vitest.config.ts` thresholds 대폭 상향:
  - `branches`: 50 → **75**
  - `functions`: 60 → **85**
  - `lines`: 60 → **88**
  - `statements`: 60 → **88**
- `coverage.include`에 `src/app/api/shinjeom/result/[id]/route.ts` 추가 (PR-L #142에서 신설)
- CLAUDE.md 커버리지 표기, 완료된 미구현 항목 정리

## Why these numbers
현재 실측 커버리지: branches 81.44% / functions 92.9% / lines·statements 94.11%
각 임계값에 6~7%p 버퍼를 두어 신규 코드 추가 시 CI red 방지.

## Test Plan
- [x] `pnpm type-check` 통과
- [x] `pnpm lint` 통과
- [x] `pnpm test:coverage` — 모든 임계값 통과 (582 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)