### PR TITLE
docs: sync-test-count 패턴 수정 + SonarCloud Q 시리즈 이력 정리

### DIFF
--- a/docs/operations/known-issues.md
+++ b/docs/operations/known-issues.md
@@ -34,3 +34,12 @@
 | **D** | `fix/sonar-badge-followup` | ✅ merged | reading-saver.ts 신설·retry 3회, tarot·saju·shinjeom 라우트 위임 (539→558) |
 | **E** | PR-N (임계값 상향) | ✅ merged | branches 75/functions 85/lines 88/statements 88, 587개 |
 | **F** | (미시작) | 선택 | 우회 주석 태깅 |
+
+---
+
+## SonarCloud Quality Gate 수정 이력
+
+| PR | 번호 | 상태 | 내용 |
+|----|------|------|------|
+| **Q1** | PR #148 | ✅ merged | E2E cross-platform.spec.ts testPaths miko/default.jpg → nukki/*.png (PR-K 누락 수정) |
+| **Q3** | PR #149 | ✅ merged | Reliability Bug 2개(접근성), Security Hotspot 2개(ReDoS regex·Math.random) 해소 → Quality Gate Passed |

--- a/scripts/sync-test-count.ts
+++ b/scripts/sync-test-count.ts
@@ -20,16 +20,17 @@ function getActualTestCount(): number {
       "pnpm exec vitest run --reporter=verbose 2>&1 || true",
       { cwd: ROOT, encoding: "utf-8", timeout: 120_000 }
     );
-    // "Tests  539 passed" or "539 passed" 형태 파싱
-    const match = output.match(/(\d+)\s+passed/);
-    if (match) return parseInt(match[1], 10);
-
-    // fallback: "Test Files  31 passed" 다음에 나오는 "Tests" 라인
+    // "Tests  587 passed" 라인을 우선 탐색 (Test Files N passed 오탐 방지)
     const testsLine = output.split("\n").find((l) => /^\s*Tests\s+\d+/.test(l));
     if (testsLine) {
       const m = testsLine.match(/(\d+)\s+passed/);
-      if (m) return parseInt(m[1], 10);
+      if (m) return Number.parseInt(m[1], 10);
     }
+
+    // fallback: 마지막 "N passed" 패턴
+    const allMatches = [...output.matchAll(/(\d+)\s+passed/g)];
+    const last = allMatches.at(-1);
+    if (last) return Number.parseInt(last[1], 10);
     throw new Error("테스트 수 파싱 실패:\n" + output.slice(-500));
   } catch (e) {
     console.error("[sync-test-count] 테스트 실행 오류:", e);
@@ -38,9 +39,9 @@ function getActualTestCount(): number {
 }
 
 function getDocumentedCount(content: string): number | null {
-  // "Vitest 2.0 (node env, v8 coverage, 539개 테스트" 패턴
-  const match = content.match(/Vitest[^(]*\(node env[^,]*,\s*v8 coverage[^,]*,\s*(\d+)개\s*테스트/);
-  if (match) return parseInt(match[1], 10);
+  // "Vitest 2.0 (587개, statements 88%)" 패턴
+  const match = content.match(/Vitest[^(]*\(\s*(\d+)개,?\s*statements/);
+  if (match) return Number.parseInt(match[1], 10);
   return null;
 }
 
@@ -72,8 +73,8 @@ if (CHECK_MODE) {
 }
 
 const updated = claudeMd.replace(
-  /(Vitest[^(]*\(node env[^,]*,\s*v8 coverage[^,]*,\s*)\d+(개\s*테스트)/,
-  `$1${actual}$2`
+  /(Vitest[^(]*\(\s*)(\d+)(개,?\s*statements)/,
+  `$1${actual}$3`
 );
 fs.writeFileSync(CLAUDE_MD, updated, "utf-8");
 console.log(`[sync-test-count] CLAUDE.md 갱신 완료: ${documented}개 → ${actual}개`);


### PR DESCRIPTION
## Summary

- `scripts/sync-test-count.ts` — CLAUDE.md 현재 형식(`Vitest 2.0 (587개, statements 88%)`)에 맞게 grep 패턴 수정. `Test Files N passed` 오탐 방지를 위해 `Tests` 라인 우선 탐색으로 변경. `parseInt` → `Number.parseInt`, `[length-1]` → `.at(-1)` (SonarCloud 경고 해소)
- `docs/operations/known-issues.md` — SonarCloud Quality Gate 수정 PR 이력 섹션 추가 (Q1 #148, Q3 #149 완료 기록)

## Test Plan

- [x] `pnpm exec tsx scripts/sync-test-count.ts` → 587개 정확히 인식, 일치 확인
- [x] `pnpm type-check` 통과
- [x] `pnpm lint` 통과
- [x] `pnpm exec tsx scripts/check-doc-links.ts` → 깨진 링크 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)