### PR TITLE
chore: GitHub Actions Node.js 24 조기 적용

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,6 +12,9 @@ on:
 # 배포는 Railway 자체 GitHub 연동이 담당 (railway.toml 기준 자동 배포)
 # 이 워크플로우는 코드 품질 검증 전용
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/docs-sync.yml
+++ b/.github/workflows/docs-sync.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: [main]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/qa-recheck.yml
+++ b/.github/workflows/qa-recheck.yml
@@ -11,6 +11,9 @@ on:
       - 'n8n/**'
       - '.github/ISSUE_TEMPLATE/**'
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 permissions:
   contents: read
   issues: read     # QA 실패 Issue 목록 조회

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -14,6 +14,9 @@ on:
       - 'docs/**'
       - 'n8n/**'
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 permissions:
   contents: read
   pull-requests: write   # SonarCloud PR 코멘트·데코레이션

--- a/.github/workflows/weekly-qa.yml
+++ b/.github/workflows/weekly-qa.yml
@@ -6,6 +6,9 @@ on:
     - cron: "0 0 * * 6"
   workflow_dispatch: # 수동 실행 가능
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 permissions:
   contents: read
   issues: write    # QA 실패 Issue 생성·닫기


### PR DESCRIPTION
## Summary
- 5개 워크플로 전체에 워크플로 레벨 `env: FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` 추가
- 대상: `deploy.yml`, `docs-sync.yml`, `sonar.yml`, `weekly-qa.yml`, `qa-recheck.yml`
- GitHub Actions Node.js 20 deprecated 경고 해소 (2026-09-16 제거 전 선제 대응)

## Background
PR #209 CI 로그에서 다음 경고 발생:
> Node.js 20 actions are deprecated... Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026.

`@v4` 최신 버전 유지하면서 `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true`로 Action 실행 런타임만 Node.js 24로 전환. 프로젝트 코드 자체의 `node-version: 20` 빌드 환경과는 별개.

## Test Plan
- [ ] CI — Lint, Type Check, Build & E2E 통과 확인
- [ ] SonarCloud & Codecov 통과 확인
- [ ] 문서 정합성 검사 통과 확인

🤖 Generated with [Claude Code](https://claude.ai/claude-code)