### PR TITLE
fix(i18n): PR-A 정합성 핫픽스 — locale wiring·sonar 정리·E2E testid

### DIFF
--- a/e2e/responsive.spec.ts
+++ b/e2e/responsive.spec.ts
@@ -8,8 +8,8 @@ test.describe("반응형 레이아웃", () => {
     await page.goto("/");
     await page.waitForLoadState("networkidle");
 
-    // 데스크탑 네비 표시
-    const desktopNav = page.locator("nav").filter({ hasText: /타로 상담/ });
+    // 데스크탑 네비 표시 (data-testid 사용 — i18n 텍스트 변경에 안정적)
+    const desktopNav = page.locator('[data-testid="desktop-nav"]');
     await expect(desktopNav).toBeVisible();
 
     // MobileNav 숨김
@@ -26,8 +26,8 @@ test.describe("반응형 레이아웃", () => {
     await page.goto("/");
     await page.waitForLoadState("networkidle");
 
-    // 최소 5개의 네비 아이템 (홈/타로/사주/신점/MY)
-    const navItems = page.locator("nav a, nav button").filter({ hasText: /홈|타로|사주|신점|MY/ });
+    // 최소 5개의 모바일 네비 아이템 (data-testid="mobile-nav-*" 사용 — i18n 안정적)
+    const navItems = page.locator('[data-testid^="mobile-nav-"]');
     expect(await navItems.count()).toBeGreaterThanOrEqual(4);
   });
 

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -43,19 +43,22 @@ sonar.coverage.exclusions=\
   src/data/birth-hours.ts,\
   src/data/error-messages.ts,\
   src/data/ui-copy.ts,\
-  src/lib/supabase/**,\
+  src/lib/supabase/client.ts,\
+  src/lib/supabase/server.ts,\
+  src/lib/supabase/middleware.ts,\
+  src/lib/supabase/storage.ts,\
   src/lib/auth/**,\
   src/lib/storage/**,\
-  src/lib/validation/**,\
   src/lib/db/schema/**,\
   src/lib/db/types.ts,\
-  src/lib/db/index.ts,\
   src/lib/db/postgres-adapter.ts,\
   src/lib/db/supabase-admin-adapter.ts,\
+  src/lib/db/reading-saver.ts,\
   src/services/core/ai-provider.ts,\
   src/services/saju/saju-types.ts,\
   src/i18n/LocaleProvider.tsx,\
   src/i18n/useT.ts,\
+  src/i18n/server-locale.ts,\
   src/i18n/translations/ko/**,\
   src/i18n/translations/en/**,\
   src/i18n/translations/ja/**

--- a/src/__tests__/api/locale-wiring.test.ts
+++ b/src/__tests__/api/locale-wiring.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+/**
+ * locale wiring 검증 — PR-A 정합성 핫픽스.
+ * 3개 session 라우트 + reading-saver 3개 함수가 locale을 INSERT 인자로 전달하는지 확인.
+ */
+
+beforeEach(() => {
+  vi.resetModules();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+function makeMockDb() {
+  const insertCalls: { table: string; data: Record<string, unknown> }[] = [];
+  const insert = vi.fn(async (table: string, data: Record<string, unknown>) => {
+    insertCalls.push({ table, data });
+    return { id: "mock-session-id", ...data };
+  });
+  const insertMany = vi.fn(async () => undefined);
+  const update = vi.fn(async () => undefined);
+  const findOne = vi.fn(async () => null);
+  return { insert, insertMany, update, findOne, insertCalls };
+}
+
+function setupServerLocale(value: "ko" | "en" | "ja") {
+  vi.doMock("@/i18n/server-locale", () => ({
+    getRequestLocale: vi.fn().mockResolvedValue(value),
+  }));
+}
+
+function makePostRequest(body: unknown) {
+  return new Request("http://localhost/api/test", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  }) as unknown as import("next/server").NextRequest;
+}
+
+describe("locale wiring — sessions INSERT", () => {
+  it("tarot/session: locale='en' 헤더 → sessions INSERT에 locale='en' 동봉", async () => {
+    setupServerLocale("en");
+    const mockDb = makeMockDb();
+    vi.doMock("@/lib/db", () => ({ getDb: () => mockDb }));
+    vi.doMock("@/lib/auth", () => ({ getCurrentUser: vi.fn().mockResolvedValue(null) }));
+
+    const { POST } = await import("@/app/api/tarot/session/route");
+    await POST(makePostRequest({ topic: "love", characterId: null, spreadType: "three-card" }));
+
+    const sessionInsert = mockDb.insertCalls.find((c) => c.table === "sessions");
+    expect(sessionInsert).toBeDefined();
+    expect(sessionInsert!.data.locale).toBe("en");
+  });
+
+  it("saju/session: locale='ja' → sessions INSERT에 locale='ja' 동봉", async () => {
+    setupServerLocale("ja");
+    const mockDb = makeMockDb();
+    vi.doMock("@/lib/db", () => ({ getDb: () => mockDb }));
+    vi.doMock("@/lib/auth", () => ({ getCurrentUser: vi.fn().mockResolvedValue(null) }));
+
+    const { POST } = await import("@/app/api/saju/session/route");
+    await POST(makePostRequest({ topic: "saju-career", characterId: null }));
+
+    const sessionInsert = mockDb.insertCalls.find((c) => c.table === "sessions");
+    expect(sessionInsert).toBeDefined();
+    expect(sessionInsert!.data.locale).toBe("ja");
+  });
+
+  it("shinjeom/session: locale='ko' → sessions INSERT에 locale='ko' 동봉", async () => {
+    setupServerLocale("ko");
+    const mockDb = makeMockDb();
+    vi.doMock("@/lib/db", () => ({ getDb: () => mockDb }));
+    vi.doMock("@/lib/auth", () => ({ getCurrentUser: vi.fn().mockResolvedValue(null) }));
+
+    const { POST } = await import("@/app/api/shinjeom/session/route");
+    await POST(makePostRequest({ topic: "love", characterId: "arcana" }));
+
+    const sessionInsert = mockDb.insertCalls.find((c) => c.table === "sessions");
+    expect(sessionInsert).toBeDefined();
+    expect(sessionInsert!.data.locale).toBe("ko");
+  });
+});
+
+describe("locale wiring — reading-saver", () => {
+  it("saveTarotReading: locale 인자가 readings INSERT에 동봉", async () => {
+    const { saveTarotReading } = await import("@/lib/db/reading-saver");
+    const mockDb = makeMockDb();
+    await saveTarotReading(
+      mockDb as unknown as Parameters<typeof saveTarotReading>[0],
+      "sess-1",
+      { overallReading: "test", advice: "" },
+      [{ cardId: "major-00", position: 0, isReversed: false }],
+      "en"
+    );
+    const readingsInsert = mockDb.insertCalls.find((c) => c.table === "readings");
+    expect(readingsInsert!.data.locale).toBe("en");
+  });
+
+  it("saveSajuReading: locale 인자가 saju_readings INSERT에 동봉", async () => {
+    const { saveSajuReading } = await import("@/lib/db/reading-saver");
+    const mockDb = makeMockDb();
+    await saveSajuReading(
+      mockDb as unknown as Parameters<typeof saveSajuReading>[0],
+      "sess-2",
+      { session_id: "sess-2", overall_reading: "" },
+      "ja"
+    );
+    const sajuInsert = mockDb.insertCalls.find((c) => c.table === "saju_readings");
+    expect(sajuInsert!.data.locale).toBe("ja");
+  });
+
+  it("saveShinjeomFinalReading: locale 인자가 shinjeom_readings INSERT에 동봉", async () => {
+    const { saveShinjeomFinalReading } = await import("@/lib/db/reading-saver");
+    const mockDb = makeMockDb();
+    await saveShinjeomFinalReading(
+      mockDb as unknown as Parameters<typeof saveShinjeomFinalReading>[0],
+      "sess-3",
+      { overallReading: "test", advice: "" },
+      "en"
+    );
+    const shinInsert = mockDb.insertCalls.find((c) => c.table === "shinjeom_readings");
+    expect(shinInsert!.data.locale).toBe("en");
+  });
+
+  it("saveTarotReading: locale 미지정 시 기본값 'ko'", async () => {
+    const { saveTarotReading } = await import("@/lib/db/reading-saver");
+    const mockDb = makeMockDb();
+    await saveTarotReading(
+      mockDb as unknown as Parameters<typeof saveTarotReading>[0],
+      "sess-default",
+      { overallReading: "", advice: "" },
+      [{ cardId: "major-00", position: 0, isReversed: false }]
+    );
+    const readingsInsert = mockDb.insertCalls.find((c) => c.table === "readings");
+    expect(readingsInsert!.data.locale).toBe("ko");
+  });
+});

--- a/src/__tests__/api/saju-reading.test.ts
+++ b/src/__tests__/api/saju-reading.test.ts
@@ -158,7 +158,7 @@ describe("POST /api/saju/reading", () => {
     const res = await POST(makePostRequest({ ...VALID_BODY, sessionId: "sess-saju" }));
     await readSSEStream(res);
     await Promise.resolve();
-    expect(mockSave).toHaveBeenCalledWith(mockDb, "sess-saju", expect.any(Object));
+    expect(mockSave).toHaveBeenCalledWith(mockDb, "sess-saju", expect.any(Object), expect.any(String));
   });
 
   it("topicReading 없는 AI 응답 → topic_reading || '' 분기 커버", async () => {

--- a/src/__tests__/api/shinjeom-message.test.ts
+++ b/src/__tests__/api/shinjeom-message.test.ts
@@ -149,7 +149,7 @@ describe("POST /api/shinjeom/message", () => {
     const res = await POST(makePostRequest({ ...VALID_BODY, sessionId: "sess-final", isFinalTurn: true }));
     await readSSEStream(res);
     await Promise.resolve();
-    expect(mockSaveFinal).toHaveBeenCalledWith(mockDb, "sess-final", expect.any(Object));
+    expect(mockSaveFinal).toHaveBeenCalledWith(mockDb, "sess-final", expect.any(Object), expect.any(String));
   });
 
   it("AI 오류 → 스트림 내부 catch에서 errMsg 전송", async () => {

--- a/src/__tests__/api/tarot-reading.test.ts
+++ b/src/__tests__/api/tarot-reading.test.ts
@@ -201,7 +201,8 @@ describe("POST /api/tarot/reading", () => {
       mockDb,
       "sess-existing",
       expect.objectContaining({ overallReading: expect.any(String) }),
-      expect.any(Array)
+      expect.any(Array),
+      expect.any(String)  // locale (PR-A: i18n wiring)
     );
   });
 

--- a/src/app/api/saju/reading/route.ts
+++ b/src/app/api/saju/reading/route.ts
@@ -12,6 +12,7 @@ import { SajuReadingSchema } from "@/lib/validation/api-schemas";
 import { checkRateLimit, rateLimitResponse } from "@/lib/rate-limit"
 import { getClientIp, jsonError, SSE_HEADERS } from "@/lib/request-utils"
 import { saveSajuReading } from "@/lib/db/reading-saver";
+import { getRequestLocale } from "@/i18n/server-locale";
 
 const sajuService = new SajuService();
 const grokProvider = new FallbackProvider();
@@ -58,6 +59,7 @@ export async function POST(request: NextRequest) {
     const ip = getClientIp(request.headers);
     if (!(await checkRateLimit(`saju:${ip}`, 10, 60_000))) return rateLimitResponse();
 
+    const locale = await getRequestLocale();
     const rawBody = await request.json();
 
     // Zod 입력 검증
@@ -138,7 +140,7 @@ export async function POST(request: NextRequest) {
               overall_reading: result.overallReading,
               topic_reading: result.topicReading || "",
               advice: result.advice,
-            }).catch((e) => console.error("사주 DB 저장 최종 실패:", e))
+            }, locale).catch((e) => console.error("사주 DB 저장 최종 실패:", e))
           }
         } catch (e) {
           console.error("사주 리딩 생성 실패:", e instanceof Error ? e.message : String(e));

--- a/src/app/api/saju/session/route.ts
+++ b/src/app/api/saju/session/route.ts
@@ -5,6 +5,7 @@ import { getCharacterById } from "@/data/characters"
 import { Topic } from "@/types/session"
 import { SAJU_TOPICS } from "@/data/topics"
 import { SajuSessionSchema } from "@/lib/validation/api-schemas"
+import { getRequestLocale } from "@/i18n/server-locale"
 
 export async function POST(request: NextRequest) {
   try {
@@ -20,6 +21,7 @@ export async function POST(request: NextRequest) {
     const validCharId = characterId && getCharacterById(characterId) ? characterId : null
     const user = await getCurrentUser()
     const db = getDb()
+    const locale = await getRequestLocale()
     const session = await db.insert("sessions", {
       user_id: user?.id ?? null,
       service_type: "saju",
@@ -27,6 +29,7 @@ export async function POST(request: NextRequest) {
       spread_type: null,
       status: "in_progress",
       character_id: validCharId,
+      locale,
     })
     return NextResponse.json({ session })
   } catch (e) {

--- a/src/app/api/shinjeom/message/route.ts
+++ b/src/app/api/shinjeom/message/route.ts
@@ -10,6 +10,7 @@ import { ShinjeomMessageSchema } from "@/lib/validation/api-schemas";
 import { checkRateLimit, rateLimitResponse } from "@/lib/rate-limit"
 import { getClientIp, jsonError, SSE_HEADERS } from "@/lib/request-utils"
 import { saveShinjeomFinalReading, saveShinjeomMessages } from "@/lib/db/reading-saver";
+import { getRequestLocale } from "@/i18n/server-locale";
 
 const shinjeomService = new ShinjeomService();
 const aiProvider = new FallbackProvider();
@@ -36,6 +37,7 @@ export async function POST(request: NextRequest) {
     const ip = getClientIp(request.headers);
     if (!(await checkRateLimit(`shinjeom:${ip}`, 20, 60_000))) return rateLimitResponse();
 
+    const locale = await getRequestLocale();
     const rawBody = await request.json();
 
     // Zod 입력 검증 (chatHistory 100개 상한으로 토큰 과소비 방어)
@@ -83,7 +85,7 @@ export async function POST(request: NextRequest) {
             // 결과를 먼저 클라이언트에 전송 (DB 저장은 비동기 fire-and-forget, 3회 retry)
             controller.enqueue(encoder.encode(`data: ${JSON.stringify({ done: true, isFinal: true, result })}\n\n`));
             if (db && sessionId) {
-              void saveShinjeomFinalReading(db, sessionId, result).catch(
+              void saveShinjeomFinalReading(db, sessionId, result, locale).catch(
                 (e) => console.error("신점 최종 DB 저장 최종 실패:", e)
               );
             }

--- a/src/app/api/shinjeom/session/route.ts
+++ b/src/app/api/shinjeom/session/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server"
 import { getDb } from "@/lib/db"
 import { getCurrentUser } from "@/lib/auth"
 import { ShinjeomSessionSchema } from "@/lib/validation/api-schemas"
+import { getRequestLocale } from "@/i18n/server-locale"
 
 export async function POST(request: NextRequest) {
   try {
@@ -15,12 +16,14 @@ export async function POST(request: NextRequest) {
     try {
       const user = await getCurrentUser()
       const db = getDb()
+      const locale = await getRequestLocale()
       session = await db.insert("sessions", {
         service_type: "shinjeom",
         topic,
         character_id: characterId,
         user_id: user?.id ?? null,
         status: "in_progress",
+        locale,
       })
     } catch (e) {
       console.warn("세션 생성 실패 (신점은 계속 진행):", e)

--- a/src/app/api/tarot/reading/route.ts
+++ b/src/app/api/tarot/reading/route.ts
@@ -14,6 +14,7 @@ import { TarotReadingSchema } from "@/lib/validation/api-schemas";
 import { checkRateLimit, rateLimitResponse } from "@/lib/rate-limit"
 import { getClientIp, jsonError, SSE_HEADERS } from "@/lib/request-utils";
 import { saveTarotReading } from "@/lib/db/reading-saver";
+import { getRequestLocale } from "@/i18n/server-locale";
 
 const tarotService = new TarotService();
 const grokProvider = new FallbackProvider();
@@ -54,6 +55,7 @@ export async function POST(request: NextRequest) {
     const ip = getClientIp(request.headers);
     if (!(await checkRateLimit(`tarot:${ip}`, 10, 60_000))) return rateLimitResponse();
 
+    const locale = await getRequestLocale();
     const rawBody = await request.json();
 
     // Zod 입력 검증
@@ -125,7 +127,7 @@ export async function POST(request: NextRequest) {
 
           // DB 저장 — fire-and-forget (스트림 블로킹 없음, 3회 retry)
           if (db && sessionId) {
-            void saveTarotReading(db, sessionId, result, cards).catch(
+            void saveTarotReading(db, sessionId, result, cards, locale).catch(
               (e) => console.error("타로 DB 저장 최종 실패:", e)
             )
           }

--- a/src/app/api/tarot/session/route.ts
+++ b/src/app/api/tarot/session/route.ts
@@ -7,6 +7,7 @@ import { getCharacterById } from "@/data/characters"
 import { Topic } from "@/types/session"
 import { TAROT_TOPICS } from "@/data/topics"
 import { TarotSessionSchema } from "@/lib/validation/api-schemas"
+import { getRequestLocale } from "@/i18n/server-locale"
 
 const tarotService = new TarotService()
 const spreadResolver = new SpreadResolver()
@@ -30,6 +31,7 @@ export async function POST(request: NextRequest) {
       : sessionData.spreadType
 
     const db = getDb()
+    const locale = await getRequestLocale()
     const session = await db.insert("sessions", {
       user_id: user?.id ?? null,
       service_type: sessionData.serviceType,
@@ -37,6 +39,7 @@ export async function POST(request: NextRequest) {
       spread_type: resolvedSpreadType,
       status: sessionData.status,
       character_id: validCharId,
+      locale,
     })
     return NextResponse.json({ session })
   } catch (e) {

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -89,7 +89,7 @@ export function Header() {
         </Link>
 
         {/* 데스크탑 네비게이션 */}
-        <nav className="hidden md:flex items-center gap-6">
+        <nav data-testid="desktop-nav" className="hidden md:flex items-center gap-6">
           <Link
             href="/tarot"
             className="text-arcana-muted hover:text-arcana-text transition-colors font-sans text-sm"

--- a/src/i18n/__tests__/server-locale.test.ts
+++ b/src/i18n/__tests__/server-locale.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const headersMock = vi.fn();
+const cookiesMock = vi.fn();
+
+vi.mock("next/headers", () => ({
+  headers: () => headersMock(),
+  cookies: () => cookiesMock(),
+}));
+
+beforeEach(() => {
+  vi.resetModules();
+  headersMock.mockReset();
+  cookiesMock.mockReset();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+function buildHeaders(xLocale?: string | null) {
+  return Promise.resolve({
+    get: (name: string) => (name === "x-locale" ? (xLocale ?? null) : null),
+  });
+}
+
+function buildCookies(localeValue?: string) {
+  return Promise.resolve({
+    get: (name: string) =>
+      name === "ai_locale" && localeValue !== undefined ? { value: localeValue } : undefined,
+  });
+}
+
+describe("getRequestLocale", () => {
+  it("x-locale 헤더 우선 (en)", async () => {
+    headersMock.mockReturnValue(buildHeaders("en"));
+    cookiesMock.mockReturnValue(buildCookies("ja"));
+    const { getRequestLocale } = await import("../server-locale");
+    expect(await getRequestLocale()).toBe("en");
+  });
+
+  it("x-locale 헤더 우선 (ja)", async () => {
+    headersMock.mockReturnValue(buildHeaders("ja"));
+    cookiesMock.mockReturnValue(buildCookies(undefined));
+    const { getRequestLocale } = await import("../server-locale");
+    expect(await getRequestLocale()).toBe("ja");
+  });
+
+  it("헤더 미존재 시 쿠키 사용", async () => {
+    headersMock.mockReturnValue(buildHeaders(null));
+    cookiesMock.mockReturnValue(buildCookies("en"));
+    const { getRequestLocale } = await import("../server-locale");
+    expect(await getRequestLocale()).toBe("en");
+  });
+
+  it("헤더가 알 수 없는 값이면 쿠키로 fallback", async () => {
+    headersMock.mockReturnValue(buildHeaders("fr"));
+    cookiesMock.mockReturnValue(buildCookies("ja"));
+    const { getRequestLocale } = await import("../server-locale");
+    expect(await getRequestLocale()).toBe("ja");
+  });
+
+  it("헤더·쿠키 모두 없으면 DEFAULT(ko)", async () => {
+    headersMock.mockReturnValue(buildHeaders(null));
+    cookiesMock.mockReturnValue(buildCookies(undefined));
+    const { getRequestLocale } = await import("../server-locale");
+    expect(await getRequestLocale()).toBe("ko");
+  });
+
+  it("쿠키 값이 알 수 없으면 DEFAULT(ko)", async () => {
+    headersMock.mockReturnValue(buildHeaders(null));
+    cookiesMock.mockReturnValue(buildCookies("zh"));
+    const { getRequestLocale } = await import("../server-locale");
+    expect(await getRequestLocale()).toBe("ko");
+  });
+});

--- a/src/i18n/server-locale.ts
+++ b/src/i18n/server-locale.ts
@@ -1,0 +1,20 @@
+import { cookies, headers } from "next/headers";
+import { DEFAULT_LOCALE, LOCALE_COOKIE, isLocale, type Locale } from "./config";
+
+/**
+ * 서버 사이드 (route handler · Server Component) locale 결정.
+ * 우선순위: middleware가 부착한 `x-locale` 헤더 → 쿠키 → DEFAULT.
+ * middleware가 모든 요청에 헤더를 넣으므로 사실상 헤더로 결정되지만,
+ * 일부 정적 라우트(/api/*) 캐시·테스트 환경에서 헤더 누락 시 쿠키 fallback.
+ */
+export async function getRequestLocale(): Promise<Locale> {
+  const headerStore = await headers();
+  const fromHeader = headerStore.get("x-locale");
+  if (isLocale(fromHeader)) return fromHeader;
+
+  const cookieStore = await cookies();
+  const fromCookie = cookieStore.get(LOCALE_COOKIE)?.value;
+  if (isLocale(fromCookie)) return fromCookie;
+
+  return DEFAULT_LOCALE;
+}

--- a/src/lib/db/reading-saver.ts
+++ b/src/lib/db/reading-saver.ts
@@ -23,12 +23,14 @@ async function withRetry<T>(fn: () => Promise<T>, attempts = 3): Promise<T> {
   throw lastErr;
 }
 
-/** 타로 리딩 결과 + 세션 완료 + 카드 목록 저장 (3회 retry) */
+/** 타로 리딩 결과 + 세션 완료 + 카드 목록 저장 (3회 retry).
+ *  locale 인자는 readings 테이블에 작성 시점 locale을 기록 (sessions.locale과 별도 — 결과 텍스트 언어 추적용). */
 export async function saveTarotReading(
   db: DbClient,
   sessionId: string,
   reading: { cardInterpretations?: unknown; overallReading: string; advice: string },
-  cards: { cardId: string; position: number; isReversed: boolean }[]
+  cards: { cardId: string; position: number; isReversed: boolean }[],
+  locale: string = "ko"
 ): Promise<void> {
   await withRetry(() =>
     Promise.all([
@@ -37,6 +39,7 @@ export async function saveTarotReading(
         card_interpretation: reading.cardInterpretations,
         overall_reading: reading.overallReading,
         advice: reading.advice,
+        locale,
       }),
       db.update("sessions", { id: sessionId }, {
         status: "completed",
@@ -54,15 +57,16 @@ export async function saveTarotReading(
   );
 }
 
-/** 사주 리딩 결과 + 세션 완료 저장 (3회 retry) */
+/** 사주 리딩 결과 + 세션 완료 저장 (3회 retry). locale은 saju_readings 테이블 컬럼. */
 export async function saveSajuReading(
   db: DbClient,
   sessionId: string,
-  sajuReadingData: Record<string, unknown>
+  sajuReadingData: Record<string, unknown>,
+  locale: string = "ko"
 ): Promise<void> {
   await withRetry(() =>
     Promise.all([
-      db.insert("saju_readings", sajuReadingData),
+      db.insert("saju_readings", { ...sajuReadingData, locale }),
       db.update("sessions", { id: sessionId }, {
         status: "completed",
         completed_at: new Date().toISOString(),
@@ -71,11 +75,12 @@ export async function saveSajuReading(
   );
 }
 
-/** 신점 최종 리딩 결과 + 세션 완료 저장 (3회 retry) */
+/** 신점 최종 리딩 결과 + 세션 완료 저장 (3회 retry). locale은 shinjeom_readings 테이블 컬럼. */
 export async function saveShinjeomFinalReading(
   db: DbClient,
   sessionId: string,
-  result: { overallReading: string; topicReading?: string; advice: string }
+  result: { overallReading: string; topicReading?: string; advice: string },
+  locale: string = "ko"
 ): Promise<void> {
   await withRetry(() =>
     Promise.all([
@@ -84,6 +89,7 @@ export async function saveShinjeomFinalReading(
         overall_reading: result.overallReading,
         topic_reading: result.topicReading || "",
         advice: result.advice,
+        locale,
       }),
       db.update("sessions", { id: sessionId }, {
         status: "completed",

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -12,3 +12,10 @@ process.env.NEXT_PUBLIC_SITE_URL = "http://localhost:3000";
 
 // fetch 전역 모킹 (AI Provider, 외부 HTTP 호출)
 global.fetch = vi.fn();
+
+// next/headers 전역 mock — server-only API 사용 코드(API 라우트·server-locale)의 단위 테스트 지원.
+// 개별 테스트에서 vi.doMock("next/headers", ...) 으로 override 가능 (server-locale.test.ts 참고).
+vi.mock("next/headers", () => ({
+  headers: vi.fn().mockResolvedValue({ get: () => null }),
+  cookies: vi.fn().mockResolvedValue({ get: () => undefined }),
+}));


### PR DESCRIPTION
## Summary

10 멀티 에이전트 교차 감사로 식별한 i18n 정합성 결함 7건(P0)을 수정. PR #223·#225 머지 후 발견된 코드 영역 결함만 처리. 문서 정합성은 후속 PR-B에서 다룬다.

## 수정 내용

### locale wiring (R1B 감사 — P0 데이터 정합성)
- **신규** `src/i18n/server-locale.ts` — `getRequestLocale()`: Next.js `headers()` → 쿠키 → DEFAULT 우선순위
- **3개 session 라우트** sessions INSERT에 locale 동봉:
  - `src/app/api/{tarot,saju,shinjeom}/session/route.ts`
- **3개 reading-saver 함수** 시그니처에 locale 추가 + readings/saju_readings/shinjeom_readings INSERT 동봉
  - 호출부 3개 reading/message route 갱신
- **영향**: 영어/일본어 사용자가 신규 세션·리딩 만들면 모두 `locale='ko'`로 고정되던 문제 해결

### Sonar↔vitest 표류 정리 (R1D)
- `sonar-project.properties`:
  - `validation/**` 전체 제외 → `api-schemas.ts`가 측정에 포함됨 (vitest include와 정합)
  - `db/index.ts` 명시 제외 제거
  - `supabase/**` 전체 → 4개 명시 (`admin.ts`는 측정)
  - `server-locale.ts`·`reading-saver.ts` 명시 제외 추가

### E2E 셀렉터 안정화 (R1D)
- `Header.tsx` desktop nav: `data-testid="desktop-nav"` 추가
- `e2e/responsive.spec.ts`: 한글 regex 셀렉터 → testid 전환
  - L12: `/타로 상담/` → `[data-testid="desktop-nav"]`
  - L30: `/홈|타로|사주|신점|MY/` → `[data-testid^="mobile-nav-"]`
- **영향**: PR-2 i18n 텍스트 변경(타로 상담→타로, MY→마이페이지)에 안정적

## daily_cards 결정 (사용자 결정 — 옵션 B)
- locale 컬럼 미추가. `character_id+date` UNIQUE 단일 사전 정책 유지
- 표시 시점 locale 분리는 PR-3·5에서 활용 가능

## 테스트 (757/757 통과)
- **신규** `src/i18n/__tests__/server-locale.test.ts` (6 tests): 헤더·쿠키·DEFAULT 우선순위
- **신규** `src/__tests__/api/locale-wiring.test.ts` (7 tests): session/reading INSERT locale 동봉 검증
- 기존 fire-and-forget 테스트 3건 갱신 (locale 인자 검증 추가)
- `vitest.setup.ts`: `next/headers` 전역 mock (개별 override 가능)

## DB 검증 (016 마이그레이션 운영 적용 후)
- `profiles` 2/2, `sessions` 106/106, `readings` 75/75 모두 `locale='ko'` DEFAULT backfill 정상
- `saju_readings`·`shinjeom_readings`는 현재 0행

## Test plan

- [x] `pnpm type-check` — 0 errors
- [x] `pnpm lint` — 0 warnings
- [x] `pnpm test` — 757/757 (이전 744 + 신규 13)
- [x] `pnpm build` — 통과
- [x] Supabase SELECT 5개 테이블 검증
- [ ] CI E2E 회귀 0
- [ ] SonarCloud Quality Gate Pass (Sonar 표류 정리 검증)

## 후속

- **PR-B**: CLAUDE.md·docs/architecture·conventions·known-issues 갱신 (R2A·R2B·R2C·R2D 감사 결과 17건)
- **PR-3**: 외부 번역 발주 + 도메인 데이터 영문화 (마스터 플랜)

https://claude.ai/code/session_011iPkqTGyMoZQkC2ntMFmf3

---
_Generated by [Claude Code](https://claude.ai/code/session_011iPkqTGyMoZQkC2ntMFmf3)_