### PR TITLE
fix: Reliability quick wins — floating promise, NaN guard, circuit-breaker 타입 보강

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,7 @@
 | **인증·DB** | Supabase Auth / NextAuth.js v5 (DB_PROVIDER별 전환) |
 | **DB ORM** | Supabase PostgreSQL / Drizzle ORM (DB_PROVIDER별 전환) |
 | **상태·패키지** | Zustand v5.0, pnpm 10.33.0 |
-| **테스트** | Vitest 2.0 (592개, statements 88%), Playwright (3 디바이스) |
+| **테스트** | Vitest 2.0 (596개, statements 88%), Playwright (3 디바이스) |
 | **CI/CD·호스팅** | GitHub Actions → Railway |
 
 ## 프로젝트 구조

--- a/docs/workflow/unit-testing.md
+++ b/docs/workflow/unit-testing.md
@@ -6,7 +6,7 @@ Vitest 기반 단위 테스트 작성 패턴과 주의사항입니다.
 
 ## 1. 테스트 현황
 
-- **592개 테스트** / statements 88%+ 커버리지
+- **596개 테스트** / statements 88%+ 커버리지
 - **Vitest 2.0** (node env, v8 coverage)
 - 임계값: `branches 75 / functions 85 / lines 88 / statements 88`
 

--- a/e2e/navigation.spec.ts
+++ b/e2e/navigation.spec.ts
@@ -63,7 +63,7 @@ test.describe("네비게이션 — Header 테마 드롭다운", () => {
     await page.waitForLoadState("networkidle");
 
     // 다른 테마 클릭 (황혼의 노을) → 에러 없이 전환되면 성공
-    const sunsetBtn = page.locator("text=황혼의 노을");
+    const sunsetBtn = page.locator("button:has-text('황혼의 노을')").first();
     if (await sunsetBtn.isVisible()) {
       await sunsetBtn.click();
       await page.waitForTimeout(500);

--- a/src/__tests__/api/shinjeom-message.test.ts
+++ b/src/__tests__/api/shinjeom-message.test.ts
@@ -88,6 +88,30 @@ describe("POST /api/shinjeom/message", () => {
     expect(res.status).toBe(500);
   });
 
+  it("DB 저장 실패해도 SSE 응답 정상 완료 (fire-and-forget 비블로킹)", async () => {
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const mockSaveFail = vi.fn().mockRejectedValue(new Error("DB connection lost"));
+    vi.doMock("@/lib/db/reading-saver", () => ({
+      saveShinjeomMessages: mockSaveFail,
+      saveShinjeomFinalReading: vi.fn().mockResolvedValue(undefined),
+    }));
+    vi.doMock("@/lib/rate-limit", () => ({
+      checkRateLimit: vi.fn().mockReturnValue(true),
+      rateLimitResponse: vi.fn(),
+    }));
+    const mockDb = makeMockDb();
+    vi.doMock("@/lib/db", () => ({ getDb: vi.fn().mockReturnValue(mockDb) }));
+    vi.doMock("@/lib/auth", () => makeAuthMock());
+    vi.doMock("@/services/core/fallback-provider", () => makeMockAiModule());
+    const { POST } = await import("@/app/api/shinjeom/message/route");
+    const res = await POST(makePostRequest({ ...VALID_BODY, sessionId: "sess-sh", isFinalTurn: false }));
+    const text = await readSSEStream(res);
+    expect(text).toContain("done");
+    await Promise.resolve();
+    expect(mockSaveFail).toHaveBeenCalled();
+    consoleSpy.mockRestore();
+  });
+
   it("중간 메시지 → saveShinjeomMessages fire-and-forget 호출", async () => {
     const mockSaveMsg = vi.fn().mockResolvedValue(undefined);
     vi.doMock("@/lib/db/reading-saver", () => ({

--- a/src/app/api/shinjeom/message/route.ts
+++ b/src/app/api/shinjeom/message/route.ts
@@ -65,7 +65,7 @@ export async function POST(request: NextRequest) {
             // 결과를 먼저 클라이언트에 전송 (DB 저장은 비동기 fire-and-forget, 3회 retry)
             controller.enqueue(encoder.encode(`data: ${JSON.stringify({ done: true, isFinal: true, result })}\n\n`));
             if (db && sessionId) {
-              saveShinjeomFinalReading(db, sessionId, result).catch(
+              void saveShinjeomFinalReading(db, sessionId, result).catch(
                 (e) => console.error("신점 최종 DB 저장 최종 실패:", e)
               );
             }
@@ -73,7 +73,7 @@ export async function POST(request: NextRequest) {
             // 중간 대화 — 응답 먼저 전송, DB 저장은 비동기 (3회 retry)
             controller.enqueue(encoder.encode(`data: ${JSON.stringify({ done: true, isFinal: false, message: fullResponse })}\n\n`));
             if (db && sessionId && currentMessage && messageIndex !== undefined) {
-              saveShinjeomMessages(db, sessionId, currentMessage, fullResponse, messageIndex).catch(
+              void saveShinjeomMessages(db, sessionId, currentMessage, fullResponse, messageIndex).catch(
                 (e) => console.error("신점 메시지 DB 저장 최종 실패:", e)
               );
             }
@@ -87,7 +87,8 @@ export async function POST(request: NextRequest) {
     });
 
     return new Response(stream, { headers: SSE_HEADERS });
-  } catch {
+  } catch (err) {
+    console.error("[shinjeom-message] internal error:", err instanceof Error ? err.message : String(err));
     return jsonError("Internal server error", 500);
   }
 }

--- a/src/services/core/circuit-breaker.test.ts
+++ b/src/services/core/circuit-breaker.test.ts
@@ -62,4 +62,21 @@ describe("CircuitBreaker — globalKey 공유 상태", () => {
     shared.markDown(60_000, "shared 다운");
     expect(local.isAvailable()).toBe(true);
   });
+
+  it("globalKey 위치에 손상된 값이 있을 때 graceful 복구 후 정상 동작", () => {
+    (globalThis as Record<string, unknown>)[KEY] = "corrupted-string";
+    const cb = new CircuitBreaker({ prefix: "test", globalKey: KEY });
+    expect(cb.isAvailable()).toBe(true);
+    cb.markDown(60_000, "복구 후 다운");
+    expect(cb.isAvailable()).toBe(false);
+    cb.resetForTests();
+    expect(cb.isAvailable()).toBe(true);
+  });
+
+  it("markDown 시점에 globalKey 값이 null이면 새 State로 재생성", () => {
+    const cb = new CircuitBreaker({ prefix: "test", globalKey: KEY });
+    (globalThis as Record<string, unknown>)[KEY] = null;
+    cb.markDown(60_000, "null 상태에서 다운");
+    expect(cb.isAvailable()).toBe(false);
+  });
 });

--- a/src/services/core/circuit-breaker.ts
+++ b/src/services/core/circuit-breaker.ts
@@ -16,15 +16,27 @@ export class CircuitBreaker {
   }
 
   private getState(): State {
-    if (this.globalKey) return (globalThis as Record<string, unknown>)[this.globalKey] as State;
+    if (this.globalKey) {
+      const g = globalThis as Record<string, unknown>;
+      const val = g[this.globalKey];
+      if (typeof val === "object" && val !== null && "down" in val) return val as State;
+      g[this.globalKey] = { down: false, downUntil: 0 };
+      return g[this.globalKey] as State;
+    }
     return { down: this._down, downUntil: this._downUntil };
   }
 
   private setState(down: boolean, downUntil: number): void {
     if (this.globalKey) {
-      const s = (globalThis as Record<string, unknown>)[this.globalKey] as State;
-      s.down = down;
-      s.downUntil = downUntil;
+      const g = globalThis as Record<string, unknown>;
+      const val = g[this.globalKey];
+      if (typeof val === "object" && val !== null) {
+        const s = val as State;
+        s.down = down;
+        s.downUntil = downUntil;
+      } else {
+        g[this.globalKey] = { down, downUntil };
+      }
     } else {
       this._down = down;
       this._downUntil = downUntil;

--- a/src/services/core/grok-provider.test.ts
+++ b/src/services/core/grok-provider.test.ts
@@ -152,6 +152,16 @@ describe("GrokProvider", () => {
       expect((error as RateLimitError).retryAfterMs).toBe(30000);
     });
 
+    it("429 + retry-after 헤더가 비숫자이면 기본 30초로 fallback한다", async () => {
+      mockFetch.mockResolvedValue(
+        makeErrorResponse(429, "rate limited", { "retry-after": "not-a-number" })
+      );
+
+      const error = await provider.generateReading("s", "u").catch((e) => e);
+      expect(error).toBeInstanceOf(RateLimitError);
+      expect((error as RateLimitError).retryAfterMs).toBe(30000);
+    });
+
     it("500 응답 시 일반 Error를 던진다", async () => {
       mockFetch.mockResolvedValue(makeErrorResponse(500, "server error"));
 

--- a/src/services/core/grok-provider.ts
+++ b/src/services/core/grok-provider.ts
@@ -55,7 +55,8 @@ export class GrokProvider implements AIProvider {
       return response.text().then((e) => { throw new AuthError(response.status, e); });
     }
     if (response.status === 429) {
-      const retryAfter = parseInt(response.headers.get("retry-after") ?? String(DEFAULT_RETRY_AFTER_SEC), 10) * 1000;
+      const raw = Number.parseInt(response.headers.get("retry-after") ?? "", 10);
+      const retryAfter = (Number.isNaN(raw) ? DEFAULT_RETRY_AFTER_SEC : raw) * 1000;
       return Promise.reject(new RateLimitError(retryAfter));
     }
     return response.text().then((e) => { throw new Error(`Grok API error (${response.status}): ${e}`); });


### PR DESCRIPTION
## Summary

- `shinjeom/message/route.ts`: fire-and-forget DB 저장 2건에 `void` 키워드 추가 (SonarQube S6544), 빈 catch → 에러 로깅 추가 (S2486)
- `grok-provider.ts`: `retry-after` 파싱에 `Number.parseInt` + `Number.isNaN` 적용 — 비숫자 헤더 값 수신 시 silent 장애 방지 (S7773)
- `circuit-breaker.ts`: `globalThis` 공유 상태에 타입 가드 추가 — 손상된 값 수신 시 graceful 복구 (S4204)

## 신규 테스트 (+4)

- `grok-provider.test.ts`: 비숫자 `retry-after` → 30초 fallback 검증
- `circuit-breaker.test.ts`: 손상된/null globalKey 값 복구 검증 (2건)
- `shinjeom-message.test.ts`: DB 저장 실패가 SSE 응답에 영향 없음 (fire-and-forget 비블로킹) 검증

## 예상 효과

- Reliability: 12~15건 → 7~10건 (목표 ≤10건 달성)
- 테스트: 592 → 596개
- `circuit-breaker.ts`: lines 100% / branches 100% 달성

## Test plan

- [x] `pnpm type-check` 통과
- [x] `pnpm lint` 통과
- [x] `pnpm test:coverage` 596개 통과
- [ ] CI: lint → test → build

🤖 Generated with [Claude Code](https://claude.com/claude-code)