### PR TITLE
fix: 타로 리딩 결과 실패 현상 수정 — parseError 분기 + max_tokens 상향

### DIFF
--- a/src/__tests__/api/tarot-reading.test.ts
+++ b/src/__tests__/api/tarot-reading.test.ts
@@ -242,11 +242,11 @@ describe("POST /api/tarot/reading", () => {
     expect(text).toContain("error");
   });
 
-  it("computeReadingMaxTokens 정책 — 1장→2000, 5장→5000, 10장→9500이 streamReading에 전달", async () => {
+  it("computeReadingMaxTokens 정책 — 1장→2000, 5장→5000, 10장→11000이 streamReading에 전달", async () => {
     const cases: { count: number; expected: number }[] = [
       { count: 1, expected: 2000 },
       { count: 5, expected: 5000 },
-      { count: 10, expected: 9500 },
+      { count: 10, expected: 11000 },
     ];
     for (const { count, expected } of cases) {
       vi.resetModules();

--- a/src/app/api/tarot/reading/route.ts
+++ b/src/app/api/tarot/reading/route.ts
@@ -27,6 +27,7 @@ const spreadResolver = new SpreadResolver();
  * 한국어는 영어 대비 토큰 효율이 약 1.3배 낮고, JSON 구조 오버헤드(~10%)도 더해진다.
  * 이전 정책(4단)에서는 5장 이상에서 잘림이 발생해 cardInterpretations가 누락되었음.
  * 출력 토큰만 과금되므로 max_tokens 상한 자체는 비용을 늘리지 않는다.
+ * celtic-cross(10장)·zodiac(12장) 등 대형 스프레드는 상한을 분리해 잘림을 방지한다.
  */
 function computeReadingMaxTokens(cardCount: number): number {
   if (cardCount <= 1) return 2000;
@@ -34,7 +35,8 @@ function computeReadingMaxTokens(cardCount: number): number {
   if (cardCount <= 5) return 5000;
   if (cardCount <= 7) return 6500;
   if (cardCount <= 9) return 8000;
-  return 9500;
+  if (cardCount <= 10) return 11000; // celtic-cross (10장)
+  return 13000;                      // zodiac(12장) 등 대형 스프레드
 }
 
 /** 캐릭터 메모리 조회 — 실패해도 빈 문자열 반환 (리딩 계속) */

--- a/src/app/tarot/session/page.tsx
+++ b/src/app/tarot/session/page.tsx
@@ -354,15 +354,21 @@ export default function TarotSessionPage() {
           return;
         }
 
-        // 부분 파싱(잘림/JSON 실패) 시 잘못된 결과를 정상처럼 표시하지 않음
-        if (result.parseError) {
-          console.warn("[tarot-session] 부분 파싱 응답:", { parseError: result.parseError, expected: result.expectedCardCount, got: result.cardInterpretations?.length ?? 0 });
-          addChatMessage({ id: crypto.randomUUID(), role: "character", content: "AI 해석이 일부만 도착했어요. 다시 시도해주세요.", mood: "default", timestamp: new Date() });
+        // JSON 파싱 완전 실패 — 결과 표시 불가
+        if (result.parseError === "invalid_json") {
+          console.warn("[tarot-session] JSON 파싱 완전 실패:", { expected: result.expectedCardCount });
+          addChatMessage({ id: crypto.randomUUID(), role: "character", content: "카드 해석 결과를 받지 못했어요. 다시 시도해주세요.", mood: "default", timestamp: new Date() });
           setMood("default"); setReadingError(true);
           return;
         }
 
-        // 정상 흐름 — 카드 뒤집기 완료 + 결과 phase 진입
+        // 부분 파싱(잘림) — 받은 해석은 그대로 표시하고 안내 메시지 추가
+        if (result.parseError === "truncated") {
+          console.warn("[tarot-session] 부분 파싱 응답:", { expected: result.expectedCardCount, got: result.cardInterpretations?.length ?? 0 });
+          addChatMessage({ id: crypto.randomUUID(), role: "character", content: "일부 카드 해석이 도착하지 않았어요. 받은 결과를 먼저 보여드릴게요.", mood: "default", timestamp: new Date() });
+        }
+
+        // 정상 흐름 (또는 부분 결과) — 카드 뒤집기 완료 + 결과 phase 진입
         setRevealedPositions(cards.map((c) => c.position));
         setReadingResult(result);
         const currentSpread = spreadType ? spreads[spreadType] : null;


### PR DESCRIPTION
## Summary
- `parseError === "invalid_json"`: 완전 파싱 실패 → 에러 화면 (기존 동작 유지)
- `parseError === "truncated"`: 부분 누락(토큰 잘림) → 경고 메시지 후 결과 화면으로 진행 (기존은 전체 차단으로 결과 미노출)
- `computeReadingMaxTokens`: 10장 9500→11000 (celtic-cross), 12장 이상 13000 (zodiac 등) 추가 — 한국어 토큰 효율 1.3배 낮음 반영

## Root Cause
기존 코드는 `if (result.parseError) { setReadingError(true); return; }` 로 truncated/invalid_json 구분 없이 전체 차단. 10장 스프레드에서 한국어 AI 응답이 9500 토큰 한도를 초과해 truncated 상태가 되면 완성된 결과도 표시되지 않았음.

## Test Plan
- [ ] `pnpm test` 764개 전체 통과 확인
- [ ] `pnpm type-check && pnpm lint` 통과 확인
- [ ] 10장 스프레드(Celtic Cross) 리딩 후 결과 화면 정상 진입 확인
- [ ] truncated 시 "일부 카드 해석이 도착하지 않았어요" 경고 메시지 표시 확인