### PR TITLE
docs: PR-D 시리즈 리팩터링 결과 문서 반영

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,7 @@
 | **인증·DB** | Supabase Auth / NextAuth.js v5 (DB_PROVIDER별 전환) |
 | **DB ORM** | Supabase PostgreSQL / Drizzle ORM (DB_PROVIDER별 전환) |
 | **상태·패키지** | Zustand v5.0, pnpm 10.33.0 |
-| **테스트** | Vitest 2.0 (587개, statements 88%), Playwright (3 디바이스) |
+| **테스트** | Vitest 2.0 (599개, statements 88%), Playwright (3 디바이스) |
 | **CI/CD·호스팅** | GitHub Actions → Railway |
 
 ## 프로젝트 구조
@@ -33,15 +33,16 @@ src/
 ├── hooks/           # Zustand stores + useSSEStream, useTheme, useFavoriteCharacter
 ├── lib/
 │   ├── env.ts       # 환경변수 getter 23개 (하드코딩 금지)
+│   ├── request-utils.ts  # getClientIp / pickFields / jsonError / SSE_HEADERS
 │   ├── rate-limit.ts
 │   ├── db/          # getDb() — SupabaseAdapter / PostgresAdapter (DB_PROVIDER 분기)
 │   ├── auth/        # getCurrentUser() / requireUser() / assertSessionOwnership()
 │   ├── validation/  # api-schemas.ts (Zod 7종)
 │   ├── verum/       # 프롬프트 A/B 라우팅 + 서킷 브레이커 (README.md 참조)
 │   └── storage/     # getCardImageUrl() — provider별 이미지 URL
-├── services/        # core/ (FallbackProvider·PromptBuilder), tarot/, saju/, shinjeom/
+├── services/        # core/ (FallbackProvider·PromptBuilder·CircuitBreaker·http-utils), tarot/, saju/, shinjeom/
 ├── types/           # card.ts, character.ts, session.ts, service.ts, user-info.ts
-├── test-helpers/    # mock-db, mock-auth, mock-request, mock-ai, reset-modules
+├── test-helpers/    # mock-db, mock-auth, mock-request, mock-ai, reset-modules, api-route-setup
 └── __tests__/api/   # API 라우트 단위 테스트 (vitest.config.ts exclude 우회)
 
 docs/                # → docs/README.md 인덱스
@@ -87,7 +88,7 @@ scripts/             # sync-test-count.ts, check-env-docs.ts, check-doc-links.ts
 
 **API 보안**: Rate Limit → Zod safeParse → requireUser → assertSessionOwnership. → [`docs/architecture/auth-abstraction.md`](docs/architecture/auth-abstraction.md)
 
-**SSE 스트리밍**: tarot/saju/shinjeom reading API. 클라이언트 `fetchSSEStream()` (`src/hooks/useSSEStream.ts`). `/api/daily-card`는 JSON (비스트리밍).
+**SSE 스트리밍**: tarot/saju/shinjeom reading API. 서버 공통 헤더 `SSE_HEADERS` + `jsonError()` (`src/lib/request-utils.ts`), Provider 공통 SSE 리더 `readSseLines` + `withAbortTimeout` (`src/services/core/http-utils.ts`). 클라이언트 `fetchSSEStream()` (`src/hooks/useSSEStream.ts`). `/api/daily-card`는 JSON (비스트리밍).
 
 **share_token**: `/*/result/[id]` 공개 공유. 소유자 전용 = `assertReadingAccess("owner")`.
 

--- a/docs/architecture/ai-infrastructure.md
+++ b/docs/architecture/ai-infrastructure.md
@@ -45,6 +45,23 @@ API Route (route.ts)
 - `ANTHROPIC_API_KEY` 미설정 시 Grok 단독 사용 (fallback 없음)
 - 쿨다운 중 새 요청은 즉시 Claude로 라우팅 (retry 없음)
 
+### CircuitBreaker 클래스
+
+서킷 상태는 `CircuitBreaker` (`src/services/core/circuit-breaker.ts`) 로 관리:
+
+```ts
+new CircuitBreaker({ prefix: "FallbackProvider/Grok", globalKey: "grok_circuit" })
+```
+
+| 메서드 | 역할 |
+|--------|------|
+| `isAvailable()` | 서킷 열림 여부 확인 |
+| `markDown(ms, reason)` | 서킷 오픈 + 쿨다운 설정 |
+| `resetForTests()` | 테스트용 상태 초기화 |
+
+- `globalKey` 옵션: `globalThis`에 상태 공유 → 서버리스 warm instance 간 쿨다운 보존
+- Verum 클라이언트(`src/lib/verum/client.ts`)도 동일 클래스를 인스턴스 단위로 사용
+
 ---
 
 ## 3. Verum — A/B 프롬프트 라우팅
@@ -103,6 +120,24 @@ resetVerumClientForTests(): void  // 테스트 전용
 | `/api/daily-card` | JSON 단일 응답 | `NextResponse.json()` |
 
 클라이언트 공통 유틸: `src/hooks/useSSEStream.ts` — `fetchSSEStream()`
+
+### 서버 공통 유틸
+
+| 유틸 | 위치 | 역할 |
+|------|------|------|
+| `withAbortTimeout(fn, ms)` | `src/services/core/http-utils.ts` | AbortController + setTimeout 래퍼 (Grok/Claude 공용) |
+| `readSseLines(response, extractDelta)` | `src/services/core/http-utils.ts` | OpenAI·Anthropic SSE 공통 reader — `extractDelta` 콜백으로 포맷 차이 흡수 |
+| `SSE_HEADERS` | `src/lib/request-utils.ts` | API 라우트 SSE 응답 표준 헤더 상수 |
+| `jsonError(msg, status)` | `src/lib/request-utils.ts` | JSON 오류 응답 헬퍼 |
+| `getClientIp(headers)` | `src/lib/request-utils.ts` | x-forwarded-for 첫 IP 추출 (rate-limit 용) |
+| `pickFields(obj, keys)` | `src/lib/request-utils.ts` | 응답 직렬화 whitelist — 새 컬럼 자동 제외로 IDOR 방지 |
+
+### 텍스트·프롬프트 공통 유틸
+
+| 유틸 | 위치 | 역할 |
+|------|------|------|
+| `extractFallbackText(raw)` | `src/services/core/text-cleaner.ts` | JSON 파싱 실패 시 본문 회수 (tarot/saju 공용, ReDoS-safe) |
+| `buildCharacterHeader(character, subtitle?)` | `src/services/core/prompt-builder.ts` | 3 서비스 공통 캐릭터 system-prompt 헤더 |
 
 ---
 

--- a/docs/architecture/auth-abstraction.md
+++ b/docs/architecture/auth-abstraction.md
@@ -48,6 +48,7 @@
   │      세션 소유자 불일치 시 403
   │
   └─ 5. AI 처리 → SSE 스트리밍 응답
+         SSE_HEADERS / jsonError() (src/lib/request-utils.ts)
 ```
 
 ---
@@ -60,12 +61,18 @@
 // 공유 결과 조회 라우트 패턴
 await assertReadingAccess("public");  // 항상 통과
 const result = await getDb().findOne("readings", { share_token });
+// whitelist 직렬화 — 새 컬럼이 추가돼도 명시하지 않으면 응답에서 자동 제외
+return Response.json(pickFields(result, READING_PUBLIC_FIELDS));
 ```
 
 소유자 전용 쓰기·삭제:
 ```ts
 await assertReadingAccess("owner");   // 소유자만 통과
 ```
+
+**응답 whitelist 패턴** (`src/lib/request-utils.ts`):
+- blacklist 방식(`delete result.user_id`)은 새 민감 컬럼 추가 시 누출 위험
+- `pickFields(obj, allowedKeys)` — 허용 필드만 추출해 IDOR/PII 회귀 방지
 
 ---
 

--- a/docs/workflow/task-playbooks.md
+++ b/docs/workflow/task-playbooks.md
@@ -22,7 +22,11 @@
 1. `src/services/core/ai-provider.ts` — 인터페이스 확인
 2. `src/services/tarot/tarot-service.ts` — 기존 구현체 참조 패턴
 3. `src/app/api/tarot/` — API 라우트 구조 참조
-4. → `.claude/agents/divination-scaffold.md` 에이전트 활용
+4. `src/services/core/prompt-builder.ts` — `buildCharacterHeader()` 재사용
+5. `src/services/core/text-cleaner.ts` — `extractFallbackText()` JSON-recovery 재사용
+6. `src/services/core/http-utils.ts` — `withAbortTimeout` / `readSseLines` Provider 공통 유틸
+7. `src/services/core/circuit-breaker.ts` — fallback 서킷 (필요 시)
+8. → `.claude/agents/divination-scaffold.md` 에이전트 활용
 
 ---
 
@@ -56,8 +60,11 @@
 ## AI 프롬프트 수정
 
 1. `src/services/core/prompt-builder.ts` — 공통 프롬프트 빌더
+   - `buildCharacterHeader(character, subtitle?)` — 타로·사주·신점 공통 캐릭터 헤더
 2. `src/services/[service]/[service]-service.ts` — 서비스별 프롬프트
 3. `src/services/core/fallback-provider.ts` — Grok→Claude fallback 동작 확인
+   - `CircuitBreaker` (`circuit-breaker.ts`) — 서킷 상태 공유
+4. `src/services/core/text-cleaner.ts` — `extractFallbackText()` JSON 파싱 실패 회수
 
 참고: [`docs/architecture/ai-infrastructure.md`](../architecture/ai-infrastructure.md)
 
@@ -107,7 +114,12 @@ Next.js `<Image>` DOM 렌더링: `/_next/image?url=%2Fpath` → `src*="/path/"` 
 1. [`docs/conventions/zod-schemas.md`](../conventions/zod-schemas.md) — Zod 스키마 먼저 정의 필수
 2. [`docs/architecture/auth-abstraction.md`](../architecture/auth-abstraction.md) — API 보안 패턴 (Rate Limit → Zod → Auth → IDOR)
 3. `src/lib/validation/api-schemas.ts` — 스키마 추가
-4. `src/__tests__/api/` — 단위 테스트 배치 (주의: `src/app/api/` 내 테스트 파일은 수집 불가)
+4. `src/lib/request-utils.ts` — 공통 헬퍼 재사용:
+   - `jsonError(msg, status)` — JSON 오류 응답
+   - `SSE_HEADERS` — SSE 스트리밍 헤더
+   - `getClientIp(headers)` — rate-limit IP 추출
+   - `pickFields(obj, keys)` — 응답 whitelist 직렬화
+5. `src/__tests__/api/` — 단위 테스트 배치 (`src/test-helpers/api-route-setup.ts` 헬퍼 활용)
 
 ---
 

--- a/docs/workflow/unit-testing.md
+++ b/docs/workflow/unit-testing.md
@@ -6,7 +6,7 @@ Vitest 기반 단위 테스트 작성 패턴과 주의사항입니다.
 
 ## 1. 테스트 현황
 
-- **587개 테스트** / statements 88%+ 커버리지
+- **599개 테스트** / statements 88%+ 커버리지
 - **Vitest 2.0** (node env, v8 coverage)
 - 임계값: `branches 75 / functions 85 / lines 88 / statements 88`
 
@@ -85,6 +85,7 @@ async function setup() {
 | `mock-request.ts` | `makePostRequest()` — NextRequest POST 헬퍼 |
 | `mock-ai.ts` | `makeMockAiModule()`, `makeMockVerum()`, `readSSEStream()` |
 | `reset-modules.ts` | `setupDoMock()` — `beforeEach(vi.resetModules)` 등록 유틸 |
+| `api-route-setup.ts` | `makeSessionRouteSetup()` / `makeResultRouteSetup()` / `makeStreamingRouteSetup()` — API 라우트 setup 보일러플레이트 |
 
 ### setupDoMock() 패턴
 


### PR DESCRIPTION
## Summary

- **CLAUDE.md**: 테스트 수 587→599, 프로젝트 구조 트리에 `request-utils.ts`/`circuit-breaker.ts`/`http-utils.ts`/`api-route-setup` 추가, SSE 스트리밍 섹션에 서버 공통 헬퍼 언급
- **ai-infrastructure.md**: `CircuitBreaker` 클래스 통합 패턴 설명, 서버/텍스트 공통 유틸 표 신설 (`withAbortTimeout`, `readSseLines`, `extractFallbackText`, `buildCharacterHeader` 등)
- **auth-abstraction.md**: `jsonError`/`SSE_HEADERS` 헬퍼, `pickFields` whitelist 패턴 (blacklist 대비 IDOR 방지 근거)
- **unit-testing.md**: 테스트 수 갱신, `api-route-setup.ts` 헬퍼 표 추가
- **task-playbooks.md**: 새 운세 서비스/새 API 라우트/AI 프롬프트 섹션에 신규 헬퍼 진입점 안내

## 관련 PR

- #155 (D1) ✅ Merged — `sonar.cpd.exclusions`
- #156 (D2) ✅ Merged — `api-route-setup.ts` 테스트 헬퍼
- #157 (D3) ⚠️ Open — `request-utils.ts` 확장 (`jsonError`, `SSE_HEADERS`)
- #158 (D4) ⚠️ Open — `circuit-breaker.ts`, `http-utils.ts`, `extractFallbackText`, `buildCharacterHeader`

> 문서는 #157/#158 머지 전이라도 미리 반영. 해당 PR이 머지되면 본 PR과 함께 적용 가능.

## Test plan

- [x] `pnpm exec tsx scripts/check-doc-links.ts` — 45개 파일, 깨진 링크 없음
- [x] `pnpm exec tsx scripts/check-env-docs.ts` — 환경변수 정합성 통과
- [x] `pnpm type-check` — 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)