### PR TITLE
test: 분기 커버리지 보강 — services/ + fallback-provider 부분-yield 버그 수정

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,7 @@
 | **인증·DB** | Supabase Auth / NextAuth.js v5 (DB_PROVIDER별 전환) |
 | **DB ORM** | Supabase PostgreSQL / Drizzle ORM (DB_PROVIDER별 전환) |
 | **상태·패키지** | Zustand v5.0, pnpm 10.33.0 |
-| **테스트** | Vitest 2.0 (596개, statements 88%), Playwright (3 디바이스) |
+| **테스트** | Vitest 2.0 (609개, statements 88%), Playwright (3 디바이스) |
 | **CI/CD·호스팅** | GitHub Actions → Railway |
 
 ## 프로젝트 구조

--- a/docs/workflow/unit-testing.md
+++ b/docs/workflow/unit-testing.md
@@ -6,7 +6,7 @@ Vitest 기반 단위 테스트 작성 패턴과 주의사항입니다.
 
 ## 1. 테스트 현황
 
-- **596개 테스트** / statements 88%+ 커버리지
+- **609개 테스트** / statements 88%+ 커버리지
 - **Vitest 2.0** (node env, v8 coverage)
 - 임계값: `branches 75 / functions 85 / lines 88 / statements 88`
 

--- a/src/services/core/fallback-provider.test.ts
+++ b/src/services/core/fallback-provider.test.ts
@@ -43,6 +43,12 @@ async function* makeStream(chunks: string[]): AsyncGenerator<string, void, unkno
   }
 }
 
+/** 청크를 일부 yield 후 throw하는 Grok 부분 스트림 시뮬레이터 */
+async function* makePartialThenFailStream(chunks: string[], errorMsg: string): AsyncGenerator<string, void, unknown> {
+  for (const chunk of chunks) yield chunk;
+  throw new Error(errorMsg);
+}
+
 describe("FallbackProvider", () => {
   let mockGrokInstance: {
     generateReading: ReturnType<typeof vi.fn>;
@@ -276,6 +282,44 @@ describe("FallbackProvider", () => {
       expect(result).toBe("Claude 응답");
       expect(mockGrokInstance.generateReading).toHaveBeenCalledOnce(); // provider1에서 1회만
       expect(mockClaudeInstance.generateReading).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  // ─── streamReading — ANTHROPIC_API_KEY 미설정 + Grok 실패 ─────────────────
+
+  describe("streamReading — ANTHROPIC_API_KEY 미설정 + Grok 실패", () => {
+    it("Claude 키 없이 Grok 스트림이 실패하면 원래 에러를 throw한다", async () => {
+      process.env.ANTHROPIC_API_KEY = "";
+      mockGrokInstance.streamReading = vi.fn().mockReturnValue(makePartialThenFailStream([], "Grok 스트림 에러"));
+
+      const provider = new FallbackProvider();
+      await expect(collectStream(provider.streamReading("s", "u"))).rejects.toThrow("Grok 스트림 에러");
+      expect(mockClaudeInstance.streamReading).not.toHaveBeenCalled();
+    });
+  });
+
+  // ─── streamReading — 부분 yield 후 throw → Claude fallback 차단 ──────────
+
+  describe("streamReading — 부분 yield 후 Grok throw → Claude fallback 차단", () => {
+    it("Grok가 청크를 일부 yield한 뒤 throw하면 Claude로 fallback하지 않는다", async () => {
+      mockGrokInstance.streamReading = vi.fn().mockReturnValue(
+        makePartialThenFailStream(["청크1", "청크2"], "중간에 스트림 끊김")
+      );
+      mockClaudeInstance.streamReading = vi.fn().mockReturnValue(makeStream(["Claude 청크"]));
+
+      const provider = new FallbackProvider();
+      await expect(collectStream(provider.streamReading("s", "u"))).rejects.toThrow("중간에 스트림 끊김");
+      expect(mockClaudeInstance.streamReading).not.toHaveBeenCalled();
+    });
+
+    it("Grok가 청크를 yield하지 않고 즉시 throw하면 Claude로 fallback된다", async () => {
+      mockGrokInstance.streamReading = vi.fn().mockReturnValue(makePartialThenFailStream([], "즉시 실패"));
+      mockClaudeInstance.streamReading = vi.fn().mockReturnValue(makeStream(["Claude 응답"]));
+
+      const provider = new FallbackProvider();
+      const result = await collectStream(provider.streamReading("s", "u"));
+      expect(result).toEqual(["Claude 응답"]);
+      expect(mockClaudeInstance.streamReading).toHaveBeenCalledOnce();
     });
   });
 });

--- a/src/services/core/fallback-provider.ts
+++ b/src/services/core/fallback-provider.ts
@@ -74,11 +74,16 @@ export class FallbackProvider implements AIProvider {
 
   async *streamReading(systemPrompt: string, userPrompt: string, maxTokens?: number): AsyncGenerator<string, void, unknown> {
     if (grokCircuit.isAvailable()) {
+      let hasYielded = false;
       try {
-        yield* this.grok.streamReading(systemPrompt, userPrompt, maxTokens);
+        for await (const chunk of this.grok.streamReading(systemPrompt, userPrompt, maxTokens)) {
+          hasYielded = true;
+          yield chunk;
+        }
         return;
       } catch (e) {
         console.error("[FallbackProvider] Grok streamReading 실패:", e);
+        if (hasYielded) throw e;
         if (this.hasClaude()) {
           this.handleGrokError(e);
         } else {

--- a/src/services/saju/saju-calculator.test.ts
+++ b/src/services/saju/saju-calculator.test.ts
@@ -167,7 +167,7 @@ describe("calculateSaju", () => {
       // 합/충/형 문자열이 있다면 포맷을 검증
       for (const s of allInteractions) {
         expect(s).toMatch(/^(연지|월지|일지|시지)/);
-        expect(s).toMatch(/(합|충|형)$/);
+        expect(s).toMatch(/[합충형]$/);
       }
     });
   });
@@ -276,6 +276,11 @@ describe("calculateSaju", () => {
 
     it("yearlyMulti 없으면 yearlyFortunes가 undefined다", () => {
       const result = calculateSaju(MALE_1990);
+      expect(result.yearlyFortunes).toBeUndefined();
+    });
+
+    it("yearlyMulti가 음수이면 yearlyFortunes가 undefined다 (0 이하 조건)", () => {
+      const result = calculateSaju(MALE_1990, { yearlyMulti: -1 });
       expect(result.yearlyFortunes).toBeUndefined();
     });
   });

--- a/src/services/saju/saju-service.test.ts
+++ b/src/services/saju/saju-service.test.ts
@@ -238,6 +238,80 @@ describe("SajuService", () => {
     });
   });
 
+  describe("buildSajuPrompt — 추가 fortune 섹션", () => {
+    it("'this-month' + monthlyFortunes 제공 시 이번 달 운세 섹션이 포함된다", () => {
+      const thisMonth = new Date().getMonth() + 1;
+      const monthlyFortunes = Array.from({ length: 12 }, (_, i) => ({
+        month: i + 1,
+        stem: "갑",
+        branch: "자",
+        element: "wood" as const,
+        description: `${i + 1}월 운세`,
+      }));
+      const prompt = service.buildSajuPrompt(
+        "saju-general",
+        "this-month",
+        makeSajuResult({ monthlyFortunes }),
+      );
+      expect(prompt).toContain(`${thisMonth}월`);
+      expect(prompt).toContain("이번 달 월운");
+    });
+
+    it("yearlyFortunes 제공 시 세운 전망 섹션이 포함된다", () => {
+      const prompt = service.buildSajuPrompt(
+        "saju-general",
+        "next-year",
+        makeSajuResult({
+          yearlyFortunes: [
+            { year: 2025, stem: "을", branch: "사", element: "wood", description: "2025년 운세" },
+            { year: 2026, stem: "병", branch: "오", element: "fire", description: "2026년 운세" },
+          ],
+        })
+      );
+      expect(prompt).toContain("세운 전망");
+    });
+
+    it("dailyFortunes 제공 시 이번 주 일운 섹션이 포함된다", () => {
+      const prompt = service.buildSajuPrompt(
+        "saju-general",
+        "this-week",
+        makeSajuResult({
+          dailyFortunes: [
+            { date: "2026-04-26", stem: "갑", branch: "자", element: "wood", description: "일요일 운세" },
+          ],
+        })
+      );
+      expect(prompt).toContain("이번 주 일운");
+    });
+
+    it("'three-year' timeRange 시 향후 3년 컨텍스트가 포함된다", () => {
+      const prompt = service.buildSajuPrompt("saju-general", "three-year", makeSajuResult());
+      expect(prompt).toContain("3년");
+    });
+  });
+
+  describe("buildSajuPrompt — 알 수 없는 topic fallback", () => {
+    it("등록되지 않은 topic이면 topic 문자열 자체가 프롬프트에 포함된다", () => {
+      const prompt = service.buildSajuPrompt(
+        "unknown-topic" as Parameters<typeof service.buildSajuPrompt>[0],
+        "this-year",
+        makeSajuResult()
+      );
+      expect(prompt).toContain("unknown-topic");
+    });
+  });
+
+  describe("buildSajuPrompt — isStrong false(신약)", () => {
+    it("isStrong false 시 프롬프트에 '신약'이 포함된다", () => {
+      const prompt = service.buildSajuPrompt(
+        "saju-general",
+        "this-year",
+        makeSajuResult({ isStrong: false })
+      );
+      expect(prompt).toContain("신약");
+    });
+  });
+
   // ─── parseResult ──────────────────────────────────────────────────────────
 
   describe("parseResult", () => {

--- a/src/services/shinjeom/shinjeom-service.test.ts
+++ b/src/services/shinjeom/shinjeom-service.test.ts
@@ -243,6 +243,22 @@ describe("ShinjeomService", () => {
     });
   });
 
+  // ─── getReadingPrompt ─────────────────────────────────────────────────────
+
+  describe("getReadingPrompt", () => {
+    it("chatHistory가 비어있으면 currentMessage가 빈 문자열로 처리된다", () => {
+      const context = {
+        topic: "shinjeom-general",
+        chatHistory: [],
+        session: { spreadType: null, selectedCards: [] },
+        selectedCards: [],
+      };
+      const prompt = service.getReadingPrompt(context as unknown as Parameters<typeof service.getReadingPrompt>[0]);
+      expect(typeof prompt).toBe("string");
+      expect(prompt.length).toBeGreaterThan(0);
+    });
+  });
+
   // ─── topicLabels 매핑 ─────────────────────────────────────────────────────
 
   describe("topicLabels 매핑 — buildConversationPrompt 프롬프트 반영", () => {
@@ -263,6 +279,16 @@ describe("ShinjeomService", () => {
         false
       );
       expect(prompt).toContain(label);
+    });
+
+    it("등록되지 않은 topic이면 topic 문자열 자체가 프롬프트에 포함된다", () => {
+      const prompt = service.buildConversationPrompt(
+        "unknown-topic" as Parameters<typeof service.buildConversationPrompt>[0],
+        "메시지",
+        [],
+        false
+      );
+      expect(prompt).toContain("unknown-topic");
     });
   });
 
@@ -309,6 +335,22 @@ describe("ShinjeomService", () => {
 
       const result = service.parseResult(partialJson);
       expect(result.overallReading).toContain("종합 운세");
+    });
+
+    it("overallReading 필드가 없는 빈 JSON이면 빈 문자열로 처리한다", () => {
+      // parsed.overallReading || "" 에서 || "" 분기 (L128)
+      const result = service.parseResult("{}");
+      expect(typeof result.overallReading).toBe("string");
+    });
+
+    it("중괄호가 포함됐지만 JSON.parse가 실패하면 경고 후 텍스트 fallback 반환", () => {
+      const consoleSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      // 중괄호는 있지만 유효하지 않은 JSON — match() 는 성공하나 JSON.parse 실패
+      const brokenJson = "결과는 다음과 같습니다: {invalid json here}";
+      const result = service.parseResult(brokenJson);
+      expect(result.overallReading).toBeTruthy();
+      expect(consoleSpy).toHaveBeenCalled();
+      consoleSpy.mockRestore();
     });
   });
 });

--- a/src/services/tarot/tarot-service.test.ts
+++ b/src/services/tarot/tarot-service.test.ts
@@ -142,6 +142,34 @@ describe("TarotService", () => {
     });
   });
 
+  describe("getReadingPrompt(context)", () => {
+    it("session.spreadType이 있으면 그 spreadType을 우선 사용한다", () => {
+      // spreadType이 있을 때 → getSpreadByType() 호출 분기
+      const context = {
+        session: { spreadType: "three-card", selectedCards: [] },
+        topic: "love",
+        chatHistory: [],
+        selectedCards: [],
+      };
+      const prompt = service.getReadingPrompt(context as unknown as Parameters<typeof service.getReadingPrompt>[0]);
+      expect(typeof prompt).toBe("string");
+      expect(prompt.length).toBeGreaterThan(0);
+    });
+
+    it("session.spreadType이 null이면 topic으로 spreadType을 결정한다", () => {
+      // spreadType이 null → resolveForTopic() 분기
+      const context = {
+        session: { spreadType: null, selectedCards: [] },
+        topic: "health",
+        chatHistory: [],
+        selectedCards: [],
+      };
+      const prompt = service.getReadingPrompt(context as unknown as Parameters<typeof service.getReadingPrompt>[0]);
+      expect(typeof prompt).toBe("string");
+      expect(prompt.length).toBeGreaterThan(0);
+    });
+  });
+
   describe("parseResult(aiResponse)", () => {
     it("유효한 JSON 응답을 파싱해 cardInterpretations 배열을 반환한다", () => {
       const validJson = JSON.stringify({
@@ -253,6 +281,12 @@ describe("TarotService", () => {
 
     it("빈 문자열 입력 시 Error를 던지지 않는다", () => {
       expect(() => service.parseResult("")).not.toThrow();
+    });
+
+    it("JSON 파싱 실패 + extractFallbackText 결과 빈 문자열이면 기본 에러 메시지를 반환한다", () => {
+      // 빈 문자열 → extractFallbackText("") = "" → cleanText || "해석 결과..." fallback
+      const result = service.parseResult("");
+      expect(result.overallReading).toContain("해석 결과를 처리하는 중 문제가 발생했습니다");
     });
   });
 });


### PR DESCRIPTION
## Summary

- `fallback-provider.ts` 부분-yield 후 throw 시 두 모델 응답이 합쳐지는 버그 수정 (`hasYielded` 플래그)
- `saju-service.ts` 분기 커버리지 70.58% → 91.22% (monthlyFortunes/yearlyFortunes/dailyFortunes/three-year/unknown-topic/isStrong 분기)
- `shinjeom-service.ts` 분기 커버리지 84% → 92.59% (getReadingPrompt, unknown-topic, 빈 JSON, catch 분기)
- `tarot-service.ts` 분기 커버리지 69.56% → 79.16% (getReadingPrompt spreadType 분기, 빈 입력 기본 에러 메시지)
- `fallback-provider.ts` 분기 커버리지 97% → ~99% (ANTHROPIC_API_KEY 미설정+스트림 실패, 부분 yield 차단)
- `saju-calculator.test.ts` S6035 정규식 수정 (`/(합|충|형)$/` → `/[합충형]$/`)
- 테스트 수: 592 → 609개 | Overall branches: 84.51% → 87.22%

## Test plan

- [x] `pnpm type-check` 통과
- [x] `pnpm lint` 통과
- [x] `pnpm test` 609개 전체 통과
- [x] `pnpm exec tsx scripts/sync-test-count.ts` CLAUDE.md 갱신 완료

🤖 Generated with [Claude Code](https://claude.com/claude-code)