### PR TITLE
fix: 타로 스프레드 타입 라우팅 버그 — celtic-cross 등 7종 리딩 결과 미생성

### DIFF
--- a/scripts/e2e-full/flows/tarot-flow.ts
+++ b/scripts/e2e-full/flows/tarot-flow.ts
@@ -15,18 +15,19 @@ const TOPIC_KO: Record<string, string> = {
   finance: '재물',
   career: '직장',
   health: '건강',
-  general: '종합',
+  general: '일반 상담',
 };
 
 const SPREAD_KO: Record<string, string> = {
   'one-card': '원카드',
   'three-card': '쓰리카드',
-  'relationship': '관계',
-  'horseshoe': '말굽',
-  'decision': '결정',
-  'week-ahead': '주간',
-  'celtic-cross': '켈틱크로스',
-  'zodiac': '조디악',
+  'five-card': '켈틱 크로스 (5장)',
+  'relationship': '관계 스프레드',
+  'horseshoe': '말굽 스프레드',
+  'decision': '의사결정',
+  'week-ahead': '한 주 전망',
+  'celtic-cross': '켈틱 크로스 (10장)',
+  'zodiac': '조디악 휠',
   'tree-of-life': '생명의 나무',
 };
 
@@ -83,12 +84,12 @@ export async function executeTarotFlow(
     await startBtn.click();
   }
 
-  // 6. 카드 선택
+  // 6. 카드 선택 (data-testid^="card-back-" — CardDeck motion.div 마다 부여)
   const count = CARD_COUNTS[tc.spreadType ?? 'three-card'] ?? 3;
   const selectedCards: string[] = [];
 
   for (let i = 0; i < count; i++) {
-    const card = page.locator('[data-testid^="card-back"]').first();
+    const card = page.locator('[data-testid^="card-back-"]').first();
     await card.waitFor({ timeout: 15000 });
     const cardName = await card.getAttribute('data-card-name') ?? `card-${i}`;
     selectedCards.push(cardName);
@@ -101,13 +102,12 @@ export async function executeTarotFlow(
     await page.waitForTimeout(300);
   }
 
-  // 7. 결과 페이지 대기
-  await page.waitForURL('**/tarot/result/**', { timeout: 120000 });
+  // 7. 결과 대기 — 타로 세션은 URL 변경 없이 인라인으로 결과 표시
+  const resultLocator = page.locator('[data-testid="reading-content"]');
+  await resultLocator.waitFor({ timeout: 120000 });
 
   // 8. 응답 텍스트 추출
-  const textLocator = page.locator('[data-testid="reading-content"]').first();
-  await textLocator.waitFor({ timeout: 30000 });
-  const responseText = await textLocator.innerText();
+  const responseText = await resultLocator.innerText();
 
   return { responseText, selectedCards };
 }

--- a/src/app/api/tarot/reading/route.ts
+++ b/src/app/api/tarot/reading/route.ts
@@ -3,7 +3,7 @@ import { TarotService } from "@/services/tarot/tarot-service";
 import { FallbackProvider } from "@/services/core/fallback-provider";
 import { DeckManager } from "@/services/tarot/deck-manager";
 import { SpreadResolver } from "@/services/tarot/spread-resolver";
-import { Topic } from "@/types/session";
+import { Topic, SpreadType } from "@/types/session";
 import { SelectedCard } from "@/types/card";
 import { buildUserInfoPrompt, buildFreeQuestionPrompt, buildCharacterMemoryPrompt } from "@/services/core/prompt-builder";
 import { getCurrentUser, assertSessionOwnership } from "@/lib/auth";
@@ -85,9 +85,9 @@ export async function POST(request: NextRequest) {
     const systemPrompt = tarotService.getSystemPrompt(characterId);
     const userInfoPrompt = buildUserInfoPrompt(userInfo);
     const freeQuestionPrompt = buildFreeQuestionPrompt(freeQuestion);
-    const resolvedSpreadType = (spreadType === "one-card" || spreadType === "three-card" || spreadType === "five-card")
-      ? spreadType
-      : spreadResolver.resolveForTopic(topic).type;
+    const resolvedSpreadType: SpreadType = (spreadType && spreadResolver.getSpreadByType(spreadType))
+      ? (spreadType as SpreadType)
+      : spreadResolver.resolveForTopic(topic as Topic).type;
     const readingPrompt = tarotService.getReadingPrompt({
       session: { id: sessionId || "anonymous", userId: null, serviceType: "tarot", topic, status: "in_progress",
         spreadType: resolvedSpreadType, selectedCards, createdAt: new Date(), completedAt: null },

--- a/src/app/tarot/session/page.tsx
+++ b/src/app/tarot/session/page.tsx
@@ -553,7 +553,7 @@ export default function TarotSessionPage() {
                 className="w-full flex-1 flex flex-col overflow-hidden py-4"
               >
                 {/* 리딩 결과만 표시 (캐릭터 대사 제외) */}
-                <div ref={resultContainerRef} className="space-y-4 md:space-y-5 flex-1 overflow-y-auto pr-2">
+                <div ref={resultContainerRef} data-testid="reading-content" className="space-y-4 md:space-y-5 flex-1 overflow-y-auto pr-2">
                   {/* 카드별 해석 — 순차 공개 */}
                   {readingResult.cardInterpretations?.map((interp, i) => {
                     const card = selectedCards.find(c => c.card.id === interp.cardId);

--- a/src/components/card/CardDeck.tsx
+++ b/src/components/card/CardDeck.tsx
@@ -129,6 +129,8 @@ export function CardDeck({ cards, isSpread, selectedIndices, onCardSelect }: Car
         return (
           <motion.div
             key={card.id}
+            data-testid={`card-back-${index}`}
+            data-card-name={card.id}
             initial={{ x: 0, y: 50, rotate: 0, opacity: 0 }}
             animate={{ x: xOffset, y, rotate: angle, opacity: isSelected ? 0.3 : 1, scale }}
             transition={{


### PR DESCRIPTION
## Summary

- **근본 원인**: `route.ts`에서 `one-card`/`three-card`/`five-card` 3종만 인식, 나머지 7종(`celtic-cross`, `relationship`, `horseshoe`, `decision`, `week-ahead`, `zodiac`, `tree-of-life`)은 `resolveForTopic(topic)`으로 강제 덮어씀
- 결과: 10장 celtic-cross를 선택해도 API는 3장 스프레드 프롬프트로 생성 → AI가 잘못된 구조 응답 → `parseError: "truncated"` → 리딩 결과 미표시
- **Verum 영향 없음** — 에이전트 3종 확인 결과 src/ 전체에 Verum 코드 잔재 없음

## Changes

| 파일 | 변경 내용 |
|---|---|
| `src/app/api/tarot/reading/route.ts` | `SpreadType` import 추가, `resolvedSpreadType` → `getSpreadByType()`으로 전체 enum 검증 |
| `src/components/card/CardDeck.tsx` | `data-testid="card-back-{index}"`, `data-card-name={card.id}` 추가 |
| `src/app/tarot/session/page.tsx` | 결과 컨테이너에 `data-testid="reading-content"` 추가 |
| `scripts/e2e-full/flows/tarot-flow.ts` | `TOPIC_KO` general 매핑 정정, `SPREAD_KO` 완전 매핑, `waitForURL` → 인라인 결과 대기 |

## Test plan

- [ ] `celtic-cross` (10장) 선택 후 리딩 결과 정상 표시 확인
- [ ] `relationship` (7장), `zodiac` (12장), `week-ahead` (7장) 확인
- [ ] 기존 `one-card`/`three-card`/`five-card` 회귀 없음
- [ ] `pnpm type-check && pnpm lint` 통과
- [ ] CI E2E Desktop Chrome 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)