### PR TITLE
docs(i18n): PR-B 정합성 핫픽스 — CLAUDE.md·architecture·conventions·operations 갱신

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,32 +31,36 @@
 | **인증·DB** | Supabase Auth / NextAuth.js v5 (DB_PROVIDER별 전환) |
 | **DB ORM** | Supabase PostgreSQL / Drizzle ORM (DB_PROVIDER별 전환) |
 | **상태·패키지** | Zustand v5.0, pnpm 10.33.0 |
-| **테스트** | Vitest 2.0 (714개, statements 98%), Playwright (3 디바이스) |
+| **다국어·i18n** | 자체 translations 모듈 + middleware locale 쿠키 (ko/en/ja) — → [`docs/architecture/i18n.md`](docs/architecture/i18n.md) |
+| **테스트** | Vitest 2.0 (757개, statements 98%), Playwright (3 디바이스) |
 | **CI/CD·호스팅** | GitHub Actions → Railway |
 
 ## 프로젝트 구조
 
 ```
 src/
-├── app/             # Pages & API (tarot·saju·shinjeom·mypage·auth·character·settings)
+├── app/             # Pages & API (tarot·saju·shinjeom·mypage·auth·character·settings·api/locale)
 ├── components/      # card/, character/, chat/, common/, effects/, home/, layout/, saju/, skin/, tarot/
+│   ├── common/      # Toast (locale 변경 알림), LocaleConfirmModal (첫방문 자동 감지)
 │   ├── effects/     # MysticBackground (별자리·안개·룬 오버레이 z-[5]), ServiceBackground (배경 파티클 -z-10), ParticleOverlay, ScrollReveal
+│   ├── layout/      # Header·Footer·MobileNav·LanguageSwitcher (데스크탑·모바일 분리 testid)
 │   ├── character/   # CharacterDisplay (GlowBurstRing 내장), SpriteAnimator (drop-shadow 키프레임), CharacterAuraLayer (오라 링)
 │   └── tarot/       # ShuffleCeremony (카드 선택 진입 시 2.2s Canvas rAF 의식 애니메이션)
+├── i18n/            # config·detect·LocaleProvider·useT·server-locale + translations/{ko,en,ja,shared}
 ├── data/            # cards/, characters/, skins/, spreads/, saju/, home/, topics.ts, birth-hours.ts, error-messages.ts, ui-copy.ts
-├── hooks/           # Zustand stores: useSession, useSajuSession, useShinjeomSession, useSkinStore, useGenderStore, useFavoriteCharacter, useReducedMotionStore + useSSEStream, useTheme, useCharacter, useCardAnimation
+├── hooks/           # Zustand stores: useSession, useSajuSession, useShinjeomSession, useSkinStore, useGenderStore, useFavoriteCharacter, useReducedMotionStore, useLocaleStore + useSSEStream, useTheme, useCharacter, useCardAnimation
 ├── lib/
 │   ├── env.ts       # 환경변수 getter 16개 (하드코딩 금지)
 │   ├── request-utils.ts  # getClientIp / pickFields / jsonError / SSE_HEADERS
 │   ├── rate-limit.ts
-│   ├── db/          # getDb() — SupabaseAdapter / PostgresAdapter (DB_PROVIDER 분기)
+│   ├── db/          # getDb() — SupabaseAdapter / PostgresAdapter (DB_PROVIDER 분기), reading-saver.ts (locale 동봉)
 │   ├── auth/        # getCurrentUser() / requireUser() / assertSessionOwnership()
-│   ├── validation/  # api-schemas.ts (Zod 7종)
+│   ├── validation/  # api-schemas.ts (Zod 7종 + LocaleSchema)
 │   └── storage/     # getCardImageUrl() — provider별 이미지 URL
 ├── services/        # core/ (FallbackProvider·PromptBuilder·CircuitBreaker·http-utils), tarot/, saju/, shinjeom/
 ├── types/           # card.ts, character.ts, session.ts, service.ts, user-info.ts
 ├── test-helpers/    # mock-db, mock-auth, mock-request, mock-ai, reset-modules, api-route-setup
-└── __tests__/api/   # API 라우트 단위 테스트 (vitest.config.ts exclude 우회)
+└── __tests__/api/   # API 라우트 단위 테스트 (vitest.config.ts exclude 우회) + locale-wiring
 
 docs/                # → docs/README.md 인덱스
 ├── architecture/    # system-overview, ai-infrastructure, db-abstraction, auth-abstraction, data-model
@@ -65,7 +69,7 @@ docs/                # → docs/README.md 인덱스
 ├── operations/      # known-issues, env-variables, deployment, monitoring, operation-guide
 └── archive/         # process-diagrams, skills-original, ai-quality-roadmap
 
-supabase/migrations/ # 001 + 003~015 SQL (002 결번, 14개 파일, PostgreSQL 모드: src/lib/db/schema/index.ts)
+supabase/migrations/ # 001 + 003~016 SQL (002 결번, 15개 파일, PostgreSQL 모드: src/lib/db/schema/index.ts)
 e2e/                 # 21개 spec (smart-ci.spec.ts 포함), 3 디바이스 — → docs/workflow/e2e-testing.md
 scripts/
 ├── e2e-full/        # 멀티 에이전트 E2E 전수 검증 (252 조합)
@@ -95,6 +99,8 @@ scripts/
 | `lix` | 릭스 | 남 | ~는데/~ㄹ까, 장난 | 트릭스터 |
 | `ethan` | 에단 | 남 | ~거든요, 친절·상세 | 학구적 |
 
+> **다국어 페르소나**: 영어·일본어 페르소나는 PR-4에서 외부 번역가 의뢰로 추가 예정 (캐릭터별 화법 시그니처 보존: arcana=elegant mystic, hoshi=casual GenZ, ren=archaic 등).
+
 **표정 규칙 (6-mood)**: `default` → 세션 진입/대기 | `mystical` → 카드 선택/리딩 대기 | `smile` → 결과 도착 | `serious` / `surprised` / `wink` → 대기 대사 mood 연동. 에러 시 `default` 복귀. 대기 대사 중 표정은 `line.mood` 따름.
 
 **이미지 경로**: 12캐릭터 모두 `nukki/[mood].png` (1408×768)
@@ -116,6 +122,8 @@ scripts/
 **ShuffleCeremony**: 타로 카드 선택 진입 시 2.2초 Canvas rAF 의식 애니메이션. `phase === "card-shuffle"` 조건부 렌더 → `onComplete` 시 `setPhase("card-select")`. 4단계: ① 덱 컷(0–500ms) ② 글로우 폭발(500–700ms) ③ 타이프라이터(700–1400ms, 58ms/자) ④ 부채꼴 펼침(1400–2200ms, spring). 클릭·키보드(Enter/Space) 스킵, `prefers-reduced-motion` 즉시 스킵. `shuffleCeremonyText` 12캐릭터 텍스트 → `waiting-lines.ts`. N=9 고정(시각 효과, 실제 스프레드 크기 무관).
 
 **캐릭터 경험 시스템**: `CharacterId` 타입 (`src/types/character.ts` — `CHARACTER_IDS as const` 기반 union). `CHAR_ENTRANCE: Record<CharacterId, EntranceConfig>` (SpriteAnimator 모듈 내 상수). 에러 대사: `characterErrorLines` / `defaultErrorLines` (`waiting-lines.ts`). 결과 mood: `CHARACTER_RESULT_MOODS` (same file). 6-mood 전체 활성화: 카드 선택→`surprised`, 대기줄→`line.mood`, 결과→캐릭터별. 자유 질문: `freeQuestion` (Zustand `useSession`) → Zod 검증 → `buildFreeQuestionPrompt()`. 캐릭터 메모리: `getRecentCharacterMemory()` (`src/lib/db/character-context.ts`) → `buildCharacterMemoryPrompt()` → system prompt 주입 (인증 사용자 전용, 실패 시 빈 문자열 반환).
+
+**i18n 다국어 시스템**: 한국어(ko)·영어(en)·일본어(ja) 3개 locale. middleware가 쿠키→Accept-Language→DEFAULT 우선순위로 locale 결정 후 `x-locale` 헤더 부착. SSR layout이 `cookies()`로 `<html lang>` 동적 결정 + `LocaleProvider`가 client store(`useLocaleStore`) 동기화 (CLAUDE.md SSR 규칙: useEffect 내 setState `setTimeout` 래핑 필수). 클라이언트 호출 = `useT()` 훅, 서버 호출 = `t(key, locale)` 직접. 사전 모듈 `src/i18n/translations/{ko,en,ja}/index.ts` + 공통 베이스 `shared/keys.ts` (SonarCloud 중복 방지). DB 5개 테이블(profiles·sessions·readings·saju_readings·shinjeom_readings)에 `locale TEXT DEFAULT 'ko' CHECK` 컬럼 (016 마이그레이션) — `idx_sessions_user_locale` 인덱스 (PR-4 character-context 필터). `daily_cards`는 character_id+date 단일 사전(locale 분리 없음). 신규 세션·리딩 INSERT 시 `getRequestLocale()` (`src/i18n/server-locale.ts`)로 locale 동봉. 영어 사전은 1차 임시(외부 번역가 발주 대기), 일본어는 common·locale namespace만 1차 — PR-3·PR-4·PR-5에서 점진 채움. → [`docs/architecture/i18n.md`](docs/architecture/i18n.md)
 
 ## 명령어
 
@@ -222,6 +230,13 @@ pnpm check:doc-links        # docs 링크 검증
 - **npm 미등록 패키지 side-effect import 즉시 차단**: `import "미등록패키지/path"` 형태는 모듈 로딩 시점에 vitest·Next.js 전체 차단. 새 PR에서 발견 시 병합 전 제거.
 - **비슷한 파일 N개 생성 시 공통 베이스 추출 검토**: 동일 의도 파일 2개 이상 → 팩토리/베이스 우선 설계. SonarCloud `new_duplicated_lines_density` 임계치 3%. — **2026-05-01 OG 이미지 중복 SonarCloud 실패 원인**.
 
+### i18n 다국어 (UI 텍스트·번역·locale 작업 시)
+- **LocaleProvider SSR 패턴 필수**: `useEffect` 내 `setLocale()` 동기 호출 금지. `setTimeout(() => setLocale(initial), 0); return () => clearTimeout(t)` 패턴 사용. 미준수 시 hydration error #418 발생. — **`react-hooks/set-state-in-effect` 린트 위반 원인**.
+- **번역 키 정의 우선**: 새 UI 텍스트 추가 → ① `src/i18n/translations/shared/keys.ts`에 타입 추가 → ② `ko/index.ts` (SSOT) 채움 → ③ `en/index.ts` 임시 영문 (외부 번역 대기) → ④ `ja/index.ts`는 PR-5에서 일괄. ko 사전이 SSOT, en/ja는 부분 번역 허용 (Partial<SharedKeys>).
+- **LanguageSwitcher 데스크탑·모바일 별도 ref + 별도 testid 필수**: 동일 ref 공유 시 React last-wins로 outside-click 오탐. 데스크탑 `data-testid="lang-option-${l}"`, 모바일 `data-testid="mobile-lang-option-${l}"`. PR #211 테마 드롭다운 교훈 동일 적용.
+- **API 라우트 INSERT에 locale 동봉 필수**: 신규 `sessions`·`readings` INSERT 시 `getRequestLocale()` (`src/i18n/server-locale.ts`)로 locale 결정 후 동봉. 미동봉 시 DEFAULT 'ko' 자동 입력 → 영어/일본어 사용자 데이터가 'ko'로 고정. — **PR-A 정합성 핫픽스 원인**.
+- **E2E 셀렉터는 data-testid 우선**: 한글 텍스트 `hasText` regex 셀렉터는 i18n 텍스트 변경에 깨짐. nav·LanguageSwitcher·드롭다운은 `data-testid` 부여 필수. — **PR-A E2E `responsive.spec.ts` 수정 원인**.
+
 ## 업무 유형별 가이드
 
 → 상세: [`docs/workflow/task-playbooks.md`](docs/workflow/task-playbooks.md)
@@ -235,6 +250,7 @@ pnpm check:doc-links        # docs 링크 검증
 | 카드 스킨 | `src/data/skins/index.ts`, `src/lib/storage/index.ts` | `skin-manager` |
 | DB 스키마 | `supabase/migrations/`, `src/lib/db/schema/index.ts` | — |
 | AI 프롬프트 | `src/services/core/prompt-builder.ts`, `[service]-service.ts` | — |
+| 다국어·번역 | `src/i18n/translations/shared/keys.ts`, `{ko,en,ja}/index.ts` | — |
 | 코드 품질 검증 | `pnpm type-check && pnpm lint && pnpm build` | `quality-gate` |
 
 ## 미구현 기능·기술 부채

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 <p align="right"><a href="README.en.md">🇺🇸 English</a></p>
 
 > **애니메이션 캐릭터와 대화하며 타로 리딩 · 사주 분석 · 신점 상담을 받는 운세 종합 플랫폼**
+> **3개 locale 지원** (한국어 · English · 日本語) — `ai_locale` 쿠키 기반 자동 전환 (PR-3·4·5에서 점진 채움)
 
 <p align="center">
   <img src="public/images/backgrounds/hero-bg.jpg" alt="ArcanaInsight Hero" width="100%" style="border-radius:12px" />

--- a/docs/architecture/ai-infrastructure.md
+++ b/docs/architecture/ai-infrastructure.md
@@ -131,3 +131,7 @@ for (let i = start; i < text.length; i++) {
 잡기 때문에 여러 JSON 블록이 있거나 값에 `}`가 포함되면 오파싱된다.
 `shinjeom-service.ts`가 이 정규식을 사용하다가 `parseJsonSafe()`로 교체됨.
 
+
+## 다국어 응답 (PR-4 예정)
+
+`prompt-builder.ts`에 `LANGUAGE_INSTRUCTIONS[locale]` 분기 도입 예정 (PR-4). 현재 `parseJsonSafe()`는 일본어 「」·중영일 혼합 응답을 안전하게 파싱한다 (`src/services/core/__tests__/text-cleaner.locale.test.ts` 검증). 캐릭터 메모리는 `locale` 필터를 추가해 cross-locale 오염 방지 (`idx_sessions_user_locale` 인덱스 활용). 상세: [`i18n.md`](i18n.md)

--- a/docs/architecture/auth-abstraction.md
+++ b/docs/architecture/auth-abstraction.md
@@ -92,3 +92,7 @@ GOOGLE_CLIENT_SECRET=
 Google Cloud Console에서 Authorized redirect URI에 `{NEXTAUTH_URL}/api/auth/callback/google` 추가 필요.
 
 API 라우트: `src/app/api/auth/[...nextauth]/` — PostgreSQL 모드 전용
+
+## i18n locale 필드
+
+`AuthUser` 타입은 `{ id, email }`만 포함. locale 필드는 PR-4에서 추가 예정. 현재는 쿠키(`ai_locale`)가 SSOT이고 `profiles.locale`은 보조 동기화 (`/api/locale` POST가 양쪽 갱신). 상세: [`i18n.md`](i18n.md)

--- a/docs/architecture/data-model.md
+++ b/docs/architecture/data-model.md
@@ -120,3 +120,12 @@ ArcanaInsight의 정적 데이터(캐릭터, 카드, 스프레드, 스킨) 모�
 | 출생시간(12시진) | `src/data/birth-hours.ts` |
 | 홈 페이지 정적 데이터 | `src/data/home/` (faq.ts) |
 | 에러 메시지 상수 | `src/data/error-messages.ts` |
+
+## 다국어 데이터 (PR-3·PR-4·PR-5 예정)
+
+- 카드 80장 `name`·`meanings` 객체화 (`{ ko, en, ja? }`) — PR-3에서 외부 번역가 의뢰
+- 12 캐릭터 페르소나 5필드(`greeting`·`personality`·`description`·`speciality`·`speechStyle`)에 영문·일문 추가 — PR-4 외부 번역
+- `waiting-lines.ts` 186줄 영문·일문 — PR-4
+- 일본어 전체 사전 채움 — PR-5
+
+상세: [`i18n.md`](i18n.md)

--- a/docs/architecture/db-abstraction.md
+++ b/docs/architecture/db-abstraction.md
@@ -63,6 +63,9 @@ src/lib/db/
 | `009_shinjeom_topics_expand.sql` | 신점 직장/이직 + 택일 토픽 |
 | `010_share_token_default_fix.sql` | readings share_token NULL 백필 |
 | `011_saju_shinjeom_share_token_defaults.sql` | saju/shinjeom share_token NULL 백필 |
+| `012_spread_type_expand.sql` | sessions.spread_type CHECK 제약 확장 (10개 스프레드, PR #216) |
+| `013_*` ~ `015_fix_sessions_rls.sql` | RLS 보강 (PR #219·#221 — share_token USING(true), 익명 세션 SELECT 허용 등) |
+| `016_locale_columns.sql` | 5개 테이블 locale 컬럼 + idx_sessions_user_locale (PR #223) |
 
 PostgreSQL 모드: `src/lib/db/schema/index.ts` (Drizzle)에 동일 스키마 정의됨
 
@@ -118,3 +121,16 @@ GOOGLE_CLIENT_SECRET=
 ```
 
 > Google Cloud Console: PostgreSQL 모드 사용 시 Authorized redirect URI에 `{NEXTAUTH_URL}/api/auth/callback/google` 추가 필요
+
+## i18n locale 컬럼 (016 마이그레이션)
+
+5개 테이블에 `locale TEXT DEFAULT 'ko' CHECK (locale IN ('ko','en','ja'))` 컬럼:
+- `profiles` — 사용자 선호 locale (인증 사용자 SSOT)
+- `sessions` — 세션 작성 시점 locale (`idx_sessions_user_locale` 인덱스, PR-4 character-context 필터)
+- `readings` / `saju_readings` / `shinjeom_readings` — 결과 텍스트 작성 언어
+
+`daily_cards`는 `(date, character_id)` UNIQUE 단일 사전 정책으로 locale 미포함 (의도). 표시 시점 locale 분리는 PR-3·PR-5에서 처리.
+
+INSERT 시 `getRequestLocale()` (`src/i18n/server-locale.ts`)로 결정한 locale 명시 동봉. 미동봉 시 DEFAULT 'ko' 자동 입력 — PR-A 정합성 핫픽스에서 6개 INSERT 경로에 추가됨.
+
+상세: [`i18n.md`](i18n.md)

--- a/docs/architecture/i18n.md
+++ b/docs/architecture/i18n.md
@@ -1,0 +1,129 @@
+# 다국어(i18n) 인프라
+
+ArcanaInsight는 한국어(`ko`)·영어(`en`)·일본어(`ja`) 3개 locale을 지원한다. 외부 번역가 의뢰 정책으로 SSOT는 한국어이며, 영어·일본어는 부분 번역(`Partial<SharedKeys>`)을 허용해 미번역 키는 자동 ko fallback 한다.
+
+## locale 결정 흐름
+
+```
+Request → middleware (Supabase auth + locale 결정)
+            ↓
+       [x-locale 헤더 부착] + [ai_locale 쿠키 갱신]
+            ↓
+       SSR layout: cookies() → <html lang={locale}>
+            ↓
+       LocaleProvider: setTimeout 패턴으로 client store 동기화
+            ↓
+       useT() 훅 / t(key, locale) 직접 호출
+```
+
+### 우선순위
+1. **쿠키** `ai_locale` (`src/i18n/config.ts` `LOCALE_COOKIE`)
+2. **Accept-Language** 헤더 (q값 정렬)
+3. **DEFAULT** = `'ko'` (`DEFAULT_LOCALE`)
+
+### middleware (`middleware.ts` + `src/lib/supabase/middleware.ts`)
+- DB_PROVIDER=supabase / postgres 양 경로 모두 처리
+- Supabase auth 응답 객체 보존하며 locale 쿠키·헤더만 부착
+- 30일 max-age, `path=/`, `SameSite=Lax`
+- `x-locale` 응답 헤더로 server-side route handler에 locale 전달
+
+## 번역 모듈
+
+```
+src/i18n/
+├── config.ts                 # LOCALES·DEFAULT_LOCALE·LOCALE_COOKIE·isLocale
+├── detect.ts                 # detectLocale(req) — middleware 전용
+├── server-locale.ts          # getRequestLocale() — route handler·Server Component 전용
+├── LocaleProvider.tsx        # SSR locale → client store 동기화
+├── useT.ts                   # 클라이언트 컴포넌트 훅
+└── translations/
+    ├── index.ts              # buildDict + t(key, locale) + fallback chain
+    ├── shared/keys.ts        # SharedKeys 타입 (5 namespace) + flatten 헬퍼
+    ├── ko/index.ts           # SSOT (전체 키)
+    ├── en/index.ts           # 1차 임시 영문 (외부 번역 발주 대기)
+    └── ja/index.ts           # common·locale namespace만 1차 (PR-5 일괄)
+```
+
+### namespace
+- `common` — skip-link, loading, retry, language 등 공유 키
+- `header` — nav, auth, theme 라벨
+- `footer` — tagline, section, link
+- `home` — hero, services, daily-card
+- `settings` — page, section, account
+- `locale` — confirm modal·toast 메시지
+
+### t(key, locale) fallback chain
+1. `dict[locale][key]` 존재 → 반환
+2. `dict['ko'][key]` 존재 → 반환 (en→ko, ja→ko)
+3. 없으면 `key` 자체 반환 (개발 시 누락 키 가시화)
+
+## DB 스키마 (016 마이그레이션)
+
+```sql
+ALTER TABLE public.{profiles, sessions, readings, saju_readings, shinjeom_readings}
+  ADD COLUMN locale TEXT DEFAULT 'ko' CHECK (locale IN ('ko','en','ja'));
+
+CREATE INDEX idx_sessions_user_locale ON public.sessions (user_id, locale);
+```
+
+### 컬럼 의미
+- `profiles.locale`: 사용자 선호 locale (인증 사용자 전용 SSOT, 비인증은 쿠키만)
+- `sessions.locale`: 세션 작성 시점 locale (PR-4 character-context cross-locale 필터)
+- `readings.locale` / `saju_readings.locale` / `shinjeom_readings.locale`: 결과 텍스트 작성 언어 추적
+
+### `daily_cards` 미포함 (의도적)
+- 키: `(date, character_id)` UNIQUE — 단일 사전 정책
+- locale 분리 시 4×용량 폭증 → character_id 종속 해석으로 PR-3·PR-5에서 표시 시점 처리
+
+## 라우트 INSERT 정책 (PR-A 핫픽스 이후)
+
+신규 세션·리딩 INSERT 시 `getRequestLocale()`로 결정한 locale을 명시 동봉한다. 누락 시 DEFAULT 'ko'가 입력되어 영어·일본어 사용자 데이터가 'ko'로 고정되는 결함이 발생한다.
+
+```typescript
+// src/app/api/{tarot,saju,shinjeom}/session/route.ts
+const locale = await getRequestLocale();
+await db.insert("sessions", { ..., locale });
+
+// src/lib/db/reading-saver.ts
+saveTarotReading(db, sessionId, result, cards, locale);
+saveSajuReading(db, sessionId, sajuData, locale);
+saveShinjeomFinalReading(db, sessionId, result, locale);
+```
+
+## 단위 테스트
+
+- `src/i18n/__tests__/i18n.test.ts` — isLocale·t fallback chain
+- `src/i18n/__tests__/detect.test.ts` — middleware locale 결정
+- `src/i18n/__tests__/server-locale.test.ts` — route handler locale 결정 (next/headers mock)
+- `src/i18n/__tests__/translations.test.ts` — namespace × locale 사전 정합성
+- `src/i18n/__tests__/keys.test.ts` — flatten 헬퍼
+- `src/hooks/__tests__/useLocaleStore.test.ts` — Zustand store + 쿠키·document.lang
+- `src/services/core/__tests__/text-cleaner.locale.test.ts` — parseJsonSafe 일본어 「」 안전성
+- `src/__tests__/api/locale-wiring.test.ts` — 6개 INSERT locale 동봉 검증
+- `vitest.setup.ts` — `next/headers` 전역 mock (개별 테스트 override 가능)
+
+## 진행 상황
+
+| 단계 | 영역 | 상태 |
+|---|---|---|
+| PR-1 | 인프라 (middleware·DB·layout·Provider·api/locale) | 머지 완료 (#223) |
+| PR-2 | UI 사전·LanguageSwitcher·LocaleConfirmModal·Toast·Header/Footer/MobileNav | 머지 완료 (#225) |
+| PR-A | locale wiring 핫픽스·sonar 정리·E2E testid | 머지 완료 (#226) |
+| PR-B | CLAUDE.md·docs/architecture·conventions·known-issues 갱신 | 진행 중 |
+| PR-3 | 카드 299·스프레드 87·사주 51 영문 (외부 번역 발주) | 대기 |
+| PR-4 | 12 캐릭터 페르소나 + AI 프롬프트 locale 분기 | 대기 |
+| PR-5 | 일본어 전체 채움 | 대기 |
+| PR-6 | E2E locale 매트릭스 + hreflang SEO + 신점 하이브리드 | 대기 |
+
+## 외부 번역 정책
+
+영어·일본어 사전은 외부 전문 번역가 의뢰 결정. 코드에서는 임시 직역으로 placeholder 채우고, 외부 번역 도착 시 `src/i18n/translations/{en,ja}/index.ts` 교체. 캐릭터 페르소나(PR-4)·도메인 용어(PR-3)는 별도 보이스 가이드·glossary와 함께 발주 (`docs/i18n/glossary.md`·`character-voice-guide.md` PR-3·PR-4 시 작성).
+
+## 참조
+
+- 마스터 플랜: [`docs/superpowers/plans/i18n-master-plan.md`](../superpowers/plans/i18n-master-plan.md) (PR-B.6 이관)
+- 정합성 핫픽스 계획: [`docs/superpowers/plans/i18n-consistency-fix.md`](../superpowers/plans/i18n-consistency-fix.md) (PR-B.6 이관)
+- 코딩 컨벤션: [`docs/conventions/i18n-style.md`](../conventions/i18n-style.md)
+- 데이터 모델: [`docs/architecture/data-model.md`](data-model.md)
+- DB 추상화: [`docs/architecture/db-abstraction.md`](db-abstraction.md)
+- 인증 추상화: [`docs/architecture/auth-abstraction.md`](auth-abstraction.md)

--- a/docs/architecture/system-overview.md
+++ b/docs/architecture/system-overview.md
@@ -116,3 +116,19 @@ ArcanaInsight의 3개 운세 서비스(타로·사주·신점) 사용자 흐름 
 7. **BottomCTA** — 하단 행동 유도
 
 > GenderFilter 컴포넌트는 `components/home/`에 존재하지만 현재 `page.tsx`에서 미사용
+
+## 다국어(i18n) 인프라
+
+3개 locale (`ko`/`en`/`ja`) 지원. middleware → cookie → SSR layout → LocaleProvider → useT 흐름. 상세는 [`i18n.md`](i18n.md).
+
+```
+Request → middleware (locale 결정 + x-locale 헤더 부착)
+            ↓
+       SSR layout: cookies() → <html lang>
+            ↓
+       LocaleProvider (setTimeout 패턴)
+            ↓
+       useT() / t(key, locale) → translations/{ko,en,ja}
+```
+
+ko가 SSOT, en/ja는 부분 번역 허용 (Partial<SharedKeys> + ko fallback).

--- a/docs/conventions/coding-style.md
+++ b/docs/conventions/coding-style.md
@@ -91,3 +91,12 @@ ArcanaInsight 코드 작성 시 반드시 준수해야 하는 스타일 규칙�
 - 홈 페이지 데이터: `src/data/home/` 정적 관리
 - `.env` 파일 절대 커밋 금지 (Railway 환경변수로 관리)
 - DB 마이그레이션: `supabase/migrations/` 번호 순서 유지 (002 결번)
+
+## i18n 다국어
+
+UI 텍스트 추가·변경 시 한글 하드코딩 금지. `t()` 호출로 분리:
+- 클라이언트 컴포넌트: `useT()` 훅 (`src/i18n/useT.ts`)
+- 서버 컴포넌트·라우트: `t(key, locale)` 직접 호출 + `getRequestLocale()`로 locale 결정
+- 키 추가 절차: `shared/keys.ts` 타입 → `ko/index.ts` SSOT → `en/index.ts` 임시 → `ja/index.ts` PR-5
+
+상세 컨벤션: [`i18n-style.md`](i18n-style.md) / 인프라: [`../architecture/i18n.md`](../architecture/i18n.md)

--- a/docs/conventions/i18n-style.md
+++ b/docs/conventions/i18n-style.md
@@ -1,0 +1,97 @@
+# i18n 코딩 컨벤션
+
+ArcanaInsight 다국어 작업 시 준수할 코딩·번역 컨벤션. 인프라 개요는 [`docs/architecture/i18n.md`](../architecture/i18n.md) 참고.
+
+## 호출 패턴
+
+### 클라이언트 컴포넌트 (`"use client"`)
+```tsx
+import { useT } from "@/i18n/useT";
+
+export function MyComponent() {
+  const { t, locale } = useT();
+  return <button>{t("header.nav.tarot")}</button>;
+}
+```
+
+### 서버 컴포넌트 / 비-React 모듈
+```typescript
+import { t as translate } from "@/i18n/translations";
+import { cookies } from "next/headers";
+import { LOCALE_COOKIE, isLocale, DEFAULT_LOCALE, type Locale } from "@/i18n/config";
+
+export default async function Page() {
+  const cookieStore = await cookies();
+  const cookieLocale = cookieStore.get(LOCALE_COOKIE)?.value;
+  const locale: Locale = isLocale(cookieLocale) ? cookieLocale : DEFAULT_LOCALE;
+  return <h1>{translate("home.hero.title", locale)}</h1>;
+}
+```
+
+### 라우트 핸들러 (API)
+```typescript
+import { getRequestLocale } from "@/i18n/server-locale";
+
+export async function POST(req: NextRequest) {
+  const locale = await getRequestLocale();
+  await db.insert("sessions", { ..., locale });
+}
+```
+
+## 키 네이밍
+
+- 형식: `namespace.key` 또는 `namespace.section.key`
+- namespace: 5개 (`common`·`header`·`footer`·`home`·`settings`·`locale`)
+- 케이스: dot-notation, kebab-case 단어 분리 (`skip-link`, `nav.daily-card`)
+- 예: `header.nav.tarot`, `footer.section.services`, `home.hero.title`, `locale.modal.confirm`
+
+## 번역 추가 절차
+
+1. **타입 먼저**: `src/i18n/translations/shared/keys.ts`의 `SharedKeys` 인터페이스에 키 추가
+2. **ko 사전 채움**: `src/i18n/translations/ko/index.ts` (SSOT, 모든 키 필수)
+3. **en 사전 임시 영문**: `src/i18n/translations/en/index.ts` (외부 번역가 의뢰 대기 중에는 1차 직역)
+4. **ja 사전 PR-5 일괄**: 현재는 `common`·`locale` namespace만 1차 채움 (나머지는 ko fallback)
+
+## SSR 규칙 (필수 준수)
+
+- `useEffect` 내 `setLocale()` 동기 호출 금지
+- 패턴: `setTimeout(() => setLocale(initial), 0); return () => clearTimeout(t)`
+- `LocaleConfirmModal`·`LocaleProvider` 참고
+- 미준수 시 `react-hooks/set-state-in-effect` lint 위반 + hydration error #418
+
+## 우선 외부 번역 영역 (직접 영문화 금지)
+
+- 캐릭터 12명 페르소나 5필드 (PR-4): 화법 시그니처 보존 필수
+- 카드 80장 `name`·`meanings` (PR-3): 도메인 표준 영문명
+- 사주 천간·지지·오행·십성·신살 (PR-3): 학술 vs 대중 톤 결정
+- 신점 한국 무속 용어 (PR-6): 한국어+로마자+영문 해설 하이브리드
+
+## E2E 셀렉터
+
+- 한글 `hasText` regex 금지 — i18n 텍스트 변경에 깨짐
+- `data-testid` 부여 우선:
+  - LanguageSwitcher: 데스크탑 `lang-option-${l}`, 모바일 `mobile-lang-option-${l}`
+  - 데스크탑 nav: `desktop-nav` (Header 컨테이너)
+  - 모바일 nav: `mobile-nav-${name}` (각 항목)
+  - LocaleConfirmModal: `locale-confirm-modal`, `locale-confirm-keep`, `locale-confirm-accept`
+  - Toast: `toast`
+
+## SonarCloud 측정 정책
+
+- 정적 사전 ko/en/ja: `sonar.coverage.exclusions` 명시 제외 (로직 0)
+- React 클라이언트 (LocaleProvider·useT): exclusion (E2E 커버 영역)
+- server-locale.ts: exclusion (Next.js headers API 의존, 단위 테스트는 vitest setup mock)
+- vitest `coverage.include`와 `sonar.coverage.exclusions` 항상 동기 (PR-A 표류 정리 교훈)
+
+## 외부 번역 의뢰 자료
+
+- `docs/i18n/glossary.md` (PR-3 작성): 사주 십성·오방색·타로 표준 영문 용어집
+- `docs/i18n/character-voice-guide.md` (PR-4 작성): 12 캐릭터 영문·일문 화법 시그니처
+- `docs/i18n/character-qa-checklist.md` (PR-4 작성): 페르소나 톤 일관성 QA
+
+## 참조
+
+- 인프라 개요: [`docs/architecture/i18n.md`](../architecture/i18n.md)
+- LayoutSwitcher 분리 규칙: [`layout-rules.md`](layout-rules.md)
+- 코딩 스타일 통합: [`coding-style.md`](coding-style.md)
+- E2E 정책: [`../workflow/e2e-testing.md`](../workflow/e2e-testing.md)

--- a/docs/conventions/layout-rules.md
+++ b/docs/conventions/layout-rules.md
@@ -84,3 +84,7 @@ style={{
 - 5:5 비율 미준수 → 데스크탑에서 캐릭터/콘텐츠 불균형
 - CSS mask 수치 변경 → 배경 블렌딩 이질감 (Mobile iOS에서 더 눈에 띔)
 - `overflow-y-auto` 누락 → 모바일에서 콘텐츠 잘림
+
+## 6. LanguageSwitcher 분리 규칙
+
+데스크탑·모바일 LanguageSwitcher는 반드시 별도 `ref` + 별도 `data-testid` 사용. 동일 ref 공유 시 React last-wins로 outside-click 오탐 → 드롭다운이 선택 즉시 닫힘 (PR #211 테마 드롭다운 교훈). 데스크탑 `data-testid="lang-option-${l}"`, 모바일 `data-testid="mobile-lang-option-${l}"`. 상세: [`i18n-style.md`](i18n-style.md)

--- a/docs/operations/deployment.md
+++ b/docs/operations/deployment.md
@@ -122,3 +122,26 @@ railway logs --tail
 ## CI/CD 파이프라인 상세
 
 → [`../workflow/ci-cd.md`](../workflow/ci-cd.md)
+
+## 016 마이그레이션 (locale 컬럼) 적용·롤백
+
+### 적용 (이미 운영 적용 완료, 2026-05-06)
+```sql
+-- supabase/migrations/016_locale_columns.sql
+ALTER TABLE public.profiles ADD COLUMN IF NOT EXISTS locale TEXT DEFAULT 'ko'
+  CHECK (locale IN ('ko','en','ja'));
+-- (sessions·readings·saju_readings·shinjeom_readings 동일)
+CREATE INDEX IF NOT EXISTS idx_sessions_user_locale ON public.sessions (user_id, locale);
+```
+
+### 롤백 (긴급 시)
+```sql
+DROP INDEX IF EXISTS public.idx_sessions_user_locale;
+ALTER TABLE public.profiles DROP COLUMN IF EXISTS locale;
+ALTER TABLE public.sessions DROP COLUMN IF EXISTS locale;
+ALTER TABLE public.readings DROP COLUMN IF EXISTS locale;
+ALTER TABLE public.saju_readings DROP COLUMN IF EXISTS locale;
+ALTER TABLE public.shinjeom_readings DROP COLUMN IF EXISTS locale;
+```
+
+> 주의: 롤백 시 PR-A의 `db.insert("sessions", { ..., locale })` 호출이 unknown column 에러 → 코드도 함께 롤백 필요 (PR #226 revert).

--- a/docs/operations/env-variables.md
+++ b/docs/operations/env-variables.md
@@ -111,3 +111,11 @@ DB_PROVIDER=supabase
 - `src/lib/storage/index.ts` — DB_PROVIDER 기반 이미지 URL 전환
 - [`../architecture/db-abstraction.md`](../architecture/db-abstraction.md) — DB 추상화 상세
 - [`../architecture/auth-abstraction.md`](../architecture/auth-abstraction.md) — Auth 추상화 상세
+
+## i18n locale 컬럼 호환 (postgres 모드)
+
+`DB_PROVIDER=postgres` 모드에서도 016 마이그레이션 동일하게 적용해야 한다. PostgreSQL 자체 환경에서 마이그레이션 도구로 `supabase/migrations/016_locale_columns.sql` 적용 또는 동일 ALTER 문 수동 실행. `idx_sessions_user_locale` 인덱스도 함께 생성 필요. Drizzle `schema/index.ts`에 이미 `locale` 필드 정의되어 있어 ORM 레벨은 자동 처리.
+
+i18n 자체에는 신규 환경변수 없음 — 쿠키(`ai_locale`)와 헤더(`x-locale`)로 처리.
+
+상세: [`../architecture/i18n.md`](../architecture/i18n.md)

--- a/docs/operations/known-issues.md
+++ b/docs/operations/known-issues.md
@@ -49,3 +49,17 @@ Quality Gate: **PASSED** | Bugs: 0 | Vulnerabilities: 0 | CRITICAL: **0건**
 | **Verum 제거** | `refactor/remove-verum-invasive-integration` / PR #163 | ✅ merged | `src/lib/verum/` 삭제, route.ts·env.ts·테스트·문서 전체 정리, CI 빌드·SonarCloud·Codecov 통과 (620→575) |
 
 **배경**: Verum 자동 생성 PR #161 이 침투적 방식으로 코드베이스를 수정해 SonarCloud/Codecov 실패. 사용자 직접 운영 서비스이므로 향후 비침투적(외부 프록시/사이드카) 방식으로 재도입 예정. git tag `verum-removal-base`(`780bb04`) — 롤백 기준점.
+
+---
+
+## i18n 다국어 — 미해결·후속 PR 의존 (2026-05-06 multi-agent 감사)
+
+| 항목 | 영역 | 상태·근거 |
+|------|------|-----------|
+| **AuthUser 타입 locale 필드 미포함** | `src/lib/auth/index.ts` | PR-4 예정. 현재는 쿠키(`ai_locale`)가 SSOT, `profiles.locale`은 보조 동기화. cross-locale 쿼리 필요 시 PR-4에서 `getCurrentUser()` 반환 타입 확장. |
+| **`daily_cards` 테이블 locale 컬럼 의도적 미포함** | `supabase/migrations/003_daily_cards.sql` | 옵션 B 확정 — `(date, character_id)` UNIQUE 단일 사전 정책. locale 분리 시 4×용량 폭증. 표시 시점 locale 분리는 PR-3·PR-5에서 처리. |
+| **PR-2 사전 정의됨, 페이지 미적용 i18n 키 19개** | `src/i18n/translations/ko/index.ts` (`home.*` 8 + `settings.*` 11) | PR-2에서 사전만 정의됨 (정의 자체는 정상). 페이지 코드(`src/app/page.tsx`·`src/app/settings/page.tsx`) `t()` 적용은 PR-3 영역. SharedKeys 타입은 모든 locale 강제하므로 정의됨 미사용 키도 타입 안전 유지. |
+| **translations 사전 SonarCloud 중복도 모니터링** | `src/i18n/translations/{ko,en,ja}/index.ts` | 현재 4 파일(인덱스+공유키+3 locale). PR-3·PR-5에서 카드·캐릭터 데이터가 추가되면 중복도 누적 위험. `shared/keys.ts` 공통 베이스 + `flatten()` 헬퍼로 1차 방어 중. SonarCloud `new_duplicated_lines_density` 3% 임계 모니터링 필요. |
+| **외부 번역가 발주 시점 미결정** | `docs/i18n/glossary.md`·`character-voice-guide.md` | PR-3 진입 시점에 발주 권장 (사용자 결정). 발주 자료는 PR-3·PR-4 시 작성될 예정. 현재 영어 사전은 1차 임시 직역 placeholder. |
+
+상세 인프라: [`../architecture/i18n.md`](../architecture/i18n.md) / 컨벤션: [`../conventions/i18n-style.md`](../conventions/i18n-style.md)

--- a/docs/operations/operation-guide.md
+++ b/docs/operations/operation-guide.md
@@ -233,3 +233,16 @@ flowchart TB
 | **n8n Cloud** | https://xzawed.app.n8n.cloud |
 | **Supabase** | Supabase 대시보드 (프로젝트 설정) |
 | **Railway** | Railway 대시보드 (배포 관리) |
+
+## 9. i18n locale 트러블슈팅
+
+### 사용자가 "언어 변경이 적용 안 된다"고 신고하는 경우
+1. **쿠키 차단 환경 확인** — 브라우저가 third-party 쿠키 차단·시크릿 모드일 때 `ai_locale` 쿠키 저장 실패. LanguageSwitcher가 쿠키 설정 시도하지만 page reload 후 DEFAULT_LOCALE='ko'로 회귀.
+2. **localStorage 차단** — LocaleConfirmModal의 1회 표시 보장이 무효화되어 매 방문 모달 노출 (UX 저하). 사용자에게 쿠키·localStorage 허용 안내.
+3. **DB locale 동기화 확인** — 인증 사용자: `profiles.locale` SELECT로 확인. 쿠키와 불일치하면 `/api/locale` POST가 한 번 실패한 케이스.
+4. **`<html lang>` 검증** — DevTools Elements 탭에서 `<html lang="en">` 등 확인. `ko`로 표시되면 쿠키가 SSR에 도달하지 못한 상태 (middleware 동작 의심).
+
+### locale별 카드·캐릭터 표시가 한국어로 나오는 경우 (PR-3·4·5 진행 중 정상)
+- 카드 데이터 영문화는 PR-3, 캐릭터 페르소나는 PR-4, 일본어 전체 채움은 PR-5에서 진행. 현재는 ko fallback이 의도된 동작.
+
+상세: [`../architecture/i18n.md`](../architecture/i18n.md)

--- a/docs/superpowers/plans/i18n-consistency-fix.md
+++ b/docs/superpowers/plans/i18n-consistency-fix.md
@@ -1,0 +1,238 @@
+# i18n 정합성 핫픽스 계획 (PR-1·PR-2 머지 후 발견)
+
+## Context
+
+8 병렬 에이전트 감사로 PR #223 (Foundation) + PR #225 (translations·UI) 머지 후 **17건의 정합성 결함** 식별. 마스터 플랜 PR-3 진입 전에 코드 정합성·문서 정합성을 분리해 두 PR로 처리한다.
+
+## 8 라운드 발견사항 통합
+
+### R1A (i18n 자체 정합성)
+- ✅ SharedKeys ↔ ko 사전 100% 동기화 (54/54 키)
+- ✅ en 사전 54/54 (100%) — 임시 영어 번역 완료, 외부 번역가 발주 대기
+- ✅ ja 사전 11/54 (20%) — common·locale만 1차, PR-5에서 채움
+- ✅ LOCALE_COOKIE 일관성 — 8개 참조처 모두 일치
+- ✅ middleware 두 경로(supabase + postgres) 쿠키·헤더·max-age 일치
+- ⚠️ LanguageSwitcher · LocaleConfirmModal에 `setLocale + /api/locale POST` 패턴 중복 (경미)
+- ❌ **R1A 결함 보고 오인**: shared/keys.ts는 sonar exclusions에 미포함이라 이미 정상 측정 (lcov.info에 `SF:` 항목 확인). 무시.
+
+### R1B (API/DB locale 연결) — **P0 데이터 정합성 결함**
+- 🔴 sessions INSERT 3개 라우트 locale 미동봉:
+  - `src/app/api/tarot/session/route.ts:33`
+  - `src/app/api/saju/session/route.ts:23`
+  - `src/app/api/shinjeom/session/route.ts:18`
+- 🔴 readings INSERT 3개 함수 locale 미동봉 (`src/lib/db/reading-saver.ts`):
+  - `saveTarotReading` 라인 35-40
+  - `saveSajuReading` 라인 65
+  - `saveShinjeomFinalReading` 라인 82-87
+- 🔴 daily_cards 테이블 locale 컬럼 자체 부재 (016 의도적 누락 vs 결함 여부 결정 필요)
+- 🟡 character-context.ts locale 필터 미사용 (인덱스만 있음 — PR-4 예정 영역)
+- 🟡 서비스 계층(prompt-builder·saju-service 등) locale 인수 미수신 (PR-4)
+- 🟢 AuthUser 타입 locale 부재 — 설계상 허용 (cookie SSOT, profiles 보조)
+- 🟡 Zod 7 스키마 locale 필드 부재 — PR-4 일괄
+
+**영향**: 영어/일본어 사용자가 신규 세션 만들어도 모두 locale='ko'로 기록. 향후 character-context cross-locale 오염 위험.
+
+### R1C (UI 한글 잔존)
+- 페이지 한글 401줄 / 컴포넌트 219줄 / 데이터 214줄 = 총 **834줄**
+- TOP 3 적용 부담: tarot/session 76줄, privacy 62줄, mypage 54줄
+- 미사용 i18n 키 19개 (home.* 8 + settings.* 11) — PR-2가 사전만 만들고 페이지 코드는 미적용
+- PR-3 예상 범위: 약 315줄
+- **분류**: 의도적 후속 PR (PR-3·5·6에서 처리 예정), 핫픽스 대상 아님
+
+### R1D (테스트·CI·Sonar 정합) — **P0 측정 신뢰도 결함**
+- 🔴 sonar-project.properties ↔ vitest.config.ts 표류:
+  - `src/lib/validation/api-schemas.ts`: vitest include / sonar `validation/**` 전체 exclude → SonarCloud 분모 제외, vitest 측정. **불일치**
+  - `src/lib/db/index.ts`: vitest include / sonar exclude
+- 🔴 `e2e/responsive.spec.ts:12` `/타로 상담/` regex 깨짐 (Header에서 `타로 상담` → `타로` 변경)
+- 🔴 `e2e/responsive.spec.ts:30` `/홈|타로|사주|신점|MY/` regex에서 `MY` 미매칭 (`마이페이지`로 변경)
+- 🟡 i18n:check 스크립트 부재 (PR-6 예정, 현재 미가동)
+- 🟢 vitest coverage.include 22→27 모두 파일 존재
+- 🟢 i18n 단위 테스트 30개 모두 vitest 수집
+
+### R2A (CLAUDE.md drift) — 점수 **72/100**
+- L34 테스트 수: 714 → 744
+- L68 마이그레이션: "001 + 003~015 (14개)" → "001 + 003~016 (15개)"
+- 프로젝트 구조 L39-77: `src/i18n/` 디렉토리·`useLocaleStore`·`api/locale`·`Toast`·`LocaleConfirmModal`·`LanguageSwitcher` 누락
+- 기술 스택 표: i18n 항목 추가 필요
+- 핵심 아키텍처 섹션: i18n 다국어 시스템 단락 신규 필요
+- 필수 주의사항: i18n SSR 규칙(`setTimeout` 패턴) + 키 정의 우선 + E2E `data-testid` 필수
+- 업무 유형별 가이드: "다국어·번역" 행 추가
+- 캐릭터 시스템 표: 영문 페르소나 PR-4 예정 주석
+
+### R2B (docs/architecture) — 등급 **C**
+- system-overview.md: i18n 흐름·다이어그램 부재 → 즉시 추가
+- ai-infrastructure.md: parseJsonSafe 일본어 안전성 단위 테스트 명시 부재
+- db-abstraction.md: 016 마이그레이션·5테이블·인덱스 명시 부재 → 즉시 추가
+- auth-abstraction.md: AuthUser locale 미포함 PR-4 명시 → PR-4 후
+- data-model.md: 카드 name 객체화(PR-3) + 캐릭터 페르소나(PR-4) 예정 명시
+- 신규 작성: `docs/architecture/i18n.md` (필수)
+
+### R2C (docs/conventions·workflow)
+- coding-style.md: t() 호출 패턴·useT 가이드 부재
+- layout-rules.md: LanguageSwitcher 데스크탑·모바일 분리 규칙 부재
+- e2e-testing.md: data-testid 우선 정책 부재
+- code-change-process.md: i18n 체크리스트 부재
+- ci-cd.md: sonar↔vitest 정합 검증 단계 부재
+- unit-testing.md: i18n 테스트 패턴(stubGlobal·NextRequest mock) 부재 — PR-6 후
+- task-playbooks.md: i18n 작업 진입 파일 부재
+- scripts.md: i18n:check 등록 — PR-6 후
+- 신설 강권: `docs/conventions/i18n-style.md` (즉시)
+
+### R2D (docs/operations·plan)
+- known-issues.md 추가 5건:
+  1. AuthUser 타입 locale 미포함 (PR-4 대기)
+  2. daily_cards 테이블 locale 컬럼 미지 (016 누락 vs 의도)
+  3. PR-2 사전 정의 vs 페이지 적용 갭 (19 미사용 키)
+  4. translations 15 파일 SonarCloud 중복 위험 (현재 4 파일이지만 PR-3·5에서 누적)
+  5. 외부 번역가 발주 시점 미결정
+- env-variables.md: postgres 모드 + i18n 컬럼 호환 메모
+- deployment.md: 016 마이그레이션 적용 절차·롤백
+- monitoring.md: locale별 토큰 비용 모니터링 (PR-6 후)
+- operation-guide.md: 쿠키 차단 환경 트러블슈팅
+- 마스터 플랜 갱신: PR-1·PR-2 실제 작업량 vs 추정 차이 / PR-4 시간 분리 (코드 vs 외부 번역 검수)
+- 활성 마스터 플랜 archive 이관: PR-6 머지 후
+
+## 정합성 수정 계획 (2 PR 분할)
+
+### PR-A: 코드 정합성 핫픽스 (i18n wiring + 테스트·Sonar 표류 정리)
+
+**위험도**: P0 / **시간**: 4~5h / **의존성**: 없음 (PR #225 머지 위에)
+
+#### 작업 1: locale wiring (R1B 즉시 수정 영역)
+- `src/app/api/tarot/session/route.ts:33` — `db.insert("sessions", { ..., locale })` 추가
+- `src/app/api/saju/session/route.ts:23` — 동일
+- `src/app/api/shinjeom/session/route.ts:18` — 동일
+- `src/lib/db/reading-saver.ts` 3개 함수 — readings INSERT에 locale 동봉
+- locale 결정 패턴: 우선순위 = 요청 헤더 `x-locale` (middleware 부착) → 쿠키 → DEFAULT('ko')
+- 헬퍼 추가: `src/i18n/server-locale.ts` — server-side locale 추출 함수 (`getRequestLocale(req)`)
+
+#### 작업 2: daily_cards 마이그레이션 결정
+- **결정 필요**: daily_cards에 locale 컬럼 추가 여부
+  - 옵션 A: 추가 → 사용자별·locale별 카드 표시 가능 (PR-3·PR-5에서 활용)
+  - 옵션 B: 유지 → daily_cards는 캐릭터별·날짜별 단일 사전(공유), locale은 표시 시점 결정
+- 권장: **옵션 B** (daily_cards 키는 character_id+date 유니크, locale 분리 시 4×용량 폭증)
+- 단, 문서에 "daily_cards locale 미포함 = 의도적 결정" 명시
+
+#### 작업 3: Sonar↔vitest 표류 정리
+- `sonar-project.properties` 검토:
+  - `src/lib/validation/**` 통째 exclude → `src/lib/validation/auth/**` 같이 좁히거나 vitest include와 정합
+  - `src/lib/db/index.ts` 동일 검토
+- 또는 vitest include에서 빼고 sonar exclude 유지 (단순화)
+- 권장: **vitest include 유지 + sonar.coverage.exclusions에서 명시 제외 빼기** (실측치를 sonar에 반영)
+
+#### 작업 4: E2E 셀렉터 갱신
+- `e2e/responsive.spec.ts:12` — `/타로 상담/` → `data-testid` 또는 `header.nav.tarot` t() 결과 ko 값 `타로`
+- `e2e/responsive.spec.ts:30` — regex 갱신: `/홈|타로|사주|신점|마이페이지/`
+- 또는 더 안정적인 `data-testid="mobile-nav-*"` 활용
+
+#### 작업 5: 단위 테스트 보강
+- `src/__tests__/api/locale-wiring.test.ts` 신규: 3개 session route + 3개 reading 저장 함수가 locale 파라미터 전달하는지 검증 (mock-db로 INSERT 인수 캡처)
+- `src/i18n/__tests__/server-locale.test.ts` 신규: getRequestLocale 우선순위 검증
+
+#### 검증
+- type-check + lint + test (744 → ~755개 예상)
+- E2E `responsive.spec.ts` 로컬 실행 (3 디바이스)
+- SonarCloud 재분석 후 Quality Gate Pass 확인
+
+### PR-B: 문서 정합성 (CLAUDE.md + architecture + conventions + known-issues + 마스터 플랜)
+
+**위험도**: P1 / **시간**: 5~6h / **의존성**: PR-A 머지 (코드 변경 반영 후 문서 갱신)
+
+#### 작업 1: CLAUDE.md 8개 즉시 갱신 (R2A)
+- L34 테스트 수: 744
+- L68 마이그레이션: 001 + 003~016 (15개)
+- 프로젝트 구조: src/i18n/·common/·layout/·api/locale 추가
+- 기술 스택 표: i18n 항목 행 추가
+- 핵심 아키텍처: i18n 다국어 시스템 단락 신규
+- 필수 주의사항 카테고리: i18n 신규 섹션 (SSR setTimeout·키 정의 우선·data-testid 필수)
+- 업무 유형별 가이드: "다국어·번역" 행
+- 캐릭터 시스템 표 주석: PR-4 영문 페르소나 예정
+
+#### 작업 2: docs/architecture 5개 갱신 + i18n.md 신설
+- `system-overview.md`: "다국어(i18n) 인프라" 섹션 신규 (middleware → cookie → SSR → LocaleProvider → useT 흐름)
+- `ai-infrastructure.md`: parseJsonSafe 일본어·중영일 혼합 안전성 + PR-4 prompt-builder locale 분기 예정
+- `db-abstraction.md`: 016 마이그레이션·5테이블·idx_sessions_user_locale 인덱스 + daily_cards locale 미포함 의도 명시
+- `auth-abstraction.md`: AuthUser locale 필드 PR-4 예정 명시
+- `data-model.md`: 카드 name 객체화(PR-3) + 캐릭터 페르소나(PR-4) 예정 주석
+- **신규**: `docs/architecture/i18n.md` (i18n 전체 인프라 문서, 500~800자, PR-3~6 진행 시 갱신)
+
+#### 작업 3: docs/conventions 갱신 + i18n-style.md 신설
+- `coding-style.md`: t() 호출 패턴 + useT 훅 가이드 + 클라이언트 vs 서버 사이드 호출 (translate vs useT) 차이
+- `layout-rules.md`: LanguageSwitcher 데스크탑·모바일 분리 (PR #211 outside-click 교훈) + Toast 위치 규칙
+- `e2e-testing.md`: data-testid 우선 정책 + locale 매트릭스 PR-6 예정 명시
+- `code-change-process.md`: 다국어 변경 시 추가 검증 단계 (UI 텍스트 변경 → ko/en/ja 동시 검토 + e2e 셀렉터 동시 갱신)
+- `ci-cd.md`: sonar↔vitest 정합 검증 단계
+- **신규**: `docs/conventions/i18n-style.md` (t·useT·키 네이밍·namespace 규칙·번역 우선순위 통합)
+
+#### 작업 4: known-issues 5건 추가 + 운영 가이드
+- `docs/operations/known-issues.md`:
+  1. AuthUser locale 미포함 (PR-4 대기)
+  2. daily_cards locale 의도적 미추가 (단일 사전 정책)
+  3. PR-2 미사용 키 19개 (PR-3 페이지 적용 시 사용)
+  4. translations SonarCloud 중복도 모니터링 (현재 4 파일, PR-3·5에서 누적)
+  5. 외부 번역가 발주 시점 미결정 (현재 임시 영어 사용 중)
+- `docs/operations/operation-guide.md`: 쿠키 차단 환경 locale 변경 미적용 트러블슈팅
+- `docs/operations/deployment.md`: 016 마이그레이션 적용 절차·롤백 SQL
+- `docs/operations/env-variables.md`: postgres 모드 + i18n 컬럼 호환 메모
+
+#### 작업 5: 마스터 플랜 갱신
+- `~/.claude/plans/spicy-riding-token.md`:
+  - PR-1·PR-2 실제 작업량 갱신 (Round 5 추정 vs 실제)
+  - PR-4 시간 분리: 코드 ~15h + 외부 번역 검수 별도 2주
+  - 신규 발견사항 반영: daily_cards 결정·sonar 표류·E2E 셀렉터 위험 등
+  - "추가 의사결정 필요 항목" 결정 상태 업데이트
+- archive 이관 시점: PR-6 머지 후 (현재 활성 유지)
+
+#### 검증
+- `pnpm check:doc-links` 통과
+- `pnpm check:env-docs` 통과
+- 추가 multi-agent 검증 (정합성 등급 C → A 상승 확인)
+
+## 의존성 그래프
+
+```
+PR-A (코드 정합성, 4~5h)
+  └─→ PR-B (문서 정합성, 5~6h, PR-A 변경 반영 필요)
+        └─→ [외부 번역 발주] (병렬 진행 가능)
+              └─→ PR-3 (도메인 영문화, 마스터 플랜)
+```
+
+## 우선순위·시간 요약
+
+| PR | 영역 | 위험 | 시간 | 결함 수 |
+|---|---|---|---|---|
+| **PR-A** | 코드 정합성 | P0 | 4~5h | 7건 (locale wiring 6 + sonar 1 + E2E 1) |
+| **PR-B** | 문서 정합성 | P1 | 5~6h | 17건 (CLAUDE 8 + arch 5 + conv 5 + ops 5 + plan 4) |
+
+**총 9~11h** 추가 작업으로 정합성 등급 C → A.
+
+## 의도적 후속 PR 영역 (현 핫픽스 제외)
+
+- 페이지 한글 잔존 834줄 → PR-3 (315줄) + PR-4·5·6 분할
+- character-context locale 필터 → PR-4
+- 서비스 계층 locale 인수 → PR-4
+- AuthUser 타입 locale → PR-4
+- Zod 스키마 locale → PR-4
+- i18n:check 스크립트·SEO hreflang → PR-6
+- 일본어 전체 사전 → PR-5
+- archive 이관 → PR-6 머지 후
+
+## 검증 게이트 (PR-A·PR-B 공통)
+
+```bash
+pnpm type-check && pnpm lint && pnpm test
+pnpm exec tsx scripts/check-doc-links.ts
+pnpm exec tsx scripts/check-env-docs.ts
+# PR-A 추가
+curl -s -u "$SONARQUBE_TOKEN:" "https://sonarcloud.io/api/qualitygates/project_status?projectKey=xzawed_ArcanaInsight" | grep status
+```
+
+## 추가 의사결정 필요 항목
+
+1. **daily_cards 결정**: locale 컬럼 추가 vs 의도적 미포함 (옵션 B 권장)
+2. **PR 처리 방식**: PR-A·PR-B 분리 vs 단일 PR 누적 — 이전 패턴(누적) 권장
+3. **외부 번역가 발주 시점**: PR-A·PR-B 머지 후 vs PR-3 진입 시 — PR-3 진입과 함께 발주가 자연스러움
+
+---
+
+**예상 완료**: PR-A·PR-B 합쳐 9~11h, 1.5 영업일. PR-3 진입 전 정합성 정리 완료 가능.

--- a/docs/superpowers/plans/i18n-master-plan.md
+++ b/docs/superpowers/plans/i18n-master-plan.md
@@ -1,0 +1,398 @@
+# ArcanaInsight 다국어(i18n) 도입 마스터 플랜
+
+## Context
+
+ArcanaInsight를 한국어/영어/일본어 3개 locale로 확장하기 위한 점진 도입 계획이다. 12 에이전트(Round 1×4 + Round 2×4 + Round 3 위험 + Round 4 PR 설계 + Round 5×2 검토)와 직접 grep 검증으로 범위를 확정했고, 사용자 결정 3건을 반영했다.
+
+핵심 결정:
+- **URL 구조**: flat + 쿠키 + middleware 확장 (subpath 채택 시 영향 57곳 vs flat 5곳, 10배 차이)
+- **라이브러리**: 커스텀 middleware + 자체 translations 모듈 (next-intl 미설치, 학습곡선 회피)
+- **신점**: 1차 비활성 → PR-6에서 (c)+(d) 하이브리드 (Korean Cultural Reading 컬렉션, 한국어 원문+로마자+영문 해설)
+- **번역 소스**: 전면 외부 번역 (전문 번역가 의뢰) — 캐릭터 페르소나·도메인 용어·AI 응답 품질이 외부 번역에 직접 의존
+- **출시 순서**: 영어 먼저(PR-1~4) → 검증 후 일본어 추가(PR-5)
+
+## 확정된 사실 (5 라운드 검증)
+
+| 항목 | 직접 측정 |
+|---|---|
+| 고유 한글 문자열 | **2,022개** (`grep -rh '"[^"]*[가-힯]' src/`) |
+| UI 한글 라인 (코멘트 포함) | 3,287줄 |
+| 카드 데이터 unique 한글 | 299 (major-arcana 66 + minor-arcana 249 + symbols 22) |
+| 스프레드 unique 한글 | 87 |
+| 사주 constants 한글 | 51 |
+| 캐릭터 텍스트 필드 | 12 × 5 (greeting/personality/description/speciality/speechStyle) = 60 |
+| waiting-lines 한글 라인 | 186 (tarot 60 + saju 54 + loading 12 + sajuAnalyzing 12 + cardPreview 12 + characterError 24 + shuffleCeremony 12) |
+| AI 프롬프트 한글 라인 | prompt-builder 88 + saju-service 64 = 152 |
+| 페이지·라우트 | 17 page.tsx + 25 Link href + 14 router.push |
+| E2E 셀렉터 | text 기반 셀렉터 120개 (R1-A의 25개는 5배 과소평가) |
+| 테스트 케이스 | 21 spec 파일 × 평균 ~8 test = 약 165 (3 locale 매트릭스 시 495 실행) |
+
+## 직접 검증으로 발견된 R4 명세 보정사항 (Round 5)
+
+1. **Drizzle 스키마 위치 정정**: `src/lib/db/schema/profiles.ts`·`schema/readings.ts` 별도 파일은 없음 → 모두 `src/lib/db/schema/index.ts`에 통합. PR-1 영향 파일 명세 수정.
+2. **`card.name` 객체화 영향 9개 파일** (CardFace.tsx·prompt-builder.ts·daily-card·tarot session/result 등) + 80개 카드 데이터 수정. PR-3 작업량 +2h.
+3. **Translations 15 파일 SonarCloud 중복 위험**: 공통 베이스(`translations/shared/keys.ts` 또는 factory) 추출 강제 (CLAUDE.md L223 "비슷한 파일 N개" 규칙).
+4. **useThemeStore 패턴 결함**: `setMode` useEffect 내 직접 호출 (CLAUDE.md L199-200 setTimeout 패턴 위배 가능). useLocaleStore에서는 setTimeout(() => setLocale(...), 0) + cleanup return 패턴 강제.
+5. **sessions 테이블 locale 컬럼 누락 발견**: character-context.ts WHERE locale 필터 위해 sessions에도 locale 컬럼 필요. 016 마이그레이션에 sessions 추가.
+6. **E2E 매트릭스 재계산**: 21 spec × 3 locale = 63이 아니라 ~165 test × 3 = 495 실행. CI 시간 영향 30분→60분+.
+7. **시간 추정 21% 보정**: PR-1 6→7~8h, PR-2 8→10~11h, PR-3 12→13~14h, PR-4 16→20h, PR-5 18→21h, PR-6 14→22h. 총 74h → **93~96h** (12 영업일).
+
+## 누락 영역 (Round 5에서 발견 → 각 PR에 반영)
+
+- **카드 이미지 alt 텍스트** (CardFace.tsx에 `alt={card.nameKo}` 하드코딩) → PR-3
+- **에러 페이지** (`app/not-found.tsx`, `app/error.tsx`) → PR-1 (인프라)
+- **AI 응답 일본어 문자 처리** (parseJsonSafe가 「」 같은 일본어 따옴표 안전한지) → PR-5 단위 테스트
+- **사용자 locale 자동 감지 후 1회 confirm 모달** (브라우저 영어 → 자동 영어로 가지 말고 "English? 한국어?" 확인) → PR-2
+- **locale 변경 토스트 알림** ("Language changed to English") → PR-2
+- **NextAuth.js DB_PROVIDER=postgres 모드 영향** (profiles vs auth.users) → PR-1 마이그레이션에서 양 모드 모두 처리
+- **OG 이미지 폰트** (Noto Sans JP embedded 필요) → PR-5
+- **사주 십성 영문 표준 조사** (Five Elements/Wood,Fire vs 학술) → PR-3에서 외부 번역가에 가이드 제공
+
+---
+
+## PR-1: i18n Foundation (인프라·DB·Provider)
+
+**위험도**: P0 (서비스 차단 위험 영역) / **시간**: 7~8h / **의존성**: 없음
+
+### 목표
+라우팅·쿠키·DB 컬럼·Provider·`<html lang>` 동적화. UI 텍스트 0건 변경. 영어 locale 인프라만 활성화.
+
+### 신규 파일
+- `src/i18n/config.ts` — `LOCALES = ['ko','en','ja'] as const`, `DEFAULT_LOCALE = 'ko'`, `LOCALE_COOKIE = 'ai_locale'`, `COOKIE_MAX_AGE = 30*24*60*60`
+- `src/i18n/detect.ts` — `detectLocale(req)`: 쿠키 → Accept-Language → DEFAULT 우선순위
+- `src/i18n/translations/index.ts` — `t(key, locale)` + ko fallback (`en→ko / ja→ko`), 빈 사전 객체 (`ko/en/ja: {}`)
+- `src/i18n/LocaleProvider.tsx` — Client Context, `useLocale()` 훅
+- `src/hooks/useLocaleStore.ts` — Zustand (useThemeStore 패턴 + setTimeout 보정 적용, persist 미사용 — 쿠키가 SSOT)
+- `src/app/api/locale/route.ts` — POST `{locale}` → Set-Cookie + 200 응답
+- `supabase/migrations/016_locale_columns.sql`:
+  ```sql
+  ALTER TABLE profiles ADD COLUMN locale TEXT DEFAULT 'ko'
+    CHECK (locale IN ('ko','en','ja'));
+  ALTER TABLE sessions ADD COLUMN locale TEXT DEFAULT 'ko'
+    CHECK (locale IN ('ko','en','ja'));
+  ALTER TABLE readings ADD COLUMN locale TEXT DEFAULT 'ko'
+    CHECK (locale IN ('ko','en','ja'));
+  ALTER TABLE saju_readings ADD COLUMN locale TEXT DEFAULT 'ko'
+    CHECK (locale IN ('ko','en','ja'));
+  ALTER TABLE shinjeom_readings ADD COLUMN locale TEXT DEFAULT 'ko'
+    CHECK (locale IN ('ko','en','ja'));
+  -- 5개 테이블 RLS 정책 재발급 (015 패턴 참고)
+  ```
+- `src/app/not-found.tsx` 신규 (locale 인식 — 또는 기존 점검 후 i18n)
+- `src/app/error.tsx` 신규 (동일)
+
+### 수정 파일
+- `middleware.ts` (~+25줄) — Supabase auth 호출 후 `detectLocale` → `request.cookies.set(...)` + `response.headers.set('x-locale', locale)`. **Auth 응답 객체 보존** (R-02)
+- `src/app/layout.tsx` (~+10줄) — async server component 전환, `cookies().get('ai_locale')`로 lang 결정, `<html lang={locale}>`, `<LocaleProvider initial={locale}>` 래핑
+- `src/lib/db/schema/index.ts` (~+20줄) — Drizzle 스키마에 locale 컬럼 (sessions/profiles/readings/saju_readings/shinjeom_readings)
+- `src/lib/auth/supabase-auth.ts` (~+5줄) — `getCurrentUser()` 반환에 `locale: 'ko'|'en'|'ja'` 포함
+- `src/lib/validation/api-schemas.ts` — locale 필드 스키마 추가 (`z.enum(['ko','en','ja']).nullish()`)
+
+### 위험 매핑
+- **R-01 hydration**: `<html lang>` 서버에서 cookie 결정, client useState 동일값 보장
+- **R-02 middleware 체인**: Supabase auth 먼저, locale 헤더만 추가
+- **R-03 RLS**: 015 패턴 따라 5개 테이블 정책 재발급
+- **R-15 URL 호환**: 쿼리/path 변경 0
+
+### 검증
+- `pnpm type-check && pnpm lint && pnpm test` (기존 714개 통과)
+- `curl -I http://localhost:3000/ -H 'Accept-Language: en'` → `Set-Cookie: ai_locale=en`
+- DB: `SELECT locale, COUNT(*) FROM profiles GROUP BY locale` → 모두 'ko'
+- E2E `home.spec.ts`·`auth.spec.ts` 0회귀
+- `parseJsonSafe()` 일본어 따옴표 단위 테스트 (선제적)
+
+---
+
+## PR-2: UI 텍스트 영어 1차 + LanguageSwitcher
+
+**위험도**: P1 / **시간**: 10~11h / **의존성**: PR-1
+
+### 목표
+Header/Footer/Home/Settings 핵심 페이지 영어 번역 + translations 모듈 구조 + data-testid 1차 + LanguageSwitcher + locale 변경 토스트.
+
+### 신규 파일
+- `src/i18n/translations/shared/keys.ts` — namespace key 타입 정의 (drift 방지)
+- `src/i18n/translations/{ko,en,ja}/{common,header,footer,home,settings}.ts` 5×3=15 파일 (ja는 빈 객체로 PR-5 placeholder)
+- `src/components/layout/LanguageSwitcher.tsx` — 데스크탑·모바일 별도 ref + 별도 testid (PR #211 교훈)
+- `src/components/common/LocaleConfirmModal.tsx` — 첫 방문 시 자동 감지 locale ↔ 한국어 선택 모달
+- `src/components/common/Toast.tsx` 또는 기존 활용 — locale 변경 알림
+
+### 수정 파일
+- `src/components/layout/Header.tsx`, `Footer.tsx`, `MobileNav.tsx` — `t()` 호출 + LanguageSwitcher 배치
+- `src/app/page.tsx`, `src/app/settings/page.tsx`, `src/data/home/*` — 한글 → key 추출
+- `src/data/ui-copy.ts` — translations 모듈로 이관
+- `src/app/layout.tsx` — skip-link 텍스트 t() 적용
+
+### 변경 내용
+1. namespace 규칙 확정: `header.nav.tarot`, `home.hero.title` 형식
+2. 하드코딩 한글 → `t('namespace.key')` 호출, 한국어 값을 `ko` 사전으로 이관
+3. **외부 번역가 위탁**: 100키 영어 번역 (사용자 결정 — 전면 외부 번역)
+4. data-testid 1차 부여 (E2E text 셀렉터 의존 제거 시작)
+5. LanguageSwitcher: ko/en/ja 드롭다운, 데스크탑 `data-testid="lang-option-${l}"`, 모바일 `data-testid="mobile-lang-option-${l}"`
+6. 첫 방문 LocaleConfirmModal: 쿠키 미존재 + Accept-Language이 ko 아닐 때 표시
+7. setLocale 호출 시 토스트 알림
+
+### 위험 매핑
+- **R-01**: 서버·클라이언트 동일 사전 유효, fallback chain 단위 테스트
+- **R-12 E2E**: data-testid 도입 시작
+- **R-13 drift**: namespace 키 타입 강제
+
+### 검증
+- 쿠키 `ai_locale=en` → Home/Settings 영어 표시
+- 쿠키 `ai_locale=ja` → 한국어 표시 (ja 빈 객체이므로 fallback 동작)
+- `e2e/home.spec.ts`·`settings.spec.ts` testid 마이그레이션, ko/en 통과
+- `e2e/theme.spec.ts` 패턴 따른 `language-switcher.spec.ts` 신규 (드롭다운 모바일/데스크탑 분리 검증)
+- `translations/index.test.ts` 신규 — fallback 동작 검증
+
+---
+
+## PR-3: 도메인 데이터 영어 (카드·스프레드·사주·UI 데이터)
+
+**위험도**: P1 / **시간**: 13~14h / **의존성**: PR-2
+
+### 목표
+카드 299·스프레드 87·사주 constants 51·topics·birth-hours·error-messages 영어 번역 + 카드/스프레드 객체 다국어 구조 전환 + fallback chain 안전화.
+
+### 신규 파일
+- `src/data/cards/locale-helpers.ts` — `getCardName(card, locale)`, `getCardMeaning(card, position, locale)` (항상 ko fallback 보장)
+- `src/data/cards/__tests__/locale-helpers.test.ts`
+- `docs/i18n/glossary.md` — 외부 번역가용 도메인 용어집 (사주 십성·오방색·타로 카드 표준 영문명)
+
+### 수정 파일
+- `src/types/card.ts` — `name: string` → `name: { ko: string; en: string; ja?: string }`, `meanings`도 객체화 (R-04 nameJa 부재 fallback)
+- `src/data/cards/major-arcana.ts` (22장 × 6필드)
+- `src/data/cards/minor-arcana.ts` (56장)
+- `src/data/cards/symbols.ts`
+- `src/data/spreads/index.ts` (스프레드 이름·position description)
+- `src/data/saju/constants.ts`, `categories.ts` — 천간·지지·오행·십성·신살 영문
+- `src/data/topics.ts`, `src/data/birth-hours.ts`, `src/data/error-messages.ts`
+- `src/components/card/CardFace.tsx` (alt 텍스트 locale 인식, `getCardName(card, locale)`)
+- `card.name` 객체화 영향 9개 파일 (CardFace·prompt-builder·daily-card·tarot session/result/[id] 등)
+
+### 변경 내용
+1. 타입 먼저 i18n 객체로 변경 (대량 변경 1회)
+2. 외부 번역가 의뢰: 용어집(glossary) 기반으로 437개 항목 영문화
+3. 카드 컴포넌트에서 `getCardName(card, locale)` 호출로 교체
+4. saju 십성 영문 표준 채택 (일반 통용: Companion/Rival/Output/Hurt/Wealth/Officer/Resource/Seal 등) — 외부 번역가가 학술/대중 톤 선택
+5. spreads position 설명 (Past/Present/Future 등 표준)
+
+### 위험 매핑
+- **R-04 nameJa fallback**: 타입에서 `ja?` 옵셔널, helper에서 ko fallback
+- **R-09 도메인 용어 표준화**: glossary.md 작성
+- **R-06 오번역**: 외부 번역가 검수
+
+### 검증
+- 카드/스프레드 단위 테스트가 ko/en 양쪽 데이터 검증
+- E2E `tarot-flow.spec.ts` en 모드: 카드 결과 영문 표시
+- `getCardName(card, 'ja')` → ko 반환 (모든 80장)
+
+---
+
+## PR-4: 캐릭터 페르소나 + AI 프롬프트 영어
+
+**위험도**: P1 (캐릭터 정체성 보존이 가장 어려운 영역) / **시간**: 20h / **의존성**: PR-3
+
+### 목표
+12 캐릭터 영문 페르소나 재작성(번역 아닌 로컬라이즈) + waiting-lines 186줄 영문 + AI 프롬프트 locale 분기 + 메모리 locale 필터.
+
+### 신규 파일
+- `docs/i18n/character-voice-guide.md` — 외부 번역가용 캐릭터 보이스 가이드 (12 캐릭터 × 영어 화법 시그니처: arcana=elegant mystic, hoshi=casual GenZ, ren=archaic "thee/thou" 등)
+- `docs/i18n/character-qa-checklist.md` — 12×3 페르소나 톤 일관성 QA 체크리스트
+- `src/services/core/__tests__/prompt-builder.locale.test.ts` — locale 분기 단위 테스트
+- `scripts/check-ai-quality.ts` — staging에서 캐릭터별 AI 응답 샘플 수집 (회귀 테스트 도구)
+
+### 수정 파일
+- `src/types/character.ts` — `CharacterConfig`에 `nameI18n`/`personalityI18n`/`speechStyleI18n` 같은 i18n 객체 필드 추가 (또는 캐릭터 객체 자체를 locale별 분리)
+- `src/data/characters/index.ts` (~237줄) — 캐릭터별 5필드(greeting/personality/description/speciality/speechStyle)에 영문 추가
+- `src/data/characters/waiting-lines.ts` (~300줄) — 라인별 `{ko, en}` 객체화, mood 보존
+- `src/services/core/prompt-builder.ts` (~+30줄) — `buildPrompt({locale, character, ...})` 시그니처, `LANGUAGE_INSTRUCTIONS[locale]` 도입 ("Respond strictly in English"), `LOCALES`와 동일 source enum
+- `src/services/saju/saju-service.ts` — OHAENG/TEN_STARS 영문 매핑 적용 (PR-3 산출물 활용)
+- `src/lib/db/character-context.ts` — `loadMemory(userId, characterId, locale)`, `WHERE locale = $1` 필터 (R-08 cross-locale 오염 방지)
+- `src/services/*/route.ts` — readings 저장 시 locale 동봉
+
+### 변경 내용
+1. 외부 번역가 캐릭터 보이스 가이드 작성 (한국어 어미 → 영어 화법 시그니처)
+2. 12 캐릭터 영문 페르소나 외부 번역 + 자체 검수
+3. waiting-lines 186줄 영어 — mood 보존 검증 스크립트
+4. prompt-builder locale 파라미터 9개 호출부 수정
+5. character-context 메모리 조회에 locale 필터, save 시 locale 기록
+6. AI 응답 품질 staging 회귀 테스트 (캐릭터별 샘플 5개 × 3 service)
+
+### 위험 매핑
+- **R-05 캐릭터 정체성**: 외부 번역 + 보이스 가이드
+- **R-07 응답 언어 일치**: LANGUAGE_INSTRUCTIONS 명시
+- **R-08 메모리 cross-locale**: WHERE locale 필터
+
+### 검증
+- prompt-builder 단위 테스트 (locale=en 시 영문 system prompt 포함)
+- 통합 테스트: en 세션에서 메모리는 en만 로드 (DB 쿼리 검증)
+- E2E `character.spec.ts` en 모드
+- staging AI 응답 5×3 캐릭터 검증
+
+---
+
+## PR-5: 일본어 전체 (PR-2~4 자산의 ja 복제)
+
+**위험도**: P1 / **시간**: 21h / **의존성**: PR-2, PR-3, PR-4
+
+### 목표
+PR-2~4의 영어 자산 구조에 일본어 데이터 채우기. 구조 변경 0. **출시 순서: 영어 안정화 후 일본어** (사용자 결정).
+
+### 수정 파일
+- `src/i18n/translations/ja/{common,header,footer,home,settings}.ts` 5 파일 — UI 일본어
+- `src/data/cards/*.ts` — `nameJa`, `meaningsJa` 채우기 (Round 2-B에서 nameJa 부재 확인됨, 보충 필수)
+- `src/data/spreads/index.ts`, `src/data/saju/{constants,categories}.ts`, `src/data/topics.ts`, `src/data/birth-hours.ts`, `src/data/error-messages.ts`
+- `src/data/characters/index.ts` — 12캐릭터 일본어 페르소나 (외부 번역가, 일본어 화법 시그니처: miko=巫女敬語, hoshi=ギャル체, ren=古風候文)
+- `src/data/characters/waiting-lines.ts` — 186줄 일본어
+- `src/services/core/prompt-builder.ts` — `LANGUAGE_INSTRUCTIONS.ja = "日本語で回答してください"`
+- `src/app/layout.tsx` — Noto Sans JP 폰트 추가 (locale=ja 시), OG 이미지 폰트 embedded
+
+### 변경 내용
+1. 카드 nameJa 부재 항목 식별 → 일본어 표기 보충 (R-04)
+2. 캐릭터별 일본어 페르소나 외부 번역 (12명)
+3. waiting-lines 186줄 일본어
+4. AI prompt 일본어 지시
+5. 일본어 폰트 로드 + OG 이미지 embedded
+6. parseJsonSafe 일본어 따옴표(「」) 단위 테스트 강화
+
+### 위험 매핑
+- **R-04 nameJa**: 보충 완료
+- **R-05 캐릭터 정체성**: 일본어 화법 시그니처
+- **R-07 응답 언어**: 일본어 지시
+- **R-09 사주 일본 한자**: 일본어는 기존 한자 사용 가능 (영어보다 직접적)
+
+### 검증
+- 쿠키 `ai_locale=ja` → 모든 페이지 일본어
+- E2E ja 모드 home/settings/tarot/saju/character 통과
+- AI 응답 일본어 staging 확인
+- `getCardName(card, 'ja')` 단위 테스트: 모든 80 카드 ja 필드 존재
+
+---
+
+## PR-6: E2E 마무리 + SEO + 신점 하이브리드
+
+**위험도**: P2 / **시간**: 22h / **의존성**: PR-5
+
+### 목표
+E2E 셀렉터 testid 전환 마무리, hreflang/OG metadata, 신점 (c)+(d) 하이브리드 활성화, 키 drift CI 차단.
+
+### 신규 파일
+- `src/data/shinjeom/cultural-readings.ts` — 한국어 원문 + 영문 해설 + 로마자 병기 (Korean Cultural Reading 컬렉션, c+d 하이브리드)
+- `src/services/shinjeom/shinjeom-i18n.ts` — locale별 한국어+로마자+영문 해설 렌더링
+- `src/components/shinjeom/CulturalReadingDisplay.tsx` — 신점 하이브리드 UI
+- `scripts/check-translation-keys.ts` — ko/en/ja 키 drift 검출 (CI)
+- `e2e/i18n-matrix.spec.ts` — locale matrix 회귀 테스트
+
+### 수정 파일
+- `src/app/layout.tsx` — `generateMetadata` 동적화, `alternates.languages` (hreflang `ko-KR`, `en-US`, `ja-JP`, `x-default`), `openGraph.locale`
+- `src/app/_og/ResultOgBase.tsx` + 7개 OG 라우트 — locale query 수용
+- `e2e/*.spec.ts` (21개) — text 셀렉터 → testid 잔여분 전환
+- `playwright.config.ts` — projects에 locale별 storageState (쿠키 ai_locale 사전 주입)
+- `package.json` scripts — `i18n:check` 추가
+- `.github/workflows/sonar.yml` 또는 `docs-sync.yml` — `pnpm i18n:check` 추가
+- `src/app/shinjeom/page.tsx` 등 — locale=en/ja 시 cultural-readings 진입 활성화
+
+### 변경 내용
+1. `generateMetadata(props)` 도입, hreflang `x-default` + ko/en/ja
+2. 신점 페이지 locale=en/ja에서 재활성화: 한국어 원문 + 로마자 transliteration + 영문 해설 동시 표시
+3. E2E smart-ci.spec.ts에 locale 환경변수 매트릭스 (165 test × 3 locale = 495)
+4. CI: `pnpm i18n:check` script로 키 drift 차단 (R-13)
+5. 토큰 비용 모니터링: prompt-builder 로그에 locale 태그
+6. 사주 십성·오방색 영문/일문 용어집 최종본 docs/ 내 보관
+
+### 위험 매핑
+- **R-06 신점 하이브리드**: c+d 채택
+- **R-10 토큰 모니터링**
+- **R-11 E2E 셀렉터 마무리**
+- **R-13 drift 검증**
+- **R-14 hreflang SEO**
+
+### 검증
+- `curl /` HTML head에 `<link rel="alternate" hreflang="en" href="..." />` 4개 (ko/en/ja/x-default)
+- E2E ko/en/ja 매트릭스 통과 (CI 시간 60분 내)
+- 신점 ko/en/ja 모드 진입 가능, 한자/로마자 병기 단위 테스트
+- DB: `SELECT locale, count(*) FROM shinjeom_readings GROUP BY locale`
+- `pnpm i18n:check` exit 0
+
+---
+
+## 의존성 그래프
+
+```
+PR-1 (Foundation, 7~8h)
+  └─→ PR-2 (UI 영어 + LangSwitcher, 10~11h)
+        └─→ PR-3 (도메인 영어, 13~14h)
+              └─→ PR-4 (캐릭터 + AI 영어, 20h)
+                    └─→ PR-5 (일본어 전체, 21h)
+                          └─→ PR-6 (E2E + SEO + 신점, 22h)
+```
+
+순차 의존 (각 PR이 이전 PR의 자산을 활용). 병렬 진행 불가능 (단, 외부 번역 발주는 PR-2 완료 후 PR-3·4·5 자료를 한꺼번에 의뢰 가능).
+
+## 시간 추정 (Round 5 보정)
+
+| PR | 명세 | 보정 | 비고 |
+|---|---|---|---|
+| PR-1 | 6h | **7~8h** | RLS 5개 테이블 정책 재발급 시간 |
+| PR-2 | 8h | **10~11h** | 외부 번역 의뢰 + LocaleConfirmModal·Toast 추가 |
+| PR-3 | 12h | **13~14h** | card.name 객체화 9개 파일 영향 |
+| PR-4 | 16h | **20h** | 캐릭터 페르소나 외부 번역 검수, AI staging 회귀 |
+| PR-5 | 18h | **21h** | nameJa 보충, 일본어 폰트, parseJsonSafe ja 검증 |
+| PR-6 | 14h | **22h** | E2E 165→495 매트릭스, 신점 하이브리드 UI |
+| **총합** | **74h** | **93~96h** | 단일 개발자 12 영업일 |
+
+**외부 번역 작업 별도**: 캐릭터 페르소나 12명 × 5필드 × 2 locale + 카드 80장 × 6필드 × 2 + waiting-lines 186 × 2 + UI 100키 × 2 + 도메인 용어 ~150 × 2 = **약 2,000 단위 외부 번역**. 발주·검수·반영 일정 별도(2~3주 권장).
+
+## 위험 매트릭스 요약 (Round 3에서 식별, 15개)
+
+- **P0 (서비스 차단)**: R-01 hydration, R-02 middleware Auth 체인, R-03 RLS 누락, R-04 nameJa fallback
+- **P1 (UX 손상)**: R-05 캐릭터 정체성, R-06 도메인 용어, R-07 AI 응답 언어, R-08 메모리 cross-locale
+- **P2 (운영 부담)**: R-09 토큰 비용, R-10 E2E 셀렉터 120개, R-11 키 drift, R-12 URL 호환
+- **P3 (개선)**: R-13 OG locale, R-14 hreflang SEO, R-15 사용자 locale 학습
+
+각 PR이 어느 위험을 해결하는지 위 PR 명세에 매핑 완료.
+
+## 핵심 검증 게이트 (모든 PR 공통)
+
+```bash
+pnpm type-check && pnpm lint && pnpm test
+pnpm exec tsx scripts/check-doc-links.ts
+pnpm exec tsx scripts/check-env-docs.ts
+# PR-6 머지 후 추가
+pnpm i18n:check  # 키 drift 차단
+```
+
+PR-1 머지 직후 추가:
+```bash
+# DB 016 마이그레이션 검증
+curl -s -u "$SONARQUBE_TOKEN:" "https://sonarcloud.io/api/qualitygates/project_status?projectKey=xzawed_ArcanaInsight"
+```
+
+## Critical Files for Implementation
+
+- `/home/user/ArcanaInsight/middleware.ts` (PR-1, locale 분기 + Supabase Auth 체인)
+- `/home/user/ArcanaInsight/src/app/layout.tsx` (PR-1, async server + html lang 동적)
+- `/home/user/ArcanaInsight/src/lib/db/schema/index.ts` (PR-1, locale 컬럼 5개 테이블)
+- `/home/user/ArcanaInsight/supabase/migrations/016_locale_columns.sql` (PR-1, 신규)
+- `/home/user/ArcanaInsight/src/i18n/` (PR-1, 디렉토리 신규)
+- `/home/user/ArcanaInsight/src/types/card.ts` (PR-3, name 객체화)
+- `/home/user/ArcanaInsight/src/data/characters/index.ts` (PR-4, 영어 페르소나)
+- `/home/user/ArcanaInsight/src/services/core/prompt-builder.ts` (PR-4, locale 분기)
+- `/home/user/ArcanaInsight/src/lib/db/character-context.ts` (PR-4, locale 메모리 필터)
+
+## 작업하지 않을 것 (의도적 제외)
+
+- **subpath URL 구조**: 영향 57곳 vs flat 5곳 — flat 채택 후 후일 추가 도입 가능
+- **next-intl/next-i18next 라이브러리**: 학습곡선·React 19 호환 부분적 — 자체 모듈로 충분
+- **신점 영어/일본어 직역**: 도메인 의미 손실 → c+d 하이브리드만 채택
+- **사용자 locale 자동 강제 전환**: 첫 방문 시 모달로 사용자가 명시 선택
+
+## 추가 의사결정 필요 항목
+
+1. **외부 번역가 발주 시점**: PR-1 머지 후 즉시 vs PR-3 진입 시 — 비용·일정 트레이드오프
+2. **SonarCloud 임계치**: i18n 도입으로 코드 라인 수 30% 증가 예상 → 중복도 임계치 일시 완화 협의
+3. **PR 처리 방식**: 4개 커밋 누적 단일 PR(이전 작업 패턴) vs 6개 분리 PR — 사용자 결정 필요 시점
+
+---
+
+**예상 완료 일정**: 단일 개발자 12 영업일(코드 작업) + 외부 번역 2~3주 = **3~4주 출시 가능**. 영어 PR-1~4 완료 후 시장 출시 가능, 일본어는 PR-5~6 완료 후 추가 활성화.

--- a/docs/workflow/ci-cd.md
+++ b/docs/workflow/ci-cd.md
@@ -122,3 +122,12 @@ E2E 실행 방법, Docker 스크립트, 디바이스 프로필:
 워크플로우 JSON 파일 및 상세 가이드: `n8n/README.md`
 
 → 모니터링·알림 자동화 상세: [`../operations/monitoring.md`](../operations/monitoring.md)
+
+## SonarCloud ↔ Vitest 정합 검증
+
+`sonar-project.properties` 변경 시 `vitest.config.ts` `coverage.include`와 정합 확인 필수:
+- vitest include 항목이 sonar exclusions에 들어가면 SonarCloud 분모에서 빠져 측정 불일치 발생 (PR-A 정합성 핫픽스 사례)
+- 측정 안 할 파일은 vitest exclude + sonar exclusions 양쪽 모두 명시
+- 측정할 파일은 vitest include + sonar exclusions에서 제외
+
+상세: [`../conventions/i18n-style.md`](../conventions/i18n-style.md) §SonarCloud

--- a/docs/workflow/code-change-process.md
+++ b/docs/workflow/code-change-process.md
@@ -138,3 +138,16 @@ git branch | grep -v '^\* main' | xargs git branch -D
 - **마이너·패치는 허용**: 보안 패치, 버그 픽스 수준의 업데이트는 자율 적용 가능
 - **pnpm 버전 고정**: `pnpm@10.33.0` — `pnpm-lock.yaml`과 Docker 실행 스크립트에 고정됨, 임의 변경 금지
 - **Playwright 버전 고정**: Docker 이미지 `mcr.microsoft.com/playwright:v1.59.1-noble` — CI와 로컬 동기화를 위해 임의 변경 금지
+
+## i18n 체크리스트 (UI 텍스트·번역 변경 시)
+
+- [ ] `shared/keys.ts` 타입 추가 (ko/en/ja 모두 강제)
+- [ ] ko 사전 100% 채움 (SSOT)
+- [ ] en 사전 임시 영문 (외부 번역 발주 대기 중)
+- [ ] ja 사전은 PR-5 일괄 (현재는 ko fallback)
+- [ ] 클라이언트 호출 = `useT()`, 서버 호출 = `t(key, locale)` + `getRequestLocale()`
+- [ ] LocaleProvider SSR 패턴 (`setTimeout` 래핑) 준수
+- [ ] E2E 셀렉터를 `data-testid`로 (한글 regex 금지)
+- [ ] `pnpm sync:test-count` 실행 후 CLAUDE.md 자동 갱신 확인
+
+상세: [`../conventions/i18n-style.md`](../conventions/i18n-style.md)

--- a/docs/workflow/e2e-testing.md
+++ b/docs/workflow/e2e-testing.md
@@ -449,3 +449,14 @@ npx playwright test --list --project="Desktop Chrome" | tail -1  # 테스트 수
 ### Playwright 버전 업그레이드
 
 `playwright.config.ts` 버전과 `.github/workflows/` 내 `mcr.microsoft.com/playwright:vX.X.X-noble` 이미지 버전을 **반드시 동시에** 변경합니다. CI와 로컬 환경 불일치 방지.
+
+## i18n 셀렉터 정책
+
+UI 텍스트가 i18n으로 변경되므로 한글 `hasText` regex 셀렉터 금지 — `data-testid` 우선. 핵심 testid:
+- 데스크탑 nav: `desktop-nav` (Header)
+- 모바일 nav: `mobile-nav-${name}` (각 항목)
+- LanguageSwitcher: `lang-option-${l}`, `mobile-lang-option-${l}`
+- LocaleConfirmModal: `locale-confirm-modal`, `locale-confirm-keep`, `locale-confirm-accept`
+- Toast: `toast`
+
+PR-6에서 locale 매트릭스 (165 test × 3 locale = 495 실행) 도입 예정. 상세: [`../conventions/i18n-style.md`](../conventions/i18n-style.md)

--- a/docs/workflow/unit-testing.md
+++ b/docs/workflow/unit-testing.md
@@ -6,7 +6,7 @@ Vitest 기반 단위 테스트 작성 패턴과 주의사항입니다.
 
 ## 1. 테스트 현황
 
-- **714개 테스트** / statements 98%+ 커버리지
+- **757개 테스트** / statements 98%+ 커버리지
 - **Vitest 2.0** (node env, v8 coverage)
 - 임계값: `branches 92 / functions 98 / lines 98 / statements 98`
 


### PR DESCRIPTION
## Summary

10 multi-agent 감사로 식별한 i18n 문서 drift 17건 + High 등급 ≥2 multi-agent 분리 검증으로 발견한 보정 3건 적용. CLAUDE.md L289 규칙 준수.

## CLAUDE.md (8개 항목)
- L34 테스트 수: `pnpm sync:test-count` 자동 갱신 (714 → 757)
- 기술 스택 표: i18n 행 추가 (자체 translations 모듈 + middleware locale 쿠키)
- 프로젝트 구조: `src/i18n/`·`common/`·`layout/`·`hooks/useLocaleStore`·`api/locale` 추가
- L72 마이그레이션: "001 + 003~015 (14개)" → "001 + 003~016 (15개)"
- 캐릭터 시스템 표: "다국어 페르소나 PR-4 예정" 주석
- 핵심 아키텍처: "i18n 다국어 시스템" 단락 신규
- 필수 주의사항: "i18n 다국어" 카테고리 신규 (5개 항목)
- 업무 유형별 가이드: "다국어·번역" 행

## docs/architecture (5개 갱신 + 신규 i18n.md)
- **신규** `i18n.md` (130줄): locale 결정 흐름·middleware·번역 모듈·DB 스키마·INSERT 정책·테스트·진행 상황·외부 번역 정책
- `system-overview.md`: 다국어 인프라 흐름도
- `db-abstraction.md`: 016 마이그레이션·5테이블·인덱스·daily_cards 의도 + 마이그레이션 표 012~016 확장
- `auth-abstraction.md`: AuthUser locale 필드 PR-4 예정
- `data-model.md`: PR-3·4·5 다국어 데이터 명시
- `ai-infrastructure.md`: PR-4 prompt-builder locale·메모리 cross-locale

## docs/conventions·workflow (5개 갱신 + 신규 i18n-style.md)
- **신규** `i18n-style.md`: 호출 패턴·키 네이밍·번역 절차·SSR 규칙·E2E 셀렉터·SonarCloud 측정 정책
- `coding-style.md`: i18n 호출 패턴 섹션
- `layout-rules.md`: §6 LanguageSwitcher 데스크탑·모바일 분리 규칙
- `e2e-testing.md`: data-testid 우선 정책 + 핵심 testid 목록
- `code-change-process.md`: i18n 체크리스트 8개 항목
- `ci-cd.md`: SonarCloud↔Vitest 정합 검증 단계

## docs/operations
- `known-issues.md`: i18n 5건 추가 (AuthUser·daily_cards·사전 정의됨 미적용 키·SonarCloud 중복도·외부 번역 발주)
- `operation-guide.md`: §9 locale 트러블슈팅
- `deployment.md`: 016 마이그레이션 적용·롤백 SQL
- `env-variables.md`: postgres 모드 + locale 컬럼 호환

## 마스터 플랜 git 추적 이관 (사용자 결정)
- `docs/superpowers/plans/i18n-master-plan.md` (← `~/.claude/plans/`)
- `docs/superpowers/plans/i18n-consistency-fix.md` (← `~/.claude/plans/`)
- 변경 이력 git 추적 가능

## README.md
- 3개 locale 지원 (한국어·English·日本語) 한 줄 추가

## High 등급 multi-agent 검증 (≥2 분리, CLAUDE.md L289 규칙)
- **검증 A** 등급 B → 보정 3건: db-abstraction 마이그레이션 표·README locale·known-issues 용어
- **검증 B** 등급 B → 일부 사실 오인 확인, 실제 결함만 반영

## Test plan
- [x] `pnpm sync:test-count` — 757 자동 갱신
- [x] `pnpm check:doc-links` — 기존 archive 경고만 (PR-5 처리)
- [x] `pnpm check:env-docs` — 16개 변수 정합
- [x] `pnpm type-check` / `pnpm lint` — 0
- [ ] CI 통과 + SonarCloud Quality Gate Pass

## 후속
- **PR-3**: 카드·스프레드·사주 영문화 + 외부 번역 발주 (마스터 플랜)
- **PR-4**: 캐릭터 페르소나·AI 프롬프트 + AuthUser·character-context locale 필터
- **PR-5**: 일본어 전체 + i18n:check 스크립트
- **PR-6**: E2E locale 매트릭스·hreflang·신점 하이브리드

https://claude.ai/code/session_011iPkqTGyMoZQkC2ntMFmf3

---
_Generated by [Claude Code](https://claude.ai/code/session_011iPkqTGyMoZQkC2ntMFmf3)_