### PR TITLE
fix: 타로 결과 일부 카드 누락 — 토큰 정책·파싱 시그널·클라이언트 게이팅

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,7 @@
 | **인증·DB** | Supabase Auth / NextAuth.js v5 (DB_PROVIDER별 전환) |
 | **DB ORM** | Supabase PostgreSQL / Drizzle ORM (DB_PROVIDER별 전환) |
 | **상태·패키지** | Zustand v5.0, pnpm 10.33.0 |
-| **테스트** | Vitest 2.0 (663개, statements 98%), Playwright (3 디바이스) |
+| **테스트** | Vitest 2.0 (672개, statements 98%), Playwright (3 디바이스) |
 | **CI/CD·호스팅** | GitHub Actions → Railway |
 
 ## 프로젝트 구조

--- a/docs/workflow/unit-testing.md
+++ b/docs/workflow/unit-testing.md
@@ -6,7 +6,7 @@ Vitest 기반 단위 테스트 작성 패턴과 주의사항입니다.
 
 ## 1. 테스트 현황
 
-- **663개 테스트** / statements 88%+ 커버리지
+- **672개 테스트** / statements 88%+ 커버리지
 - **Vitest 2.0** (node env, v8 coverage)
 - 임계값: `branches 92 / functions 98 / lines 98 / statements 98`
 

--- a/src/__tests__/api/tarot-reading.test.ts
+++ b/src/__tests__/api/tarot-reading.test.ts
@@ -241,6 +241,71 @@ describe("POST /api/tarot/reading", () => {
     expect(text).toContain("error");
   });
 
+  it("computeReadingMaxTokens 정책 — 1장→2000, 5장→5000, 10장→9500이 streamReading에 전달", async () => {
+    const cases: { count: number; expected: number }[] = [
+      { count: 1, expected: 2000 },
+      { count: 5, expected: 5000 },
+      { count: 10, expected: 9500 },
+    ];
+    for (const { count, expected } of cases) {
+      vi.resetModules();
+      const streamSpy = vi.fn().mockImplementation(async function* () {
+        yield JSON.stringify({
+          cardInterpretations: [],
+          overallReading: "ok",
+          advice: "ok",
+        });
+      });
+      const provider = { streamReading: streamSpy, generateReading: vi.fn() };
+      vi.doMock("@/services/core/fallback-provider", () => ({
+        FallbackProvider: vi.fn().mockImplementation(() => provider),
+      }));
+      vi.doMock("@/lib/rate-limit", () => ({
+        checkRateLimit: vi.fn().mockReturnValue(true),
+        rateLimitResponse: vi.fn(),
+      }));
+      vi.doMock("@/lib/db", () => ({ getDb: vi.fn().mockReturnValue(makeMockDb()) }));
+      vi.doMock("@/lib/auth", () => makeAuthMock());
+      const { POST } = await import("@/app/api/tarot/reading/route");
+      const cardsArr = Array.from({ length: count }, (_, i) => ({
+        cardId: `major-${String(i).padStart(2, "0")}`,
+        position: i,
+        isReversed: false,
+      }));
+      const res = await POST(makePostRequest({ ...VALID_BODY, cards: cardsArr }));
+      await readSSEStream(res);
+      expect(streamSpy).toHaveBeenCalledTimes(1);
+      expect(streamSpy.mock.calls[0][2]).toBe(expected);
+    }
+  });
+
+  it("정상 케이스(1장) → done 페이로드에 expectedCardCount=1 포함, parseError 없음", async () => {
+    const { POST } = await setup();
+    const res = await POST(makePostRequest(VALID_BODY));
+    const text = await readSSEStream(res);
+    const doneLine = text.split("\n").find((l) => l.startsWith("data:") && l.includes("\"done\":true"));
+    expect(doneLine).toBeDefined();
+    const payload = JSON.parse(doneLine!.slice(5).trim());
+    expect(payload.result.expectedCardCount).toBe(1);
+    expect(payload.result.parseError).toBeUndefined();
+  });
+
+  it("AI 응답이 카드 수 부족 → done 페이로드에 parseError='truncated' 포함", async () => {
+    // mock-ai의 MOCK_JSON_RESPONSE는 cardInterpretations 1장 → 5장 요청 시 truncated
+    const { POST } = await setup();
+    const fiveCards = Array.from({ length: 5 }, (_, i) => ({
+      cardId: `major-0${i}`,
+      position: i,
+      isReversed: false,
+    }));
+    const res = await POST(makePostRequest({ ...VALID_BODY, cards: fiveCards }));
+    const text = await readSSEStream(res);
+    const doneLine = text.split("\n").find((l) => l.startsWith("data:") && l.includes("\"done\":true"));
+    const payload = JSON.parse(doneLine!.slice(5).trim());
+    expect(payload.result.expectedCardCount).toBe(5);
+    expect(payload.result.parseError).toBe("truncated");
+  });
+
   it("outer catch non-Error → String(e) 분기 커버", async () => {
     vi.doMock("@/lib/rate-limit", () => ({
       checkRateLimit: vi.fn().mockRejectedValue("string-throw"),

--- a/src/app/api/tarot/reading/route.ts
+++ b/src/app/api/tarot/reading/route.ts
@@ -19,11 +19,21 @@ const grokProvider = new FallbackProvider();
 const deckManager = new DeckManager();
 const spreadResolver = new SpreadResolver();
 
-// 카드 수에 따른 max_tokens 상수
-const TOKENS_SINGLE_CARD = 2000;
-const TOKENS_FEW_CARDS = 3000;
-const TOKENS_MEDIUM_CARDS = 4000;
-const TOKENS_MANY_CARDS = 6000;
+/**
+ * 카드 수에 비례한 max_tokens 정책.
+ *
+ * 한국어는 영어 대비 토큰 효율이 약 1.3배 낮고, JSON 구조 오버헤드(~10%)도 더해진다.
+ * 이전 정책(4단)에서는 5장 이상에서 잘림이 발생해 cardInterpretations가 누락되었음.
+ * 출력 토큰만 과금되므로 max_tokens 상한 자체는 비용을 늘리지 않는다.
+ */
+function computeReadingMaxTokens(cardCount: number): number {
+  if (cardCount <= 1) return 2000;
+  if (cardCount <= 3) return 3500;
+  if (cardCount <= 5) return 5000;
+  if (cardCount <= 7) return 6500;
+  if (cardCount <= 9) return 8000;
+  return 9500;
+}
 
 export async function POST(request: NextRequest) {
   try {
@@ -76,18 +86,23 @@ export async function POST(request: NextRequest) {
       async start(controller) {
         let fullResponse = "";
         try {
-          // 카드 수에 따라 max_tokens 조정 (JSON 구조 오버헤드 감안)
           const cardCount = cards.length;
-          let maxTokens: number;
-          if (cardCount <= 1) maxTokens = TOKENS_SINGLE_CARD;
-          else if (cardCount <= 3) maxTokens = TOKENS_FEW_CARDS;
-          else if (cardCount <= 7) maxTokens = TOKENS_MEDIUM_CARDS;
-          else maxTokens = TOKENS_MANY_CARDS;
+          const maxTokens = computeReadingMaxTokens(cardCount);
           for await (const chunk of grokProvider.streamReading(systemPrompt, readingPrompt + userInfoPrompt, maxTokens)) {
             fullResponse += chunk;
             controller.enqueue(encoder.encode(`data: ${JSON.stringify({ chunk })}\n\n`));
           }
-          const result = tarotService.parseResult(fullResponse);
+          const result = tarotService.parseResult(fullResponse, cardCount);
+
+          // 부분 파싱(누락/잘림)은 운영 로그로 명시 추적
+          if (result.parseError) {
+            console.warn("[tarot-reading] 부분 파싱:", {
+              parseError: result.parseError,
+              expected: cardCount,
+              got: result.cardInterpretations?.length ?? 0,
+              sessionId: sessionId ?? null,
+            });
+          }
 
           // 결과를 먼저 클라이언트에 전송 (DB 저장은 비동기 병렬)
           controller.enqueue(encoder.encode(`data: ${JSON.stringify({ done: true, result })}\n\n`));

--- a/src/app/tarot/session/page.tsx
+++ b/src/app/tarot/session/page.tsx
@@ -18,6 +18,8 @@ import { waitingLines, defaultWaitingLines, buildCardPreviewLine } from "@/data/
 import { DeckManager } from "@/services/tarot/deck-manager";
 import { spreads } from "@/data/spreads";
 import { TarotCard, SelectedCard } from "@/types/card";
+import { ReadingResult } from "@/types/service";
+import { fetchSSEStream } from "@/hooks/useSSEStream";
 
 const deckManager = new DeckManager();
 
@@ -225,135 +227,66 @@ export default function TarotSessionPage() {
         if (sessionId) break;
       }
     }
-    try {
-      const response = await fetch("/api/tarot/reading", {
-        method: "POST", headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ sessionId, topic, spreadType, characterId, userInfo: useSessionStore.getState().userInfo, cards: cards.map((c) => ({ cardId: c.card.id, position: c.position, isReversed: c.isReversed })) }),
-      });
-      if (!response.ok || !response.body) {
-        stopSequence();
-        let errorDetail = "";
-        try {
-          const errorBody = await response.json();
-          errorDetail = errorBody?.error || "";
-        } catch (e) { console.warn("리딩 에러 응답 JSON 파싱 실패:", e); }
-        console.error("리딩 API 응답 실패:", response.status, errorDetail);
-        const message = errorDetail.includes("GROK_API_KEY")
-          ? "AI 서비스 설정에 문제가 있어요. 관리자에게 문의해주세요."
-          : "서버에 일시적인 문제가 있어요. 잠시 후 다시 시도해주세요.";
-        addChatMessage({ id: crypto.randomUUID(), role: "character", content: message, mood: "default", timestamp: new Date() });
-        setMood("default");
-        setReadingError(true);
-        setLoading(false);
-        return;
-      }
-      const reader = response.body.getReader();
-      const decoder = new TextDecoder();
-      let sseBuffer = "";
-      let streamDone = false;
 
-      while (!streamDone) {
-        const { done, value } = await reader.read();
-        if (done) {
-          // 스트림 종료 — 버퍼에 남은 마지막 데이터 처리
-          if (sseBuffer.trim()) {
-            const remaining = sseBuffer;
-            sseBuffer = "";
-            if (remaining.startsWith("data: ")) {
-              try {
-                const data = JSON.parse(remaining.slice(6));
-                if (data.done && data.result) {
-                  stopSequence();
-                  setRevealedPositions(cards.map((c) => c.position));
-                  setReadingResult(data.result);
-                  setPhase("result"); setMood("smile");
-                }
-              } catch (e) { console.warn("SSE 버퍼 파싱 실패:", e); }
-            }
+    await fetchSSEStream({
+      url: "/api/tarot/reading",
+      body: {
+        sessionId, topic, spreadType, characterId,
+        userInfo: useSessionStore.getState().userInfo,
+        cards: cards.map((c) => ({ cardId: c.card.id, position: c.position, isReversed: c.isReversed })),
+      },
+      onChunk: () => { /* 청크별 화면 표시 없음 — 대기 연출 사용 */ },
+      onDone: (data) => {
+        stopSequence();
+        const result = data.result as ReadingResult | undefined;
+        if (!result) {
+          addChatMessage({ id: crypto.randomUUID(), role: "character", content: "카드 해석 결과를 받지 못했어요. 다시 시도해주세요.", mood: "default", timestamp: new Date() });
+          setMood("default"); setReadingError(true);
+          return;
+        }
+
+        // 부분 파싱(잘림/JSON 실패) 시 잘못된 결과를 정상처럼 표시하지 않음
+        if (result.parseError) {
+          console.warn("[tarot-session] 부분 파싱 응답:", { parseError: result.parseError, expected: result.expectedCardCount, got: result.cardInterpretations?.length ?? 0 });
+          addChatMessage({ id: crypto.randomUUID(), role: "character", content: "AI 해석이 일부만 도착했어요. 다시 시도해주세요.", mood: "default", timestamp: new Date() });
+          setMood("default"); setReadingError(true);
+          return;
+        }
+
+        // 정상 흐름 — 카드 뒤집기 완료 + 결과 phase 진입
+        setRevealedPositions(cards.map((c) => c.position));
+        setReadingResult(result);
+
+        const currentSpread = spreadType ? spreads[spreadType] : null;
+        if (Array.isArray(result.cardInterpretations) && result.cardInterpretations.length > 0) {
+          for (const interp of result.cardInterpretations) {
+            const card = cards.find((c) => c.card.id === interp.cardId);
+            const posLabel = currentSpread?.positions[interp.position]?.labelKo || `위치 ${interp.position + 1}`;
+            addChatMessage({
+              id: crypto.randomUUID(), role: "character",
+              content: `[${posLabel}] ${card?.card.nameKo || ""}\n\n${interp.interpretation}`,
+              mood: "smile", timestamp: new Date(),
+            });
           }
-          break;
         }
-        sseBuffer += decoder.decode(value, { stream: true });
-        const sseLines = sseBuffer.split("\n");
-        sseBuffer = sseLines.pop() || "";
-        for (const line of sseLines) {
-          if (!line.startsWith("data: ")) continue;
-          try {
-            const data = JSON.parse(line.slice(6));
-            // SSE 에러 처리 — Grok API 실패 등
-            if (data.error) {
-              stopSequence();
-              console.error("리딩 SSE 에러:", data.error);
-              addChatMessage({ id: crypto.randomUUID(), role: "character", content: "카드 해석 중 문제가 발생했어요. 다시 시도해주세요.", mood: "default", timestamp: new Date() });
-              setMood("default");
-              setReadingError(true);
-              setLoading(false);
-              streamDone = true;
-              break;
-            }
-            if (data.done && data.result) {
-              // 연출 중단 — 결과 도착
-              stopSequence();
-              // 모든 카드 뒤집기 완료
-              setRevealedPositions(cards.map((c) => c.position));
-
-              setReadingResult(data.result);
-              const currentSpread = spreadType ? spreads[spreadType] : null;
-              if (data.result.cardInterpretations) {
-                for (const interp of data.result.cardInterpretations) {
-                  const card = cards.find(c => c.card.id === interp.cardId);
-                  const posLabel = currentSpread?.positions[interp.position]?.labelKo || `위치 ${interp.position + 1}`;
-                  addChatMessage({
-                    id: crypto.randomUUID(), role: "character",
-                    content: `[${posLabel}] ${card?.card.nameKo || ""}\n\n${interp.interpretation}`,
-                    mood: "smile", timestamp: new Date(),
-                  });
-                }
-              }
-              if (data.result.overallReading) {
-                addChatMessage({
-                  id: crypto.randomUUID(), role: "character",
-                  content: `종합 해석\n\n${data.result.overallReading}`,
-                  mood: "smile", timestamp: new Date(),
-                });
-              }
-              if (data.result.advice) {
-                addChatMessage({
-                  id: crypto.randomUUID(), role: "character",
-                  content: `조언\n\n${data.result.advice}`,
-                  mood: "smile", timestamp: new Date(),
-                });
-              }
-              // DB 저장 실패 알림
-              if (data.dbSaved === false && sessionId) {
-                addChatMessage({
-                  id: crypto.randomUUID(), role: "system",
-                  content: "리딩 결과가 저장되지 않았습니다. 결과를 스크린샷으로 보관해주세요.",
-                  timestamp: new Date(),
-                });
-              }
-              setPhase("result"); setMood("smile");
-              streamDone = true;
-              break;
-            }
-          } catch (e) { console.warn("SSE 파싱 실패:", e); }
+        if (result.overallReading) {
+          addChatMessage({ id: crypto.randomUUID(), role: "character", content: `종합 해석\n\n${result.overallReading}`, mood: "smile", timestamp: new Date() });
         }
-      }
-      // 스트림이 끝났는데 result phase로 전환되지 않은 경우 → 에러 처리
-      if (useSessionStore.getState().phase === "reading") {
+        if (result.advice) {
+          addChatMessage({ id: crypto.randomUUID(), role: "character", content: `조언\n\n${result.advice}`, mood: "smile", timestamp: new Date() });
+        }
+        setPhase("result"); setMood("smile");
+      },
+      onError: (msg) => {
         stopSequence();
-        console.error("SSE 스트림 종료 후 결과 미수신");
-        addChatMessage({ id: crypto.randomUUID(), role: "character", content: "카드 해석 결과를 받지 못했어요. 다시 시도해주세요.", mood: "default", timestamp: new Date() });
-        setMood("default");
-        setReadingError(true);
-      }
-    } catch (e) {
-      console.error("리딩 요청 실패:", e);
-      stopSequence();
-      addChatMessage({ id: crypto.randomUUID(), role: "character", content: "카드의 메시지를 읽는 데 문제가 생겼어요. 다시 시도해주세요.", mood: "default", timestamp: new Date() });
-      setMood("default");
-      setReadingError(true);
-    }
+        console.error("리딩 SSE 에러:", msg);
+        const text = msg.includes("GROK_API_KEY")
+          ? "AI 서비스 설정에 문제가 있어요. 관리자에게 문의해주세요."
+          : "카드 해석 중 문제가 발생했어요. 다시 시도해주세요.";
+        addChatMessage({ id: crypto.randomUUID(), role: "character", content: text, mood: "default", timestamp: new Date() });
+        setMood("default"); setReadingError(true);
+      },
+    });
     setLoading(false);
   };
 

--- a/src/hooks/useSSEStream.test.ts
+++ b/src/hooks/useSSEStream.test.ts
@@ -212,6 +212,27 @@ describe("fetchSSEStream", () => {
     expect(doneData).toMatchObject({ done: true, result: "완료" });
   });
 
+  it("done 페이로드의 result.parseError를 onDone에 그대로 전달한다 (truncated 시그널)", async () => {
+    const lines = [
+      'data: {"done":true,"result":{"cardInterpretations":[],"overallReading":"부분","advice":"","parseError":"truncated","expectedCardCount":5}}',
+    ];
+    mockFetch.mockResolvedValue(makeSseResponse(lines));
+
+    let doneData: Record<string, unknown> | null = null;
+    await fetchSSEStream({
+      url: "/api/test",
+      body: {},
+      onChunk: vi.fn(),
+      onDone: (d) => { doneData = d; },
+      onError: vi.fn(),
+    });
+
+    expect(doneData).toBeTruthy();
+    const result = (doneData as unknown as { result: Record<string, unknown> }).result;
+    expect(result.parseError).toBe("truncated");
+    expect(result.expectedCardCount).toBe(5);
+  });
+
   it("POST 요청 body를 JSON으로 직렬화해서 전송한다", async () => {
     mockFetch.mockResolvedValue(makeSseResponse(['data: {"done":true}']));
 

--- a/src/services/tarot/tarot-service.test.ts
+++ b/src/services/tarot/tarot-service.test.ts
@@ -343,5 +343,70 @@ describe("TarotService", () => {
       expect(result.overallReading).toBeDefined();
       expect(result.advice).toBeDefined();
     });
+
+    describe("parseError 시그널 (truncated/invalid_json)", () => {
+      it("expectedCardCount보다 cardInterpretations가 적으면 parseError='truncated'를 반환한다", () => {
+        const json = JSON.stringify({
+          cardInterpretations: [
+            { cardId: "major-00", position: 0, interpretation: "해석1" },
+            { cardId: "major-01", position: 1, interpretation: "해석2" },
+          ],
+          overallReading: "종합",
+          advice: "조언",
+        });
+        const result = service.parseResult(json, 5);
+        expect(result.parseError).toBe("truncated");
+        expect(result.expectedCardCount).toBe(5);
+        expect(result.cardInterpretations).toHaveLength(2);
+      });
+
+      it("cardInterpretations 길이가 expectedCardCount와 같으면 parseError가 없다", () => {
+        const json = JSON.stringify({
+          cardInterpretations: [
+            { cardId: "major-00", position: 0, interpretation: "해석1" },
+            { cardId: "major-01", position: 1, interpretation: "해석2" },
+            { cardId: "major-02", position: 2, interpretation: "해석3" },
+          ],
+          overallReading: "종합",
+          advice: "조언",
+        });
+        const result = service.parseResult(json, 3);
+        expect(result.parseError).toBeUndefined();
+        expect(result.expectedCardCount).toBe(3);
+        expect(result.cardInterpretations).toHaveLength(3);
+      });
+
+      it("JSON 파싱 완전 실패 시 parseError='invalid_json'을 반환한다", () => {
+        const result = service.parseResult("완전히 망가진 응답", 3);
+        expect(result.parseError).toBe("invalid_json");
+        expect(result.expectedCardCount).toBe(3);
+        expect(result.cardInterpretations).toEqual([]);
+      });
+
+      it("expectedCardCount 미전달 시 parseError와 expectedCardCount 모두 미설정 (하위호환)", () => {
+        const json = JSON.stringify({
+          cardInterpretations: [
+            { cardId: "major-00", position: 0, interpretation: "해석1" },
+          ],
+          overallReading: "종합",
+          advice: "조언",
+        });
+        const result = service.parseResult(json);
+        expect(result.parseError).toBeUndefined();
+        expect(result.expectedCardCount).toBeUndefined();
+      });
+
+      it("expectedCardCount=0일 때 truncated 판정하지 않는다 (분기 가드)", () => {
+        const json = JSON.stringify({
+          cardInterpretations: [],
+          overallReading: "종합",
+          advice: "조언",
+        });
+        const result = service.parseResult(json, 0);
+        expect(result.parseError).toBeUndefined();
+        // expectedCardCount 자체는 그대로 보존
+        expect(result.expectedCardCount).toBe(0);
+      });
+    });
   });
 });

--- a/src/services/tarot/tarot-service.ts
+++ b/src/services/tarot/tarot-service.ts
@@ -36,19 +36,26 @@ export class TarotService implements DivinationService {
     return buildReadingPrompt(context.topic, context.selectedCards ?? [], spread);
   }
 
-  parseResult(aiResponse: string): ReadingResult {
+  parseResult(aiResponse: string, expectedCardCount?: number): ReadingResult {
     const parsed = parseJsonSafe(aiResponse);
 
     if (parsed) {
+      const cardInterpretations = (Array.isArray(parsed.cardInterpretations) ? parsed.cardInterpretations : []).map(
+        (interp: { cardId: string; position: number; interpretation: string; isReversed?: boolean }) => ({
+          ...interp,
+          interpretation: cleanReadingText(String(interp.interpretation || "")),
+        })
+      );
+      // 카드 수 부족 = AI 응답이 도중에 잘렸을 가능성 높음
+      const isTruncated = typeof expectedCardCount === "number"
+        && expectedCardCount > 0
+        && cardInterpretations.length < expectedCardCount;
       return {
-        cardInterpretations: (Array.isArray(parsed.cardInterpretations) ? parsed.cardInterpretations : []).map(
-          (interp: { cardId: string; position: number; interpretation: string; isReversed?: boolean }) => ({
-            ...interp,
-            interpretation: cleanReadingText(String(interp.interpretation || "")),
-          })
-        ),
+        cardInterpretations,
         overallReading: cleanReadingText(String(parsed.overallReading || "")),
         advice: cleanReadingText(String(parsed.advice || "")),
+        ...(isTruncated ? { parseError: "truncated" as const } : {}),
+        ...(typeof expectedCardCount === "number" ? { expectedCardCount } : {}),
       };
     }
 
@@ -59,6 +66,8 @@ export class TarotService implements DivinationService {
       cardInterpretations: [],
       overallReading: cleanText || "해석 결과를 처리하는 중 문제가 발생했습니다. 다시 시도해주세요.",
       advice: "",
+      parseError: "invalid_json",
+      ...(typeof expectedCardCount === "number" ? { expectedCardCount } : {}),
     };
   }
 

--- a/src/types/service.ts
+++ b/src/types/service.ts
@@ -8,6 +8,10 @@ export interface ReadingResult {
   advice: string;
   topicReading?: string;
   shareToken?: string | null;
+  /** AI 응답이 잘렸거나 JSON 파싱 실패 시 클라이언트가 감지하기 위한 시그널 */
+  parseError?: "truncated" | "invalid_json";
+  /** 요청 시 선택된 카드 수 — truncated 판정 기준 */
+  expectedCardCount?: number;
 }
 
 export interface SessionContext {


### PR DESCRIPTION
3-에이전트 병렬 조사로 확정된 근본 원인 3가지를 단계적으로 차단:

1. AI 응답 토큰 잘림 — max_tokens 정책을 카드 수 비례로 상향
   (1장 2000 / 2-3장 3500 / 4-5장 5000 / 6-7장 6500 / 8-9장 8000 / 10장+ 9500)
   computeReadingMaxTokens helper 도입으로 분기 누락 방지

2. 서버 fallback이 누락을 조용히 삼킴 — ReadingResult에 parseError 시그널 추가
   parseResult(aiResponse, expectedCardCount?) 시그니처 확장
   - parsed === null → parseError: "invalid_json"
   - cardInterpretations.length < expectedCardCount → parseError: "truncated"
   라우트는 cards.length를 전달하고 부분 파싱 발생 시 운영 로그
   ([tarot-reading] 부분 파싱 태그)

3. 클라이언트가 빈 배열을 정상으로 처리 — fetchSSEStream 통합 + 게이팅
   tarot/session/page.tsx의 직접 SSE 파싱 코드(약 110줄)를 useSSEStream으로 교체
   parseError 존재 시 카드별/종합/조언 메시지 미추가 + 재시도 안내 표시
   빈 배열 truthy 버그 수정 (length > 0 명시 검사)

테스트 663 → 672 (tarot-service 5건, tarot-reading API 3건, useSSEStream 1건)

https://claude.ai/code/session_01DuskrZWXSDpVwqWpXU6DSw