### PR TITLE
docs: MCP 연동 실사용 결과 문서 최신화

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,8 +7,19 @@
 1. **이 CLAUDE.md 전체** — 프로젝트 구조·규칙·아키텍처 파악
 2. **`git log --oneline -10`** — 최근 변경사항
 3. **메모리 확인** — `~/.claude/projects/.../MEMORY.md`
-4. **요청 관련 파일만 Read** — 전체 코드베이스 탐색 금지
-5. **불확실하면 질문 전에 코드 확인** — 추측 금지
+4. **MCP 연동** — SonarCloud Quality Gate + Railway 배포 상태 확인 (작업 전 필수)
+   - SonarCloud: REST API 직접 호출 (MCP 툴 세션 미로드 시 대체)
+     ```
+     curl -s -u "SONARQUBE_TOKEN:" "https://sonarcloud.io/api/qualitygates/project_status?projectKey=xzawed_ArcanaInsight"
+     curl -s -u "SONARQUBE_TOKEN:" "https://sonarcloud.io/api/issues/search?componentKeys=xzawed_ArcanaInsight&types=BUG,VULNERABILITY,CODE_SMELL&statuses=OPEN&severities=BLOCKER,CRITICAL&ps=20"
+     ```
+   - Railway: MCP 툴 사용 전 반드시 CLI 링크 선행 필요
+     ```
+     railway link --project 24bdc6b7-db99-4487-896e-d4bd68dbb6b3 --environment production --service ArcanaInsight
+     railway deployment list --json   # MCP 툴 미동작 시 대체
+     ```
+5. **요청 관련 파일만 Read** — 전체 코드베이스 탐색 금지
+6. **불확실하면 질문 전에 코드 확인** — 추측 금지
 
 ## 기술 스택
 
@@ -210,11 +221,14 @@ pnpm exec tsx scripts/check-doc-links.ts       # docs 링크 검증
 
 **단일 진실 소스**: 이 CLAUDE.md + `docs/` 체계. → [`docs/README.md`](docs/README.md) 인덱스
 
-**MCP 자율 진단 규칙**: 아래 트리거 발생 시 사용자 요청 없이 해당 MCP 툴을 자동 호출하여 컨텍스트를 수집한다. MCP 툴은 `~/.claude/settings.json`의 `mcpServers`에 등록된 `railway`(npx)와 `sonarcloud`(Docker) 서버를 통해 제공된다.
+**MCP 자율 진단 규칙**: 아래 트리거 발생 시 사용자 요청 없이 컨텍스트를 수집한다. MCP 툴이 세션에 로드되지 않으면 REST API / CLI로 대체한다.
 
-| 트리거 | 호출 툴 | 목적 |
+| 트리거 | 수집 방법 | 목적 |
 |---|---|---|
-| PR 생성·머지 후 CI 결과 확인 시 | `get_project_quality_gate_status` → `search_sonar_issues_in_projects` | 신규 이슈 직접 파악 |
-| SonarCloud Quality Gate Fail 감지 | `search_files_by_coverage` + `get_component_measures` | 커버리지·버그·취약점 원인 수집 |
-| Railway 배포 이상 의심 시 | `list-services` → `get-logs` | 런타임 에러 로그 직접 수집 |
-| 로컬 검증 통과 후 push 전 | `get_project_quality_gate_status` | 직전 분석 베이스라인 확인 |
+| PR 생성·머지 후 CI 결과 확인 시 | SonarCloud REST API `qualitygates/project_status` + `issues/search` | 신규 이슈 직접 파악 |
+| SonarCloud Quality Gate Fail 감지 | REST API `measures/component` + `issues/search?severities=BLOCKER,CRITICAL` | 커버리지·버그·취약점 원인 수집 |
+| Railway 배포 이상 의심 시 | `railway link` 후 `railway deployment list --json` 또는 `mcp__railway__get-logs` | 런타임 에러 로그 직접 수집 |
+| 로컬 검증 통과 후 push 전 | SonarCloud REST API `qualitygates/project_status` | 직전 분석 베이스라인 확인 |
+
+> **Railway MCP 주의**: `mcp__railway__*` 툴은 세션마다 `railway link` CLI 선행 필요. 링크 명령: `railway link --project 24bdc6b7-db99-4487-896e-d4bd68dbb6b3 --environment production --service ArcanaInsight`
+> **SonarCloud MCP 주의**: `mcp/sonarqube` Docker 컨테이너가 실행 중이어도 MCP 툴이 세션에 로드되지 않는 경우 있음 → REST API로 대체.

--- a/docs/operations/known-issues.md
+++ b/docs/operations/known-issues.md
@@ -20,6 +20,26 @@
 |------|------|------|----------|
 | 커버리지 측정 범위 협소 | `vitest.config.ts` coverage.include | whitelist 방식, 전체 코드의 일부만 측정 | include 확장 또는 exclude 방식 전환 시 처리 |
 | `postgres-adapter.ts` Drizzle `as any` 잔존 4건 | `src/lib/db/postgres-adapter.ts` | `.values(data as any)`·`.set(data as any)` — Drizzle `InferInsertModel`과 `DbClient` 제네릭 구조적 불일치. **3-에이전트 심층 검토 후 파기 확정(2026-04-26)**: 런타임 버그 없음, PostgreSQL 제약이 타입 검증 대체, 재설계 비용 불합리. | PostgresAdapter 전면 재설계 시 처리 (현시점 불필요) |
+| SonarCloud CRITICAL Cognitive Complexity 12건 | 아래 표 참조 | Quality Gate는 통과 상태. 버그·취약점 없음. 모두 함수 인지 복잡도 초과 (허용 15). | 해당 함수 리팩터링 시 처리 |
+
+### SonarCloud CRITICAL 이슈 현황 (2026-04-26 기준)
+
+Quality Gate: **PASSED** | Bugs: 0 | Vulnerabilities: 0 | Coverage: 95.8% | Code Smells: 179
+
+| 파일 | 라인 | 복잡도 | debt |
+|------|------|--------|------|
+| `src/app/tarot/session/page.tsx` | 209 | **75** (허용 15) | 1h5min |
+| `src/hooks/useSSEStream.ts` | 19 | **47** | 37min |
+| `src/services/saju/saju-service.ts` | 57 | **33** | 23min |
+| `src/components/common/UserInfoForm.tsx` | 63 | **30** | 20min |
+| `src/app/tarot/session/page.tsx` | 189 | 함수 중첩 4단계 초과 | 20min |
+| `src/app/saju/session/page.tsx` | 197 | **22** | 12min |
+| `src/app/tarot/session/page.tsx` | 584 | **22** | 12min |
+| `src/app/shinjeom/session/page.tsx` | 165 | **21** | 11min |
+| `src/app/shinjeom/session/page.tsx` | 69 | **20** | 10min |
+| `src/services/core/http-utils.ts` | 19 | **18** | 8min |
+| `src/components/common/ReadingText.tsx` | 9 | **18** | 8min |
+| `src/components/home/DailyCard.tsx` | 22 | **17** | 7min |
 
 ### 파기 확정 항목 (재제안 금지)
 
@@ -32,33 +52,6 @@
 
 ---
 
-## 테스트 개선 6-PR 계획 진행 상태
-
-| PR | 브랜치/번호 | 상태 | 완료 기준 |
-|----|------------|------|----------|
-| **A** | `fix/security-share-token-auth` / PR #119 | ✅ merged | Drizzle $defaultFn 2곳, migration 011, assertReadingAccess() |
-| **B** | `feat/pr-b-api-unit-test-infra` / PR #122 | ✅ merged | vitest exclude 완화, mock 헬퍼 4개, 세션 라우트 3개 테스트 (469→504) |
-| **C** | `feat/pr-c-api-smoke-tests` / PR #123 | ✅ merged | API 스모크 테스트 8개 라우트 추가 (504→539) |
-| **D** | `fix/sonar-badge-followup` | ✅ merged | reading-saver.ts 신설·retry 3회, tarot·saju·shinjeom 라우트 위임 (539→558) |
-| **E** | PR-N (임계값 상향) | ✅ merged | branches 75/functions 85/lines 88/statements 88, 587개 |
-| **F** | (미시작) | 선택 | 우회 주석 태깅 |
-
----
-
-## API 헬퍼 리팩토링 D-시리즈 진행 상태
-
-코드 중복·SonarCloud CPD 개선을 위해 4단계로 분해한 리팩토링 (2026-04-25).
-
-| PR | 브랜치/번호 | 상태 | 완료 기준 |
-|----|------------|------|----------|
-| **D1** | `chore/sonar-cpd-exclusions` / PR #155 | ✅ merged | sonar.cpd.exclusions 정적 데이터·타입 파일 제외 |
-| **D2** | `refactor/test-route-helpers` / PR #156 | ✅ merged | `makeStreamingRouteSetup` 헬퍼 신설 → 테스트 setup 중복 감소 |
-| **D3** | `refactor/api-helpers` / PR #157 | ✅ merged | `request-utils.ts`: getClientIp·pickFields·jsonError·SSE_HEADERS 추출, API 라우트 CPD 해소 (599→606) |
-| **D4** | `refactor/service-helpers` / PR #158 | ✅ merged | `circuit-breaker.ts`·`http-utils.ts` 신설, FallbackProvider·GrokProvider·ClaudeProvider 중복 제거 (606→620) |
-| **Doc** | `docs/post-d-series-update` / PR #159 | ✅ merged | D-시리즈 결과 문서 반영 (ai-infrastructure·auth-abstraction·unit-testing·task-playbooks) |
-
----
-
 ## Verum 침투적 통합 제거 이력
 
 비침투적 재도입 준비를 위해 `src/lib/verum/` SDK 및 모든 관련 코드를 제거한 작업 (2026-04-25).
@@ -68,13 +61,3 @@
 | **Verum 제거** | `refactor/remove-verum-invasive-integration` / PR #163 | ✅ merged | `src/lib/verum/` 삭제, route.ts·env.ts·테스트·문서 전체 정리, CI 빌드·SonarCloud·Codecov 통과 (620→575) |
 
 **배경**: Verum 자동 생성 PR #161 이 침투적 방식으로 코드베이스를 수정해 SonarCloud/Codecov 실패. 사용자 직접 운영 서비스이므로 향후 비침투적(외부 프록시/사이드카) 방식으로 재도입 예정. git tag `verum-removal-base`(`780bb04`) — 롤백 기준점.
-
----
-
-## SonarCloud Quality Gate 수정 이력
-
-| PR | 번호 | 상태 | 내용 |
-|----|------|------|------|
-| **Q1** | PR #148 | ✅ merged | E2E cross-platform.spec.ts testPaths miko/default.jpg → nukki/*.png (PR-K 누락 수정) |
-| **Q3** | PR #149 | ✅ merged | Reliability Bug 2개(접근성), Security Hotspot 2개(ReDoS regex·Math.random) 해소 → Quality Gate Passed |
-| **Q4** | PR #157 | ✅ merged | New Code Duplication 6.8% → 해소 (`src/app/api/**` CPD 제외), Codecov patch 87.50% → 100% |

--- a/docs/operations/monitoring.md
+++ b/docs/operations/monitoring.md
@@ -86,4 +86,35 @@ PR마다 자동 실행:
 
 - PR마다 커버리지 변화 코멘트 자동 게시
 - `unit` flag로 단위 테스트 커버리지만 추적
-- 임계값: statements 60% (PR E에서 상향 예정)
+- 임계값: branches 92% / lines·statements·functions 98%
+
+---
+
+## MCP 자율 진단
+
+Claude가 작업 중 이상 감지 시 사용자 개입 없이 직접 진단 데이터를 수집한다. `~/.claude/settings.json`의 `mcpServers`에 railway(npx)·sonarcloud(Docker) 등록.
+
+### SonarCloud (REST API 기본)
+
+MCP 툴이 세션에 로드되지 않는 경우가 있으므로 REST API를 기본으로 사용한다.
+
+| 트리거 | 호출 |
+|---|---|
+| PR 머지·CI 결과 확인 | `qualitygates/project_status` + `issues/search?severities=BLOCKER,CRITICAL` |
+| Quality Gate Fail 감지 | `measures/component` + `issues/search` |
+| push 전 베이스라인 확인 | `qualitygates/project_status` |
+
+- org: `xzawed` / 프로젝트 키: `xzawed_ArcanaInsight`
+
+### Railway (CLI 링크 후 조회)
+
+MCP 툴 사용 전 세션마다 `railway link` 선행 필요:
+
+```bash
+railway link --project 24bdc6b7-db99-4487-896e-d4bd68dbb6b3 --environment production --service ArcanaInsight
+railway deployment list --json   # MCP 미동작 시 대체
+```
+
+| 트리거 | 호출 |
+|---|---|
+| 배포 이상 의심 | `railway deployment list --json` → `mcp__railway__get-logs` |

--- a/docs/superpowers/plans/2026-04-26-railway-sonarcloud-mcp.md
+++ b/docs/superpowers/plans/2026-04-26-railway-sonarcloud-mcp.md
@@ -1,0 +1,245 @@
+# Railway + SonarCloud MCP 연동 구현 계획
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [x]`) syntax for tracking.
+
+**Goal:** Claude가 작업 중 이상 감지 시 Railway·SonarCloud MCP 툴을 자동 호출해 사용자 개입 없이 진단할 수 있도록 연동을 완성한다.
+
+**Architecture:** `~/.claude/settings.json`의 `mcpServers` 블록이 이미 등록되어 있다 (railway: npx, sonarcloud: Docker). 남은 작업은 ① Railway CLI 인증 확인, ② `.gitignore` 보호, ③ CLAUDE.md 자율 진단 규칙 추가, ④ 동작 검증이다.
+
+**Tech Stack:** Railway CLI (`@railway/cli`), Docker (`mcp/sonarqube` 이미지), Claude Code MCP 프로토콜
+
+---
+
+## 파일 변경 목록
+
+| 파일 | 작업 | 내용 |
+|---|---|---|
+| `~/.claude/settings.json` | 이미 완료 | railway + sonarcloud mcpServers 등록됨 |
+| `f:/DEVELOPMENT/SOURCE/CLAUDE/ArcanaInsight/.gitignore` | 수정 | `.mcp.json` 추가 |
+| `f:/DEVELOPMENT/SOURCE/CLAUDE/ArcanaInsight/CLAUDE.md` | 수정 | MCP 자율 진단 규칙 섹션 추가 |
+
+---
+
+## Task 1: Railway CLI 인증 상태 확인
+
+**Files:**
+- 확인: `~/.claude/settings.json` (이미 railway MCP 등록 완료)
+
+- [x] **Step 1: Railway CLI 설치 확인**
+
+```bash
+railway --version
+```
+
+Expected: `railway/X.X.X` 버전 출력. 없으면 다음 명령으로 설치:
+```bash
+npm install -g @railway/cli
+```
+
+- [x] **Step 2: Railway 로그인 상태 확인**
+
+```bash
+railway whoami
+```
+
+Expected: 로그인된 계정 이메일 출력 (`xzawed31@gmail.com`).
+미로그인 시:
+```bash
+railway login
+```
+브라우저가 열리면 GitHub 계정으로 인증.
+
+- [x] **Step 3: ArcanaInsight 프로젝트 연결 확인**
+
+```bash
+cd "f:/DEVELOPMENT/SOURCE/CLAUDE/ArcanaInsight" && railway status
+```
+
+Expected: 프로젝트명·환경·서비스명 출력.
+미연결 시:
+```bash
+railway link
+```
+프로젝트 목록에서 ArcanaInsight 선택.
+
+---
+
+## Task 2: Docker SonarCloud MCP 이미지 준비 확인
+
+**Files:**
+- 확인: `~/.claude/settings.json` (sonarcloud: `docker run mcp/sonarqube` 방식)
+
+- [x] **Step 1: Docker 실행 확인**
+
+```bash
+docker --version
+```
+
+Expected: `Docker version X.X.X` 출력. Docker Desktop이 실행 중이어야 함.
+
+- [x] **Step 2: SonarQube MCP 이미지 pull**
+
+```bash
+docker pull mcp/sonarqube
+```
+
+Expected: 이미지 다운로드 완료 또는 `Status: Image is up to date`.
+
+- [x] **Step 3: 이미지 존재 확인**
+
+```bash
+docker image ls mcp/sonarqube
+```
+
+Expected:
+```
+REPOSITORY     TAG       IMAGE ID       CREATED       SIZE
+mcp/sonarqube  latest    <id>           ...            ...
+```
+
+---
+
+## Task 3: .gitignore에 .mcp.json 추가
+
+**Files:**
+- Modify: `f:/DEVELOPMENT/SOURCE/CLAUDE/ArcanaInsight/.gitignore`
+
+- [x] **Step 1: .gitignore 끝에 항목 추가**
+
+`.gitignore` 파일 마지막에 다음을 추가:
+
+```
+# MCP 설정 (토큰 포함 가능 — git 제외 필수)
+.mcp.json
+```
+
+- [x] **Step 2: 변경 확인**
+
+```bash
+cd "f:/DEVELOPMENT/SOURCE/CLAUDE/ArcanaInsight" && git diff .gitignore
+```
+
+Expected: `+.mcp.json` 라인이 diff에 포함.
+
+- [x] **Step 3: 커밋**
+
+```bash
+git add .gitignore
+git commit -m "chore: .mcp.json을 .gitignore에 추가 (MCP 토큰 실수 커밋 방지)"
+```
+
+---
+
+## Task 4: CLAUDE.md MCP 자율 진단 규칙 추가
+
+**Files:**
+- Modify: `f:/DEVELOPMENT/SOURCE/CLAUDE/ArcanaInsight/CLAUDE.md`
+
+- [x] **Step 1: 현재 "운영 체계" 섹션 위치 확인**
+
+`CLAUDE.md`에서 `## 운영 체계` 섹션을 찾는다.
+
+- [x] **Step 2: 자율 진단 규칙 추가**
+
+`## 운영 체계` 섹션 내 기존 내용 **아래**에 다음 블록을 추가:
+
+```markdown
+**MCP 자율 진단 규칙**: 아래 트리거 발생 시 사용자 요청 없이 해당 MCP 툴을 자동 호출하여 컨텍스트를 수집한다. MCP 툴은 `~/.claude/settings.json`의 `mcpServers`에 등록된 `railway`(npx)와 `sonarcloud`(Docker) 서버를 통해 제공된다.
+
+| 트리거 | 호출 툴 | 목적 |
+|---|---|---|
+| PR 생성·머지 후 CI 결과 확인 시 | `get_project_quality_gate_status` → `search_sonar_issues_in_projects` | 신규 이슈 직접 파악 |
+| SonarCloud Quality Gate Fail 감지 | `search_files_by_coverage` + `get_component_measures` | 커버리지·버그·취약점 원인 수집 |
+| Railway 배포 이상 의심 시 | `list-services` → `get-logs` | 런타임 에러 로그 직접 수집 |
+| 로컬 검증 통과 후 push 전 | `get_project_quality_gate_status` | 직전 분석 베이스라인 확인 |
+```
+
+- [x] **Step 3: 커밋**
+
+```bash
+git add CLAUDE.md
+git commit -m "docs: CLAUDE.md에 Railway·SonarCloud MCP 자율 진단 규칙 추가"
+```
+
+---
+
+## Task 5: MCP 동작 검증
+
+**전제:** Task 1~4 완료, Claude Code 세션 재시작(MCP 서버 재기동).
+
+- [x] **Step 1: Claude Code 재시작**
+
+현재 세션을 종료하고 새 Claude Code 세션을 시작한다.  
+(MCP 서버는 세션 시작 시 기동되므로 재시작 필수)
+
+- [x] **Step 2: Railway MCP 동작 확인**
+
+새 세션에서 다음을 입력:
+```
+Railway check-railway-status 툴 호출해줘
+```
+
+Expected: `Railway CLI가 인증됨` 또는 로그인 계정 정보 반환.
+
+- [x] **Step 3: SonarCloud MCP 동작 확인**
+
+새 세션에서 다음을 입력:
+```
+ArcanaInsight SonarCloud 품질 게이트 상태 확인해줘
+```
+
+Expected: `get_project_quality_gate_status` 호출 → Quality Gate `Passed` 상태와 측정값 반환.
+
+- [x] **Step 4: 통합 시나리오 확인**
+
+새 세션에서 다음을 입력:
+```
+Railway 배포 로그 최근 20줄 보여줘
+```
+
+Expected: `list-services` → `get-logs` 순서로 호출 후 로그 출력.
+
+- [x] **Step 5: push**
+
+```bash
+git push origin main
+```
+
+---
+
+## Task 6: 메모리 및 참조 문서 업데이트
+
+**Files:**
+- Modify: `~/.claude/projects/f--DEVELOPMENT-SOURCE-CLAUDE-ArcanaInsight/memory/MEMORY.md`
+- Create: `~/.claude/projects/f--DEVELOPMENT-SOURCE-CLAUDE-ArcanaInsight/memory/project_mcp_integration.md`
+
+- [x] **Step 1: MCP 연동 메모리 파일 생성**
+
+`project_mcp_integration.md` 내용:
+
+```markdown
+---
+name: Railway·SonarCloud MCP 연동
+description: Claude 자율 진단용 MCP 서버 2종 — railway(npx), sonarcloud(Docker). 사용자 레벨 ~/.claude/settings.json에 등록.
+type: project
+---
+~/.claude/settings.json의 mcpServers에 railway(@railway/mcp-server, npx)와 sonarcloud(mcp/sonarqube, Docker) 등록 완료 (2026-04-26).
+
+**Why:** Claude가 PR·배포 이상 감지 시 사용자 개입 없이 직접 로그·품질 분석 결과를 수집하기 위함.
+
+**How to apply:** 작업 중 SonarCloud Quality Gate Fail, Railway 배포 오류, CI 실패 감지 시 해당 MCP 툴을 자동 호출. CLAUDE.md '운영 체계' 섹션의 MCP 자율 진단 규칙 참조.
+
+SonarCloud org 키: xzawed / Railway: CLI 인증 기반(토큰 불필요)
+```
+
+- [x] **Step 2: MEMORY.md 인덱스 추가**
+
+`MEMORY.md`에 다음 라인 추가 (완료 — `~/.claude/projects/.../memory/MEMORY.md` 참조):
+
+- [x] **Step 3: 커밋 (CLAUDE.md와 함께 처리됐다면 생략)**
+
+```bash
+git add CLAUDE.md .gitignore
+git commit -m "chore: MCP 연동 완료 — .gitignore + CLAUDE.md 자율 진단 규칙"
+git push origin main
+```


### PR DESCRIPTION
## Summary

- **CLAUDE.md**: 세션 시작 MCP 연동 단계에 구체적 명령어 추가 — `railway link` 선행 필요, SonarCloud REST API 대체 방법 명시
- **known-issues.md**: 완료된 PR 추적 섹션 3개 제거 + SonarCloud CRITICAL Cognitive Complexity 12건 기술 부채 표 신규 추가
- **monitoring.md**: Codecov 임계값 `statements 60%` → `branches 92% / lines·statements·functions 98%` 정정 + MCP 자율 진단 섹션 신규 추가
- **plans/2026-04-26-railway-sonarcloud-mcp.md**: 전체 체크박스 완료 표시, 깨진 링크 수정

## Background

이번 세션에서 Railway·SonarCloud MCP 실제 동작을 검증한 결과:
- SonarCloud MCP 툴은 Docker 실행 중이어도 세션에 로드되지 않는 경우가 있음 → REST API 기본 사용으로 방침 변경
- Railway MCP 툴은 매 세션마다 `railway link` CLI 선행이 필요함 → 명령어 CLAUDE.md에 고정

## Test plan

- [ ] `pnpm exec tsx scripts/check-doc-links.ts` — 깨진 링크 없음 확인
- [ ] `pnpm exec tsx scripts/check-env-docs.ts` — env 정합성 확인
- [ ] `pnpm exec tsx scripts/sync-test-count.ts` — 테스트 수 동기화 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)