### PR TITLE
fix: 타로 세션 생성 DB 제약·스프레드 라우팅 버그 수정

### DIFF
--- a/src/__tests__/api/tarot-session.test.ts
+++ b/src/__tests__/api/tarot-session.test.ts
@@ -59,12 +59,11 @@ describe("POST /api/tarot/session", () => {
     expect(mockDb.insert).toHaveBeenCalledWith("sessions", expect.objectContaining({ spread_type: "three-card" }));
   });
 
-  it("spreadType이 유효 3개 외 값이면 서비스 기본값 사용 (zodiac 등)", async () => {
+  it("spreadType이 유효한 10종이면 모두 그대로 사용 (zodiac 등)", async () => {
     const { POST, mockDb } = await setup();
     await POST(makePostRequest({ topic: "love", spreadType: "zodiac" }));
     const callArg = mockDb.insert.mock.calls[0][1] as Record<string, unknown>;
-    expect(callArg.spread_type).not.toBe("zodiac");
-    expect(callArg.spread_type).toBeTruthy();
+    expect(callArg.spread_type).toBe("zodiac");
   });
 
   it("spreadType 미지정 → sessionData.spreadType 사용", async () => {

--- a/src/app/api/tarot/session/route.ts
+++ b/src/app/api/tarot/session/route.ts
@@ -2,12 +2,14 @@ import { NextRequest, NextResponse } from "next/server"
 import { getDb } from "@/lib/db"
 import { getCurrentUser } from "@/lib/auth"
 import { TarotService } from "@/services/tarot/tarot-service"
+import { SpreadResolver } from "@/services/tarot/spread-resolver"
 import { getCharacterById } from "@/data/characters"
 import { Topic } from "@/types/session"
 import { TAROT_TOPICS } from "@/data/topics"
 import { TarotSessionSchema } from "@/lib/validation/api-schemas"
 
 const tarotService = new TarotService()
+const spreadResolver = new SpreadResolver()
 
 export async function POST(request: NextRequest) {
   try {
@@ -22,8 +24,7 @@ export async function POST(request: NextRequest) {
     const validCharId = characterId && getCharacterById(characterId) ? characterId : null
     const user = await getCurrentUser()
     const sessionData = tarotService.startSession(topic)
-    const validSpreadTypes = ["one-card", "three-card", "five-card"]
-    const resolvedSpreadType = spreadType && validSpreadTypes.includes(spreadType)
+    const resolvedSpreadType = (spreadType && spreadResolver.getSpreadByType(spreadType))
       ? spreadType
       : sessionData.spreadType
 

--- a/supabase/migrations/012_spread_type_expand.sql
+++ b/supabase/migrations/012_spread_type_expand.sql
@@ -1,0 +1,10 @@
+-- sessions.spread_type 제약 확장: celtic-cross, relationship, horseshoe, decision, week-ahead, zodiac, tree-of-life 추가
+-- 원인: topicToSpread 매핑에서 general→celtic-cross, love-couple→relationship, finance/career→horseshoe 반환 시
+--       DB CHECK 제약('one-card','three-card','five-card')에 없어 INSERT 500 발생 (2026-05-02 장애)
+ALTER TABLE sessions DROP CONSTRAINT IF EXISTS sessions_spread_type_check;
+ALTER TABLE sessions ADD CONSTRAINT sessions_spread_type_check
+  CHECK (spread_type IN (
+    'one-card', 'three-card', 'five-card',
+    'celtic-cross', 'relationship', 'horseshoe',
+    'decision', 'week-ahead', 'zodiac', 'tree-of-life'
+  ));


### PR DESCRIPTION
## 근본 원인

Railway 프로덕션 로그:
```
세션 생성 오류: Error: new row for relation "sessions" violates check constraint "sessions_spread_type_check"
```

### 실패 연쇄
```
사용자가 celtic-cross / relationship / zodiac 등 7종 선택
  → session/route.ts: 3-종 화이트리스트로 오버라이드 시도
  → DB CHECK 제약 (3종만 허용) → INSERT 500
  → sessionId = null
  → 클라이언트 3초 폴링 후 에러 처리
  → 리딩 API 호출 자체 차단
```

**Verum 영향 없음** (에이전트 3종 독립 확인)

## 변경 내용

| 파일 | 내용 |
|---|---|
| `supabase/migrations/012_spread_type_expand.sql` | `sessions_spread_type_check` 10종으로 확장 (프로덕션 DB 이미 적용) |
| `src/app/api/tarot/session/route.ts` | 3-종 화이트리스트 → `SpreadResolver.getSpreadByType()` 전체 검증 |
| `src/__tests__/api/tarot-session.test.ts` | zodiac 테스트 기대값 수정 (버그 동작 → 올바른 동작) |

## Test plan

- [ ] `celtic-cross`, `relationship`, `zodiac` 선택 시 세션 생성 정상
- [ ] 리딩 결과 표시 확인
- [ ] `one-card`/`three-card` 기존 동작 유지
- [ ] 단위 테스트 13/13 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)