### PR TITLE
docs: 문서 관리 규칙에 multi-agent 검증 의무 추가

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -192,7 +192,7 @@ pnpm exec tsx scripts/check-doc-links.ts       # docs 링크 검증
 
 **자율 관리 원칙**: 필요하면 즉시 생성, 불필요하면 즉시 삭제, 변경 후 보고. 파괴적 변경(deny 규칙·훅 삭제)만 사전 확인.
 
-**문서 관리**: 코드 변경 시 관련 문서 동시 업데이트. 중복은 링크로 대체. 변경 보고:
+**문서 관리**: 코드 변경 시 관련 문서 동시 업데이트. 중복은 링크로 대체. **High 등급(CLAUDE.md, README*, docs/architecture/*, known-issues.md, LICENSE) 변경 시 multi-agent ≥2 분리 검증 필수** (정합성·누락·구조). 변경 보고:
 ```
 📄 문서 변경: [파일명] — 변경 이유: [이유] — 변경 내용: [1줄 요약]
 ```


### PR DESCRIPTION
## Summary

- `CLAUDE.md` "문서 관리" 항목에 High 등급 문서 변경 시 multi-agent ≥2 분리 검증 필수 규칙 1줄 추가
- High 등급: CLAUDE.md, README*, docs/architecture/*, known-issues.md, LICENSE
- 검증 관점: 정합성 / 누락 / 구조 (에이전트별 분리)
- Medium(docs/workflow/*, docs/conventions/* 등) 권장, Low(오타·자동동기화) single-agent 허용
- 메모리 `feedback_document_management.md` "How to apply"에도 동일 내용 1줄 추가 (git 외부)

## 검증

- ✅ `pnpm exec tsx scripts/check-doc-links.ts` — 45개 파일, 깨진 링크 0건
- ✅ 정합성 에이전트: CLAUDE.md ↔ memory 목록·관점 일치, 기존 자율 관리 규칙과 모순 없음
- ✅ 누락 에이전트: 코드/설정 파일 제외 타당, 현 High 등급 범위 적절

🤖 Generated with [Claude Code](https://claude.ai/claude-code)