### PR TITLE
fix: JSON 파싱 버그 수정 — 문자열 내부 중괄호로 인한 결과 깨짐 방지

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -157,6 +157,7 @@ pnpm exec tsx scripts/check-doc-links.ts       # docs 링크 검증
 6. **API 라우트 outer catch 커버리지**: `POST` 핸들러 최외부 `} catch {` 블록은 `checkRateLimit: vi.fn().mockRejectedValue(new Error(...))` 패턴으로 커버. 미커버 시 Codecov patch 실패.
 7. **SSE 라우트 fire-and-forget 패턴**: 스트림 전송 완료 후 DB 저장은 `void saveFn(args).catch(e => console.error("[tag]", e))` 패턴 필수. `await` 금지 (스트림 블로킹). tarot·saju·shinjeom reading 라우트 모두 동일 패턴 적용.
 8. **DB 어댑터 동적 require**: `src/lib/db/index.ts`의 `getDb()`는 런타임에 `DB_PROVIDER`에 따라 `require()`로 어댑터 로드. 새 어댑터 추가 시 정적 `import` 금지 — 번들에 항상 포함되어 불필요한 의존성 로드 발생.
+9. **JSON 파싱 — 문자열 내 `{}` 주의**: AI 응답 파싱 시 단순 괄호 카운터(`text[i] === "{"`)나 탐욕적 정규식(`/\{[\s\S]*\}/`)은 문자열 값 안의 `{}`를 구분 못해 조기 종료 or 과잉 추출 발생. 반드시 `parseJsonSafe()` (`src/services/core/text-cleaner.ts`) 사용. — **2026-04-26 타로·신점 결과 노출 장애 원인**. → [`docs/architecture/ai-infrastructure.md`](docs/architecture/ai-infrastructure.md#3-json-파싱-파이프라인)
 
 ## 업무 유형별 가이드
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,7 @@
 | **인증·DB** | Supabase Auth / NextAuth.js v5 (DB_PROVIDER별 전환) |
 | **DB ORM** | Supabase PostgreSQL / Drizzle ORM (DB_PROVIDER별 전환) |
 | **상태·패키지** | Zustand v5.0, pnpm 10.33.0 |
-| **테스트** | Vitest 2.0 (657개, statements 98%), Playwright (3 디바이스) |
+| **테스트** | Vitest 2.0 (663개, statements 98%), Playwright (3 디바이스) |
 | **CI/CD·호스팅** | GitHub Actions → Railway |
 
 ## 프로젝트 구조

--- a/docs/architecture/ai-infrastructure.md
+++ b/docs/architecture/ai-infrastructure.md
@@ -71,6 +71,63 @@ new CircuitBreaker({ prefix: "FallbackProvider/Grok", globalKey: "grok_circuit" 
 
 | 유틸 | 위치 | 역할 |
 |------|------|------|
-| `extractFallbackText(raw)` | `src/services/core/text-cleaner.ts` | JSON 파싱 실패 시 본문 회수 (tarot/saju 공용, ReDoS-safe) |
+| `parseJsonSafe(raw)` | `src/services/core/text-cleaner.ts` | thinking 토큰 제거 → 코드블록 추출 → 문자열-aware 괄호 카운터로 JSON 추출 → 2차 파싱 시도 |
+| `extractFallbackText(raw)` | `src/services/core/text-cleaner.ts` | JSON 파싱 완전 실패 시 본문 회수 (tarot/saju 공용, ReDoS-safe) |
+| `cleanReadingText(text)` | `src/services/core/text-cleaner.ts` | 파싱 후 JSON 잔여물·이스케이프 정리 |
 | `buildCharacterHeader(character, subtitle?)` | `src/services/core/prompt-builder.ts` | 3 서비스 공통 캐릭터 system-prompt 헤더 |
+
+---
+
+## 3. JSON 파싱 파이프라인
+
+타로·사주·신점 리딩 결과는 AI가 JSON 문자열로 응답하며 서버에서 파싱한다.
+
+```
+AI 스트리밍 응답 (fullResponse 누적)
+    │
+    ├─ parseJsonSafe(fullResponse)
+    │      1. thinking 토큰 제거 (<think>...</think>)
+    │      2. 마크다운 코드블록 추출 (```json ... ```)
+    │      3. findOutermostObjectEnd() — 문자열-aware 괄호 카운팅
+    │      4. JSON.parse 1차 시도
+    │      5. 문자열 내 리터럴 개행 이스케이프 후 2차 시도
+    │      → 성공: Record<string, unknown>
+    │      → 실패: null
+    │
+    ├─ 성공 → cleanReadingText(field) 후 ReadingResult 반환
+    └─ 실패 → extractFallbackText(raw) 또는 원문 텍스트 반환
+```
+
+### 핵심 주의사항 — 문자열 내 중괄호
+
+AI 응답에 `"현재는 {도전의 시기}입니다"` 처럼 한국어 표현이 JSON 문자열 값
+안에 `{}`를 포함하는 경우가 빈번하다.
+
+**잘못된 패턴 (단순 괄호 카운터)**:
+```ts
+// ❌ 문자열 내 } 를 JSON 끝으로 오인 → 조기 종료
+for (let i = start; i < text.length; i++) {
+  if (text[i] === "{") depth++;
+  else if (text[i] === "}") { depth--; if (!depth) { end = i; break; } }
+}
+```
+
+**올바른 패턴 (`findOutermostObjectEnd`)**:
+```ts
+// ✅ inString + escape 상태로 문자열 내부의 { } 는 카운트 제외
+let inString = false, escape = false;
+for (let i = start; i < text.length; i++) {
+  const ch = text[i];
+  if (escape)        { escape = false; continue; }
+  if (ch === "\\")   { escape = true;  continue; }
+  if (ch === '"')    { inString = !inString; continue; }
+  if (inString)      continue;
+  if (ch === "{")    depth++;
+  else if (ch === "}") { depth--; if (!depth) return i; }
+}
+```
+
+**탐욕적 정규식도 동일 문제** — `/\{[\s\S]*\}/`는 첫 `{`부터 마지막 `}`까지
+잡기 때문에 여러 JSON 블록이 있거나 값에 `}`가 포함되면 오파싱된다.
+`shinjeom-service.ts`가 이 정규식을 사용하다가 `parseJsonSafe()`로 교체됨.
 

--- a/docs/workflow/unit-testing.md
+++ b/docs/workflow/unit-testing.md
@@ -6,7 +6,7 @@ Vitest 기반 단위 테스트 작성 패턴과 주의사항입니다.
 
 ## 1. 테스트 현황
 
-- **657개 테스트** / statements 88%+ 커버리지
+- **663개 테스트** / statements 88%+ 커버리지
 - **Vitest 2.0** (node env, v8 coverage)
 - 임계값: `branches 92 / functions 98 / lines 98 / statements 98`
 

--- a/src/services/core/text-cleaner.test.ts
+++ b/src/services/core/text-cleaner.test.ts
@@ -239,6 +239,45 @@ describe("parseJsonSafe", () => {
   it("닫히지 않은 중괄호는 null 반환", () => {
     expect(parseJsonSafe('{"key": "unclosed')).toBeNull();
   });
+
+  it("문자열 값 안에 { } 가 있어도 올바르게 파싱한다 (bracket counting 버그 재현)", () => {
+    // 핵심 버그: "현재는 {도전의 시기}입니다" 에서 문자열 내 } 를 JSON 끝으로 오인
+    const input = JSON.stringify({
+      overallReading: "현재는 {도전의 시기}이지만 곧 좋아집니다",
+      advice: "인내하세요",
+    });
+    const result = parseJsonSafe(input);
+    expect(result).not.toBeNull();
+    expect(result?.overallReading).toContain("도전의 시기");
+    expect(result?.advice).toBe("인내하세요");
+  });
+
+  it("문자열 값 안에 중첩 { } 표현이 있어도 파싱한다", () => {
+    const input = JSON.stringify({
+      overallReading: "운세: {길흉 {대소}를 살피면}",
+      advice: "조언입니다",
+    });
+    const result = parseJsonSafe(input);
+    expect(result).not.toBeNull();
+    expect(result?.overallReading).toContain("길흉");
+  });
+
+  it("이스케이프된 큰따옴표가 포함된 문자열 값을 올바르게 파싱한다", () => {
+    const raw = `{"overallReading": "그는 \\"행운\\"이라 했다", "advice": "믿으세요"}`;
+    const result = parseJsonSafe(raw);
+    expect(result).not.toBeNull();
+    expect(result?.overallReading).toContain("행운");
+    expect(result?.advice).toBe("믿으세요");
+  });
+
+  it("thinking 토큰 뒤에 { } 포함 JSON 값이 있어도 파싱한다", () => {
+    const input =
+      `<think>내부 사고</think>` +
+      JSON.stringify({ overallReading: "현재 {변화의 기로}입니다", advice: "결단하세요" });
+    const result = parseJsonSafe(input);
+    expect(result).not.toBeNull();
+    expect(result?.overallReading).toContain("변화의 기로");
+  });
 });
 
 describe("extractFallbackText", () => {

--- a/src/services/core/text-cleaner.ts
+++ b/src/services/core/text-cleaner.ts
@@ -37,12 +37,32 @@ export function cleanReadingText(text: string): string {
 }
 
 /**
+ * 문자열 리터럴 내부의 { } 를 무시하면서 가장 바깥 JSON 객체의 끝 인덱스를 반환.
+ * 닫히지 않은 경우 -1 반환.
+ */
+function findOutermostObjectEnd(text: string, start: number): number {
+  let depth = 0;
+  let inString = false;
+  let escape = false;
+  for (let i = start; i < text.length; i++) {
+    const ch = text[i];
+    if (escape) { escape = false; continue; }
+    if (ch === "\\") { escape = true; continue; }
+    if (ch === '"') { inString = !inString; continue; }
+    if (inString) continue;
+    if (ch === "{") depth++;
+    else if (ch === "}") { depth--; if (depth === 0) return i; }
+  }
+  return -1;
+}
+
+/**
  * AI 응답 raw 문자열에서 JSON 객체를 안전하게 추출·파싱.
  *
  * 처리 순서:
  * 1. <think>...</think> 등 thinking 토큰 제거
  * 2. 마크다운 코드블록 제거
- * 3. 가장 바깥 { ... } 추출
+ * 3. 가장 바깥 { ... } 추출 (문자열 내부 { } 무시)
  * 4. JSON.parse 1차 시도
  * 5. 문자열 값 내 리터럴 개행·탭 이스케이프 후 2차 시도
  * 6. 실패 시 null 반환
@@ -51,24 +71,18 @@ export function parseJsonSafe(raw: string): Record<string, unknown> | null {
   let text = raw.trim();
 
   // thinking 토큰 제거 (일부 Grok 버전이 <think>...</think> 붙임)
-  text = text.replace(/<think(?:ing)?[\s\S]*?<\/think(?:ing)?>/gi, "").trim();
+  text = text.replaceAll(/<think(?:ing)?[\s\S]*?<\/think(?:ing)?>/gi, "").trim();
 
   // 마크다운 코드블록에서 추출
-  const codeMatch = text.match(/```(?:json)?\s*([\s\S]*?)```/);
+  const codeMatch = /```(?:json)?\s*([\s\S]*?)```/.exec(text);
   if (codeMatch) text = codeMatch[1].trim();
 
   // 입력 길이 상한 (ReDoS 방어)
   if (text.length > 50_000) return null;
 
-  // 가장 바깥 JSON 객체만 추출 — 괄호 카운터 기반으로 ReDoS 방지
   const start = text.indexOf("{");
   if (start === -1) return null;
-  let depth = 0;
-  let end = -1;
-  for (let i = start; i < text.length; i++) {
-    if (text[i] === "{") depth++;
-    else if (text[i] === "}") { depth--; if (depth === 0) { end = i; break; } }
-  }
+  const end = findOutermostObjectEnd(text, start);
   if (end === -1) return null;
   text = text.slice(start, end + 1);
 

--- a/src/services/shinjeom/shinjeom-service.test.ts
+++ b/src/services/shinjeom/shinjeom-service.test.ts
@@ -343,14 +343,34 @@ describe("ShinjeomService", () => {
       expect(typeof result.overallReading).toBe("string");
     });
 
-    it("중괄호가 포함됐지만 JSON.parse가 실패하면 경고 후 텍스트 fallback 반환", () => {
-      const consoleSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-      // 중괄호는 있지만 유효하지 않은 JSON — match() 는 성공하나 JSON.parse 실패
+    it("유효하지 않은 JSON이면 텍스트 fallback으로 반환한다 (경고 없음)", () => {
       const brokenJson = "결과는 다음과 같습니다: {invalid json here}";
       const result = service.parseResult(brokenJson);
       expect(result.overallReading).toBeTruthy();
-      expect(consoleSpy).toHaveBeenCalled();
-      consoleSpy.mockRestore();
+      expect(result.advice).toBe("");
+    });
+
+    it("문자열 값 안에 한국어 중괄호 표현이 있어도 JSON을 올바르게 파싱한다", () => {
+      // 버그 재현: "현재는 {도전의 시기}입니다" 처럼 {} 를 포함한 값이 있으면
+      // 이전 탐욕적 정규식은 마지막 } 를 JSON 끝으로 인식해 잘못된 JSON을 추출했음
+      const jsonWithBracesInValue = JSON.stringify({
+        overallReading: "현재는 {도전의 시기}이지만 곧 나아집니다",
+        topicReading: "재물운은 {상승세}를 탈 것입니다",
+        advice: "인내심을 가지고 기다리세요",
+      });
+      const result = service.parseResult(jsonWithBracesInValue);
+      expect(result.overallReading).toContain("도전의 시기");
+      expect(result.topicReading).toContain("상승세");
+      expect(result.advice).toContain("인내심을 가지고 기다리세요");
+    });
+
+    it("두 JSON 구조가 연달아 있을 때 첫 번째 JSON만 파싱한다 (탐욕적 정규식 버그 재현)", () => {
+      // 이전 /\{[\s\S]*\}/ 는 첫 { 부터 마지막 } 까지 잡아 두 JSON을 합쳐 파싱 실패
+      const twoJsonBlocks =
+        `{"overallReading":"첫 번째 결과","advice":"조언"} ` +
+        `{"overallReading":"두 번째 블록","advice":"다른 조언"}`;
+      const result = service.parseResult(twoJsonBlocks);
+      expect(result.overallReading).toContain("첫 번째 결과");
     });
   });
 });

--- a/src/services/shinjeom/shinjeom-service.ts
+++ b/src/services/shinjeom/shinjeom-service.ts
@@ -2,7 +2,7 @@ import { DivinationService, ReadingResult, SessionContext } from "@/types/servic
 import { CharacterConfig } from "@/types/character";
 import { Session, Topic, ChatMessage } from "@/types/session";
 import { getCharacterById } from "@/data/characters";
-import { cleanReadingText } from "@/services/core/text-cleaner";
+import { cleanReadingText, parseJsonSafe } from "@/services/core/text-cleaner";
 import { buildCharacterHeader } from "@/services/core/prompt-builder";
 
 const topicLabels: Record<string, string> = {
@@ -118,19 +118,14 @@ JSON 앞뒤에 어떤 텍스트도 추가하지 않습니다.`;
   }
 
   parseResult(aiResponse: string): ReadingResult {
-    // 최종 결과인 경우 JSON 파싱 시도
-    try {
-      // JSON 추출
-      const match = aiResponse.match(/\{[\s\S]*\}/);
-      if (match) {
-        const parsed = JSON.parse(match[0]);
-        return {
-          overallReading: cleanReadingText(String(parsed.overallReading || "")),
-          topicReading: cleanReadingText(String(parsed.topicReading || "")),
-          advice: cleanReadingText(String(parsed.advice || "")),
-        };
-      }
-    } catch (e) { console.warn("신점 결과 JSON 파싱 실패 (텍스트로 처리):", e); }
+    const parsed = parseJsonSafe(aiResponse);
+    if (parsed) {
+      return {
+        overallReading: cleanReadingText(typeof parsed.overallReading === "string" ? parsed.overallReading : ""),
+        topicReading: cleanReadingText(typeof parsed.topicReading === "string" ? parsed.topicReading : ""),
+        advice: cleanReadingText(typeof parsed.advice === "string" ? parsed.advice : ""),
+      };
+    }
 
     // 중간 대화 또는 파싱 실패 → 텍스트 그대로
     return {


### PR DESCRIPTION
## 배경

타로·신점 리딩 결과가 원문 JSON 텍스트 그대로 노출되는 프로덕션 버그 수정.

## 근본 원인 (다각도 분석)

### 원인 1 — `parseJsonSafe()` 문자열-비인식 괄호 카운터 (핵심)

`text-cleaner.ts`의 괄호 카운팅 루프가 JSON 문자열 값 내부의 `{}`를 구분하지 못함.

```
AI 응답 예시:
"overallReading": "현재는 {도전의 시기}이지만 곧 나아집니다"
                              ↑ 이 } 를 JSON 끝으로 오인
                              → 조기 종료 → 불완전 JSON → 파싱 실패 → 원문 노출
```

### 원인 2 — `shinjeom-service.ts` 탐욕적 정규식

`/\{[\s\S]*\}/` 가 첫 `{`부터 **마지막** `}`까지 포착 → 다중 JSON 블록 오파싱.

## 수정 내용

### `src/services/core/text-cleaner.ts`
- `findOutermostObjectEnd()` 헬퍼 분리
- `inString` + `escape` 상태 변수로 문자열 내부 `{}` 카운트 제외
- `replaceAll()` / `RegExp.exec()` SonarQube 권장 사항 동시 반영
- 인지 복잡도 21 → ≤15 해소

### `src/services/shinjeom/shinjeom-service.ts`
- 탐욕적 정규식 → `parseJsonSafe()` 교체
- `typeof` 가드로 타입 안전성 강화 (SonarQube S6551)

## 테스트

신규 케이스 7종 추가 (663개 전체 통과):

| 파일 | 추가 케이스 |
|------|-----------|
| `text-cleaner.test.ts` | 문자열 내 `{}`·중첩 중괄호·이스케이프 따옴표·thinking 토큰 혼합 (4종) |
| `shinjeom-service.test.ts` | 한국어 `{}` 포함 값 파싱·두 JSON 블록 처리·경고 없는 fallback (3종) |

커버리지: statements **99.55%** / branches **97.01%** / `text-cleaner.ts` **branches 100%**

## 재발 방지 문서

- `docs/architecture/ai-infrastructure.md`: JSON 파싱 파이프라인 섹션 추가 (올바른/잘못된 패턴 코드 예시)
- `CLAUDE.md`: 필수 주의사항 9번 추가 — `parseJsonSafe()` 사용 필수, 단순 카운터·탐욕 정규식 금지

## 검증

```
pnpm type-check  ✅
pnpm lint        ✅
pnpm test:coverage — 663개 전체 통과 ✅
pnpm build       ✅
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)