### PR TITLE
fix: 타로 리딩 완전 수정 — DB 제약·세션 라우트·스프레드 타입 일괄 해소

### DIFF
--- a/e2e/cross-platform.spec.ts
+++ b/e2e/cross-platform.spec.ts
@@ -70,8 +70,14 @@ test.describe("크로스 플랫폼 품질 검증", () => {
 
     // 네이티브 휠 이벤트로 스크롤 — overflow-x:clip 환경에서 window.scrollTo가
     // 작동하지 않으므로 실제 브라우저 스크롤 이벤트를 사용
+    // 마우스를 뷰포트 중앙으로 이동 후 휠 이벤트 발생 (CI 헤드리스 환경 안정성)
+    await page.mouse.move(640, 400);
     await page.mouse.wheel(0, 500);
-    await page.waitForTimeout(300);
+    // 고정 타임아웃 대신 스크롤 상태 폴링 (CI 환경 응답 지연 대응)
+    await page.waitForFunction(
+      () => (window.scrollY || document.documentElement.scrollTop || document.body.scrollTop) > 0,
+      { timeout: 3000 }
+    );
 
     const scrolled = await page.evaluate(
       () => window.scrollY || document.documentElement.scrollTop || document.body.scrollTop

--- a/src/__tests__/api/tarot-session.test.ts
+++ b/src/__tests__/api/tarot-session.test.ts
@@ -59,12 +59,11 @@ describe("POST /api/tarot/session", () => {
     expect(mockDb.insert).toHaveBeenCalledWith("sessions", expect.objectContaining({ spread_type: "three-card" }));
   });
 
-  it("spreadType이 유효 3개 외 값이면 서비스 기본값 사용 (zodiac 등)", async () => {
+  it("spreadType이 유효한 10종이면 모두 그대로 사용 (zodiac 등)", async () => {
     const { POST, mockDb } = await setup();
     await POST(makePostRequest({ topic: "love", spreadType: "zodiac" }));
     const callArg = mockDb.insert.mock.calls[0][1] as Record<string, unknown>;
-    expect(callArg.spread_type).not.toBe("zodiac");
-    expect(callArg.spread_type).toBeTruthy();
+    expect(callArg.spread_type).toBe("zodiac");
   });
 
   it("spreadType 미지정 → sessionData.spreadType 사용", async () => {

--- a/src/app/api/tarot/session/route.ts
+++ b/src/app/api/tarot/session/route.ts
@@ -2,12 +2,14 @@ import { NextRequest, NextResponse } from "next/server"
 import { getDb } from "@/lib/db"
 import { getCurrentUser } from "@/lib/auth"
 import { TarotService } from "@/services/tarot/tarot-service"
+import { SpreadResolver } from "@/services/tarot/spread-resolver"
 import { getCharacterById } from "@/data/characters"
 import { Topic } from "@/types/session"
 import { TAROT_TOPICS } from "@/data/topics"
 import { TarotSessionSchema } from "@/lib/validation/api-schemas"
 
 const tarotService = new TarotService()
+const spreadResolver = new SpreadResolver()
 
 export async function POST(request: NextRequest) {
   try {
@@ -22,8 +24,7 @@ export async function POST(request: NextRequest) {
     const validCharId = characterId && getCharacterById(characterId) ? characterId : null
     const user = await getCurrentUser()
     const sessionData = tarotService.startSession(topic)
-    const validSpreadTypes = ["one-card", "three-card", "five-card"]
-    const resolvedSpreadType = spreadType && validSpreadTypes.includes(spreadType)
+    const resolvedSpreadType = (spreadType && spreadResolver.getSpreadByType(spreadType))
       ? spreadType
       : sessionData.spreadType
 

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import Image from "next/image";
 import Link from "next/link";
 import { useThemeStore, themes, ThemeId } from "@/hooks/useTheme";
@@ -14,14 +14,16 @@ export default function SettingsPage() {
   const { selectedSkinId, setSkin } = useSkinStore();
   const { genderFilter, setGenderFilter } = useGenderStore();
 
-  const [confirmEachCard, setConfirmEachCard] = useState(() => {
-    if (typeof window !== "undefined") return localStorage.getItem("arcana-confirm-each-card") === "true";
-    return false;
-  });
-  const [hasSavedInfo, setHasSavedInfo] = useState(() => {
-    if (typeof window !== "undefined") return !!localStorage.getItem("arcana_user_info");
-    return false;
-  });
+  const [confirmEachCard, setConfirmEachCard] = useState(false);
+  const [hasSavedInfo, setHasSavedInfo] = useState(false);
+
+  useEffect(() => {
+    const t = setTimeout(() => {
+      setConfirmEachCard(localStorage.getItem("arcana-confirm-each-card") === "true");
+      setHasSavedInfo(!!localStorage.getItem("arcana_user_info"));
+    }, 0);
+    return () => clearTimeout(t);
+  }, []);
 
   const toggleConfirmMode = () => {
     const next = !confirmEachCard;

--- a/src/app/tarot/session/page.tsx
+++ b/src/app/tarot/session/page.tsx
@@ -128,12 +128,7 @@ export default function TarotSessionPage() {
   const [pendingConfirm, _setPendingConfirm] = useState(false);
   const pendingConfirmRef = useRef(false);
   const setPendingConfirm = (v: boolean) => { pendingConfirmRef.current = v; _setPendingConfirm(v); };
-  const [confirmEachCard, setConfirmEachCard] = useState(() => {
-    if (typeof window !== "undefined") {
-      return localStorage.getItem("arcana-confirm-each-card") === "true";
-    }
-    return false;
-  });
+  const [confirmEachCard, setConfirmEachCard] = useState(false);
   const resultContainerRef = useRef<HTMLDivElement>(null);
   const redirectedRef = useRef(false);
 
@@ -144,6 +139,13 @@ export default function TarotSessionPage() {
       return next;
     });
   };
+
+  useEffect(() => {
+    const t = setTimeout(() => {
+      setConfirmEachCard(localStorage.getItem("arcana-confirm-each-card") === "true");
+    }, 0);
+    return () => clearTimeout(t);
+  }, []);
 
   useEffect(() => {
     if (!topic || !character || !spreadType) {
@@ -311,6 +313,19 @@ export default function TarotSessionPage() {
         sessionId = useSessionStore.getState().sessionId;
         if (sessionId) break;
       }
+    }
+
+    if (!sessionId) {
+      stopSequence();
+      addChatMessage({
+        id: crypto.randomUUID(), role: "character",
+        content: getReadingErrorText("세션 연결에 실패했습니다. 잠시 후 다시 시도해 주세요.", characterId ?? "arcana"),
+        mood: "default", timestamp: new Date(),
+      });
+      setMood("default");
+      setReadingError(true);
+      setLoading(false);
+      return;
     }
 
     await fetchSSEStream({

--- a/src/hooks/useSSEStream.test.ts
+++ b/src/hooks/useSSEStream.test.ts
@@ -188,6 +188,53 @@ describe("fetchSSEStream", () => {
     expect(chunks).toEqual(["정상"]);
   });
 
+  it("스트림 종료 시 버퍼에 error 이벤트가 남아 있으면 onError를 호출한다", async () => {
+    // TCP 비정상 종료: error 이벤트가 마지막 줄에 \n 없이 남는 케이스
+    const text = 'data: {"chunk":"시작"}\ndata: {"error":"버퍼 에러"}';
+    const stream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(encoder.encode(text));
+        controller.close();
+      },
+    });
+    mockFetch.mockResolvedValue({ ok: true, status: 200, body: stream, json: vi.fn() } as unknown as Response);
+
+    const onError = vi.fn();
+    const chunks: string[] = [];
+    await fetchSSEStream({
+      url: "/api/test",
+      body: {},
+      onChunk: (c) => chunks.push(c),
+      onDone: vi.fn(),
+      onError,
+    });
+
+    expect(onError).toHaveBeenCalledWith("버퍼 에러");
+    expect(chunks).toEqual(["시작"]);
+  });
+
+  it("스트림 종료 시 버퍼에 잘못된 JSON이 있으면 에러 없이 무시한다", async () => {
+    const text = 'data: {"chunk":"정상"}\ndata: {invalid json}';
+    const stream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(encoder.encode(text));
+        controller.close();
+      },
+    });
+    mockFetch.mockResolvedValue({ ok: true, status: 200, body: stream, json: vi.fn() } as unknown as Response);
+
+    const onError = vi.fn();
+    await fetchSSEStream({
+      url: "/api/test",
+      body: {},
+      onChunk: vi.fn(),
+      onDone: vi.fn(),
+      onError,
+    });
+
+    expect(onError).not.toHaveBeenCalled();
+  });
+
   it("스트림 종료 시 버퍼에 남은 done 이벤트를 처리한다", async () => {
     // 개행 없이 끝나는 마지막 라인을 남기는 케이스 시뮬레이션
     const text = 'data: {"chunk":"마지막"}\ndata: {"done":true,"result":"완료"}';

--- a/src/hooks/useSSEStream.ts
+++ b/src/hooks/useSSEStream.ts
@@ -61,12 +61,14 @@ function processLine(
 
 function flushRemainingBuffer(
   sseBuffer: string,
-  handlers: Pick<SSEStreamOptions, "onDone">
+  handlers: Pick<SSEStreamOptions, "onDone" | "onError">
 ): void {
   if (!sseBuffer.trim() || !sseBuffer.startsWith("data: ")) return;
   try {
     const data = JSON.parse(sseBuffer.slice(6)) as Record<string, unknown>;
-    if (data.done) {
+    if (data.error) {
+      handlers.onError?.(data.error as string);
+    } else if (data.done) {
       handlers.onDone(data);
     }
   } catch (e) {
@@ -87,7 +89,7 @@ async function readStream(
     const { done, value } = await reader.read();
 
     if (done) {
-      flushRemainingBuffer(sseBuffer, handlers);
+      flushRemainingBuffer(sseBuffer, { onDone: handlers.onDone, onError: handlers.onError });
       break;
     }
 

--- a/src/services/core/grok-provider.ts
+++ b/src/services/core/grok-provider.ts
@@ -100,7 +100,8 @@ export class GrokProvider implements AIProvider {
       yield* readSseLines(
         response,
         (p) => (p as { choices?: [{ delta?: { content?: string } }] }).choices?.[0]?.delta?.content ?? null,
-        "Grok"
+        "Grok",
+        controller.signal
       );
     } finally {
       clearTimeout(timer);

--- a/src/services/core/http-utils.test.ts
+++ b/src/services/core/http-utils.test.ts
@@ -65,4 +65,14 @@ describe("readSseLines", () => {
     expect(warn).toHaveBeenCalled();
     warn.mockRestore();
   });
+
+  it("signal이 이미 abort된 상태면 reader.cancel 후 AbortError throw", async () => {
+    const controller = new AbortController();
+    controller.abort();
+
+    const res = makeResponse(["data: {\"delta\":\"hello\"}"]);
+    const gen = readSseLines(res, () => null, "TEST", controller.signal);
+
+    await expect(gen.next()).rejects.toThrow(DOMException);
+  });
 });

--- a/src/services/core/http-utils.ts
+++ b/src/services/core/http-utils.ts
@@ -37,13 +37,18 @@ function parseSseLine(
 export async function* readSseLines(
   response: Response,
   extractDelta: (parsed: unknown) => string | null,
-  logTag = "SSE"
+  logTag = "SSE",
+  signal?: AbortSignal
 ): AsyncGenerator<string, void, unknown> {
   if (!response.body) throw new Error("Response body is null");
   const reader = response.body.getReader();
   const decoder = new TextDecoder();
   let buffer = "";
   while (true) {
+    if (signal?.aborted) {
+      await reader.cancel();
+      throw new DOMException("The operation was aborted.", "AbortError");
+    }
     const { done, value } = await reader.read();
     if (done) break;
     buffer += decoder.decode(value, { stream: true });

--- a/supabase/migrations/012_spread_type_expand.sql
+++ b/supabase/migrations/012_spread_type_expand.sql
@@ -1,0 +1,10 @@
+-- sessions.spread_type 제약 확장: celtic-cross, relationship, horseshoe, decision, week-ahead, zodiac, tree-of-life 추가
+-- 원인: topicToSpread 매핑에서 general→celtic-cross, love-couple→relationship, finance/career→horseshoe 반환 시
+--       DB CHECK 제약('one-card','three-card','five-card')에 없어 INSERT 500 발생 (2026-05-02 장애)
+ALTER TABLE sessions DROP CONSTRAINT IF EXISTS sessions_spread_type_check;
+ALTER TABLE sessions ADD CONSTRAINT sessions_spread_type_check
+  CHECK (spread_type IN (
+    'one-card', 'three-card', 'five-card',
+    'celtic-cross', 'relationship', 'horseshoe',
+    'decision', 'week-ahead', 'zodiac', 'tree-of-life'
+  ));


### PR DESCRIPTION
## 근본 원인 분석

Railway 프로덕션 로그에서 확인된 실제 에러:
```
세션 생성 오류: Error: new row for relation "sessions" violates check constraint "sessions_spread_type_check"
```

### 실패 연쇄 구조

```
사용자가 celtic-cross/relationship/zodiac 등 선택
  → session/route.ts: 3-종 하드코딩 화이트리스트로 오버라이드 시도
  → DB sessions_spread_type_check (3종만 허용) → INSERT 500
  → sessionId = null
  → session/page.tsx null 가드 3초 폴링 후 에러 처리
  → 리딩 전체 차단 (API 호출조차 안 됨)
```

**Verum 영향 없음** — 에이전트 확인 결과 src/ 전체에 잔재 없음.

## 변경 내용

| 파일 | 수정 내용 |
|---|---|
| `supabase/migrations/012_spread_type_expand.sql` | `sessions_spread_type_check` 제약 10종으로 확장 (프로덕션 DB 즉시 적용 완료) |
| `src/app/api/tarot/session/route.ts` | 3-종 화이트리스트 → `SpreadResolver.getSpreadByType()` 전체 enum 검증 |
| `src/__tests__/api/tarot-session.test.ts` | zodiac 테스트 기대값 수정 (버그 동작 → 올바른 동작) |
| *(이전 커밋)* `src/app/tarot/session/page.tsx` | sessionId null 가드 + confirmEachCard SSR 안전 초기화 |
| *(이전 커밋)* `src/hooks/useSSEStream.ts` | flushRemainingBuffer error 이벤트 처리 + AbortSignal 전파 |

## Test plan

- [ ] `celtic-cross` (10장), `relationship` (7장), `zodiac` (12장) 리딩 결과 정상 표시
- [ ] `one-card`/`three-card`/`five-card` 기존 동작 회귀 없음
- [ ] `pnpm type-check && pnpm lint` 통과
- [ ] 단위 테스트 13/13 통과
- [ ] CI E2E 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)