### PR TITLE
refactor: postgres-adapter Drizzle 정식 API 적용 + Upstash Redis 설정 가이드

### DIFF
--- a/docs/operations/deployment.md
+++ b/docs/operations/deployment.md
@@ -60,6 +60,35 @@ git push origin main
 
 ---
 
+## Rate-Limit Redis 활성화 (Upstash)
+
+현재 rate-limit은 서버 메모리 기반 fallback으로 동작합니다 (단일 인스턴스에서는 정상).
+다중 인스턴스 또는 서버 재시작 시 카운터가 초기화되는 문제를 방지하려면 Upstash Redis를 연결합니다.
+
+### 1단계 — Upstash 데이터베이스 생성
+
+1. [console.upstash.com](https://console.upstash.com) 접속 → 새 Redis 데이터베이스 생성
+2. **Region**: 서비스 지역에 가장 가까운 곳 선택 (지연 최소화)
+3. **Type**: Regional (무료 티어: 10,000 req/day)
+
+### 2단계 — Railway 환경변수 등록
+
+Railway 대시보드 → 서비스 → Variables 탭:
+
+```
+UPSTASH_REDIS_REST_URL   = https://xxx-xxxxx.upstash.io
+UPSTASH_REDIS_REST_TOKEN = AXxx...
+```
+
+Upstash 콘솔의 **REST API** 탭에서 두 값을 복사합니다.
+
+### 3단계 — 반영 확인
+
+Railway 변수 저장 → 자동 재배포 완료 후, `/api/tarot/reading` 엔드포인트에 연속 요청 시
+Redis INCR 카운터가 누적되면 정상. `railway logs --tail`로 rate-limit 관련 에러가 없으면 완료.
+
+---
+
 ## 빌드 실패 대응
 
 1. Railway 대시보드 → Build Logs 확인

--- a/docs/operations/known-issues.md
+++ b/docs/operations/known-issues.md
@@ -21,7 +21,7 @@
 | 커버리지 측정 범위 협소 | `vitest.config.ts` coverage.include | whitelist 방식, 전체 코드의 일부만 측정 | include 확장 또는 exclude 방식 전환 시 처리 |
 | rate-limit Redis 미설정 | `src/lib/rate-limit.ts` | `UPSTASH_REDIS_REST_URL` 미설정 시 in-memory fallback 동작 | Railway에서 Upstash 연결 설정 시 분산 처리 활성화 |
 | SupabaseAdapter 통합 테스트 부재 | `src/lib/db/supabase-adapter.ts` | mock 체인이 자기충족적, 실제 Supabase 응답 미검증 | 통합 테스트 환경 구축 후 처리 |
-| `postgres-adapter.ts` Drizzle `as any` 8건 | `src/lib/db/postgres-adapter.ts` | `DbClient` 제네릭 인터페이스와 Drizzle 타입 불일치로 `as any` 불가피 | Drizzle 타입 기반 PostgresAdapter 전면 재설계 시 처리 |
+| `postgres-adapter.ts` Drizzle `as any` 잔존 4건 | `src/lib/db/postgres-adapter.ts` | `getTableColumns`·`.$dynamic()` 적용으로 8→4건 감소 (PR #175). `.values(data as any)`·`.set(data as any)` 4건은 `DbClient` 제네릭과 Drizzle `InferInsertModel` 불일치로 구조적 불가피 | PostgresAdapter 전면 재설계 시 처리 |
 
 ---
 

--- a/src/lib/db/postgres-adapter.test.ts
+++ b/src/lib/db/postgres-adapter.test.ts
@@ -21,7 +21,7 @@ vi.mock("drizzle-orm/postgres-js", () => ({
 
 // ─── 헬퍼: 플루언트 체인 구성 ─────────────────────────────────────────────
 
-/** select().from(t)[.where(...)][.limit(N)][.offset(N)] 체인을 rows로 응답 */
+/** select().from(t).$dynamic()[.where(...)][.limit(N)][.offset(N)] 체인을 rows로 응답 */
 function mockSelectWith(rows: Record<string, unknown>[]) {
   const withOffset = {
     then: (resolve: (v: unknown) => unknown) => Promise.resolve(rows).then(resolve),
@@ -35,7 +35,15 @@ function mockSelectWith(rows: Record<string, unknown>[]) {
     limit: vi.fn().mockReturnValue(withOffset),
     offset: vi.fn().mockResolvedValue(rows),
   };
-  mockDb.select = vi.fn().mockReturnValue({ from: vi.fn().mockReturnValue(thenable) });
+  const fromChain = {
+    $dynamic: vi.fn().mockReturnValue(thenable),
+    where: thenable.where,
+    limit: thenable.limit,
+    offset: thenable.offset,
+    then: thenable.then,
+    catch: thenable.catch,
+  };
+  mockDb.select = vi.fn().mockReturnValue({ from: vi.fn().mockReturnValue(fromChain) });
 }
 
 /** insert(t).values(d).returning() 체인을 rows로 응답 */

--- a/src/lib/db/postgres-adapter.ts
+++ b/src/lib/db/postgres-adapter.ts
@@ -1,6 +1,6 @@
 import { drizzle } from "drizzle-orm/postgres-js"
 import postgres from "postgres"
-import { eq, and, inArray } from "drizzle-orm"
+import { eq, and, inArray, getTableColumns } from "drizzle-orm"
 import type { PgTable, PgColumn } from "drizzle-orm/pg-core"
 import type { ColumnBaseConfig, ColumnDataType } from "drizzle-orm"
 import * as schema from "./schema/index"
@@ -56,11 +56,11 @@ function normalizeRow<T>(row: Record<string, unknown>): T {
 }
 
 function buildConditions(table: PgTable, where: Record<string, unknown>) {
+  const cols = getTableColumns(table)
   return Object.entries(where).map(([k, v]) => {
-    const col = (table as unknown as Record<string, unknown>)[k]
-      ?? (table as unknown as Record<string, unknown>)[snakeToCamel(k)]
+    const col = cols[k] ?? cols[snakeToCamel(k)]
     if (!col) throw new Error(`Unknown column: ${k}`)
-    return eq(col as Parameters<typeof eq>[0], v)
+    return eq(col, v)
   })
 }
 
@@ -77,8 +77,7 @@ export class PostgresAdapter implements DbClient {
     const db = getConnection()
     const t = resolveTable(table)
     const conditions = (where && Object.keys(where).length > 0) ? buildConditions(t, where) : null
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    let q: any = db.select().from(t)
+    let q = db.select().from(t).$dynamic()
     if (conditions) q = q.where(and(...conditions))
     if (options?.limit !== undefined) q = q.limit(options.limit)
     if (options?.offset !== undefined) q = q.offset(options.offset)
@@ -90,11 +89,10 @@ export class PostgresAdapter implements DbClient {
     if (values.length === 0) return []
     const db = getConnection()
     const t = resolveTable(table)
-    const col = (t as unknown as Record<string, unknown>)[column]
-      ?? (t as unknown as Record<string, unknown>)[snakeToCamel(column)]
+    const cols = getTableColumns(t)
+    const col = cols[column] ?? cols[snakeToCamel(column)]
     if (!col) throw new Error(`Unknown column: ${column}`)
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const result = await db.select().from(t).where(inArray(col as any, values as any[]))
+    const result = await db.select().from(t).where(inArray(col, values))
     return (result as Record<string, unknown>[]).map((r) => normalizeRow<T>(r))
   }
 
@@ -128,9 +126,9 @@ export class PostgresAdapter implements DbClient {
     const db = getConnection()
     const t = resolveTable(table)
     const conflictKeys = new Set(conflictOn.split(",").map((k) => k.trim()))
+    const tableCols = getTableColumns(t)
     const conflictCols = Array.from(conflictKeys).map((key) => {
-      const col = (t as unknown as Record<string, unknown>)[key]
-        ?? (t as unknown as Record<string, unknown>)[snakeToCamel(key)]
+      const col = tableCols[key] ?? tableCols[snakeToCamel(key)]
       if (!col) throw new Error(`Unknown conflict column: ${key}`)
       return col as PgColumn<ColumnBaseConfig<ColumnDataType, string>>
     })


### PR DESCRIPTION
## Summary

- **postgres-adapter 타입 개선**: `getTableColumns()`·`.$dynamic()` 도입으로 `as unknown` 이중 캐스트 6개 + `let q: any` + `col as any` 2개 제거 — ESLint disable 주석 8 → 4건으로 감소. 런타임 동작 무변경, 타입 레벨 개선만.
- **잔존 `as any` 4건**: `.values(data as any)`·`.set(data as any)` — `DbClient` 제네릭과 Drizzle `InferInsertModel` 구조적 불일치로 불가피. `known-issues.md` 반영.
- **Upstash Redis 설정 가이드**: `deployment.md`에 3단계 활성화 절차 추가 (콘솔 → Railway 환경변수 → 확인).

## Test plan

- [x] `pnpm type-check` — 오류 없음
- [x] `pnpm lint` — 경고/오류 없음
- [x] `pnpm test:coverage` — 657개 전체 통과, 임계치 위반 없음
- [ ] CI 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)