### PR TITLE
fix: 켈틱 크로스 10장 카드 겹침 현상 수정 — Challenge 카드 90도 회전

### DIFF
--- a/src/components/card/CardSpread.tsx
+++ b/src/components/card/CardSpread.tsx
@@ -149,7 +149,10 @@ export function CardSpread({ selectedCards, spread, revealedPositions, glowColor
           >
             {selectedCard ? (
               <div className="flex flex-col items-center gap-0.5 md:gap-1">
-                <div className="relative">
+                <div
+                  className="relative"
+                  style={pos.rotation ? { transform: `rotate(${pos.rotation}deg)` } : undefined}
+                >
                   {isRevealed && (
                     <motion.div
                       className="absolute -inset-1 md:-inset-2 rounded-xl blur-md"

--- a/src/data/spreads/index.ts
+++ b/src/data/spreads/index.ts
@@ -31,7 +31,7 @@ export const spreads: Record<SpreadType, SpreadDefinition> = {
     description: "가장 전통적인 10장 배열법으로 인생의 복합적인 상황을 깊이 분석합니다.",
     positions: [
       { index: 0, label: "Present Situation", labelKo: "현재 상황", x: 35, y: 50 },
-      { index: 1, label: "Challenge", labelKo: "도전/방해 요소", x: 35, y: 50 },
+      { index: 1, label: "Challenge", labelKo: "도전/방해 요소", x: 35, y: 50, rotation: 90 },
       { index: 2, label: "Foundation", labelKo: "기반/원인", x: 35, y: 80 },
       { index: 3, label: "Recent Past", labelKo: "최근 과거", x: 15, y: 50 },
       { index: 4, label: "Crown", labelKo: "의식적 목표", x: 35, y: 20 },

--- a/src/types/session.ts
+++ b/src/types/session.ts
@@ -30,6 +30,7 @@ export interface SpreadPosition {
   labelKo: string;
   x: number;
   y: number;
+  rotation?: number;
 }
 
 export interface SpreadDefinition {


### PR DESCRIPTION
## Summary
- `SpreadPosition` 인터페이스에 `rotation?: number` 필드 추가
- celtic-cross position 1 (도전/방해 요소)에 `rotation: 90` 설정 — 전통 켈틱 크로스에서 두 번째 카드는 중앙 카드를 가로지르도록 90° 배치
- `CardSpread.tsx`: 카드 컨테이너(`<div className="relative">`)에만 `rotate(Ndeg)` transform 적용, 라벨(span)은 회전 제외

## Root Cause
position 0(현재 상황)과 position 1(도전 요소) 모두 `x: 35, y: 50`으로 동일 좌표 → 두 카드가 완전히 겹쳐 position 1이 보이지 않음. rotation 필드가 없어 렌더링 시 회전이 전혀 적용되지 않았음.

## Test Plan
- [ ] `pnpm test` 764개 전체 통과 확인
- [ ] `pnpm type-check && pnpm lint` 통과 확인
- [ ] Celtic Cross 스프레드 선택 시 도전 카드가 현재 상황 카드 위에 가로로(90°) 표시되는 것 확인
- [ ] 다른 스프레드(one-card, three-card 등) 정상 동작 확인 (rotation 미설정 시 undefined → style 미적용)