### PR TITLE
chore: CI 속도 최적화 — 병렬화·Playwright 캐시·중복 제거 (~14분→~8분)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,28 +19,34 @@ permissions:
   contents: read
 
 jobs:
-  ci:
-    name: Lint → Build → E2E
+  # ── 1단계: 정적 검사 (즉시 시작) ──────────────────────────────────────────
+  static:
+    name: Lint & Type Check
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-
       - uses: pnpm/action-setup@v4
-
       - uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: pnpm
-
       - run: pnpm install --frozen-lockfile
-
-      # 1단계: Lint + Type Check
       - run: pnpm lint
       - run: pnpm type-check
 
-      # 2단계: 단위·통합 테스트 (Vitest)
+  # ── 2단계: 단위·통합 테스트 (static와 병렬 시작) ────────────────────────
+  unit:
+    name: Unit Tests & Coverage
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
       - run: pnpm test:coverage
-
       - uses: actions/upload-artifact@v4
         if: always()
         with:
@@ -48,7 +54,19 @@ jobs:
           path: coverage/
           retention-days: 7
 
-      # 3단계: Build
+  # ── 3단계: 프로덕션 빌드 검증 (static와 병렬 시작, E2E 불필요) ─────────
+  build:
+    name: Production Build
+    runs-on: ubuntu-latest
+    needs: static
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
       - run: pnpm build
         env:
           NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL || 'https://placeholder.supabase.co' }}
@@ -58,9 +76,36 @@ jobs:
           GROK_MODEL: grok-3
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY || 'placeholder-service-key' }}
 
-      # 3단계: E2E (Chromium만 — Desktop + Android, iOS는 주간 QA에서)
-      - run: npx playwright install --with-deps chromium
-      - run: pnpm test:e2e --project="Desktop Chrome" --project="Mobile Android"
+  # ── 4단계: E2E (static + unit 완료 후, build와 무관) ────────────────────
+  # webServer: "pnpm dev" → dev server 자동 기동, build artifact 불필요
+  e2e-desktop:
+    name: E2E — Desktop Chrome
+    runs-on: ubuntu-latest
+    needs: [static, unit]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+
+      - uses: actions/cache@v4
+        id: pw-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: pw-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
+
+      - name: Playwright 설치 (캐시 미스)
+        if: steps.pw-cache.outputs.cache-hit != 'true'
+        run: npx playwright install --with-deps chromium
+
+      - name: Playwright 시스템 의존성 설치 (캐시 히트)
+        if: steps.pw-cache.outputs.cache-hit == 'true'
+        run: npx playwright install-deps chromium
+
+      - run: pnpm test:e2e --project="Desktop Chrome"
         env:
           NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL || 'https://placeholder.supabase.co' }}
           NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY || 'placeholder-anon-key' }}
@@ -72,6 +117,49 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: failure()
         with:
-          name: playwright-report
+          name: playwright-report-desktop
+          path: playwright-report/
+          retention-days: 7
+
+  e2e-android:
+    name: E2E — Mobile Android
+    runs-on: ubuntu-latest
+    needs: [static, unit]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+
+      - uses: actions/cache@v4
+        id: pw-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: pw-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
+
+      - name: Playwright 설치 (캐시 미스)
+        if: steps.pw-cache.outputs.cache-hit != 'true'
+        run: npx playwright install --with-deps chromium
+
+      - name: Playwright 시스템 의존성 설치 (캐시 히트)
+        if: steps.pw-cache.outputs.cache-hit == 'true'
+        run: npx playwright install-deps chromium
+
+      - run: pnpm test:e2e --project="Mobile Android"
+        env:
+          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL || 'https://placeholder.supabase.co' }}
+          NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY || 'placeholder-anon-key' }}
+          NEXT_PUBLIC_SITE_URL: ${{ secrets.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000' }}
+          GROK_API_KEY: ${{ secrets.GROK_API_KEY || 'placeholder-grok-key' }}
+          GROK_MODEL: grok-3
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY || 'placeholder-service-key' }}
+
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: playwright-report-android
           path: playwright-report/
           retention-days: 7

--- a/.github/workflows/docs-sync.yml
+++ b/.github/workflows/docs-sync.yml
@@ -18,8 +18,6 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: pnpm/action-setup@v4
-        with:
-          version: 10.33.0
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0   # SonarCloud는 전체 git 히스토리 필요 (blame, blame 기반 새 코드 감지)
+          fetch-depth: 0   # SonarCloud는 전체 git 히스토리 필요 (blame, 새 코드 감지)
 
       - uses: pnpm/action-setup@v4
 
@@ -42,35 +42,13 @@ jobs:
       - name: 의존성 설치
         run: pnpm install --frozen-lockfile
 
-      - name: TypeScript 타입 체크
-        run: pnpm type-check
-
-      - name: ESLint (SonarCloud 참고용)
-        run: pnpm lint
-
       # ── 단위/통합 테스트 + 커버리지 (Vitest) ──────────────────────────────
+      # type-check·lint·E2E는 deploy.yml에서 이미 검증 — 여기서는 coverage 생성만
       - name: 단위·통합 테스트 실행 (커버리지 포함)
         run: pnpm test:coverage
 
-      # ── E2E 실행 + JUnit XML ──────────────────────────────────────────────
-      - name: Playwright 설치 (Chromium)
-        run: npx playwright install --with-deps chromium
-
-      - name: E2E 테스트 실행 (Desktop Chrome)
-        run: pnpm test:e2e --project="Desktop Chrome"
-        env:
-          CI: "true"
-          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL || 'https://placeholder.supabase.co' }}
-          NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY || 'placeholder-anon-key' }}
-          NEXT_PUBLIC_SITE_URL: ${{ secrets.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000' }}
-          GROK_API_KEY: ${{ secrets.GROK_API_KEY || 'placeholder-grok-key' }}
-          GROK_MODEL: grok-3
-          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY || 'placeholder-service-key' }}
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-
       # ── SonarCloud 분석 ──────────────────────────────────────────────────
       - name: SonarCloud Scan
-        if: always()   # E2E 실패 여부와 무관하게 항상 스캔 — Coverage 뱃지 보장
         uses: SonarSource/sonarqube-scan-action@v6.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -94,7 +72,6 @@ jobs:
         with:
           name: sonar-coverage-report
           path: |
-            playwright-report/
             coverage/lcov.info
             coverage/coverage-summary.json
             coverage/junit.xml

--- a/.github/workflows/weekly-qa.yml
+++ b/.github/workflows/weekly-qa.yml
@@ -58,7 +58,20 @@ jobs:
           node-version: 20
           cache: pnpm
       - run: pnpm install --frozen-lockfile
-      - run: npx playwright install --with-deps chromium
+
+      - uses: actions/cache@v4
+        id: pw-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: pw-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
+
+      - name: Playwright 설치 (캐시 미스)
+        if: steps.pw-cache.outputs.cache-hit != 'true'
+        run: npx playwright install --with-deps chromium
+
+      - name: Playwright 시스템 의존성 설치 (캐시 히트)
+        if: steps.pw-cache.outputs.cache-hit == 'true'
+        run: npx playwright install-deps chromium
 
       - name: E2E 테스트 (Desktop Chrome)
         run: pnpm test:e2e --project="Desktop Chrome"
@@ -89,7 +102,20 @@ jobs:
           node-version: 20
           cache: pnpm
       - run: pnpm install --frozen-lockfile
-      - run: npx playwright install --with-deps chromium
+
+      - uses: actions/cache@v4
+        id: pw-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: pw-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
+
+      - name: Playwright 설치 (캐시 미스)
+        if: steps.pw-cache.outputs.cache-hit != 'true'
+        run: npx playwright install --with-deps chromium
+
+      - name: Playwright 시스템 의존성 설치 (캐시 히트)
+        if: steps.pw-cache.outputs.cache-hit == 'true'
+        run: npx playwright install-deps chromium
 
       - name: E2E 테스트 (Mobile Android — Pixel 7)
         run: pnpm test:e2e --project="Mobile Android"
@@ -120,7 +146,20 @@ jobs:
           node-version: 20
           cache: pnpm
       - run: pnpm install --frozen-lockfile
-      - run: npx playwright install --with-deps webkit
+
+      - uses: actions/cache@v4
+        id: pw-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: pw-${{ runner.os }}-webkit-${{ hashFiles('**/pnpm-lock.yaml') }}
+
+      - name: Playwright 설치 (캐시 미스)
+        if: steps.pw-cache.outputs.cache-hit != 'true'
+        run: npx playwright install --with-deps webkit
+
+      - name: Playwright 시스템 의존성 설치 (캐시 히트)
+        if: steps.pw-cache.outputs.cache-hit == 'true'
+        run: npx playwright install-deps webkit
 
       - name: E2E 테스트 (Mobile iOS — iPhone 14)
         run: pnpm test:e2e --project="Mobile iOS"


### PR DESCRIPTION
## Summary

PR CI 예상 소요시간: **~14분 → ~8분** (critical path 기준)

### deploy.yml — 단일 순차 job → 5개 병렬 job

**변경 전:**
```
install → lint → type-check → test:coverage → build → playwright install → E2E (Desktop+Android 순차)
```

**변경 후:**
```
[static]      lint + type-check          ──┐
[unit]        test:coverage               ──┼→ [e2e-desktop] needs: [static, unit]
[build]       pnpm build  (needs:static)  ──┘→ [e2e-android] needs: [static, unit]
```

- `playwright.config.ts`의 `webServer: "pnpm dev"` 확인 → E2E는 dev server 사용, build artifact 불필요
- E2E Desktop / Android를 별도 job으로 분리하여 병렬 실행
- Playwright 브라우저 캐시 추가 (`pnpm-lock.yaml` 기준 key)
  - 캐시 히트: `install-deps`만 실행 (브라우저 다운로드 생략)
  - 캐시 미스: `--with-deps` 전체 설치

### sonar.yml — 중복 스텝 4개 제거

deploy.yml과 중복되는 스텝 제거 (~6분 절감):
- ❌ `pnpm type-check` (deploy.yml static에서 이미 검증)
- ❌ `pnpm lint` (deploy.yml static에서 이미 검증)
- ❌ `playwright install` + E2E (SonarCloud/Codecov는 lcov.info만 필요)
- ✅ `pnpm test:coverage` 유지 (lcov.info 생성 필수)

### weekly-qa.yml — E2E 3개 job Playwright 캐시 추가

- chromium (Desktop, Android): `key: pw-{OS}-{lockfile-hash}`
- webkit (iOS): `key: pw-{OS}-webkit-{lockfile-hash}`
- 주간 QA 기준 최대 **~9분 절감** (3 job × ~3분)

### docs-sync.yml — pnpm 버전 명시 제거

- `package.json`의 `"packageManager": "pnpm@10.33.0"` 필드가 SSOT
- `version: 10.33.0` 중복 제거로 4개 워크플로우 모두 동일 패턴 통일

## Test plan

- [ ] 이 PR CI 자체가 새 deploy.yml 구조로 실행됨 — job 병렬 실행 확인
- [ ] e2e-desktop, e2e-android가 별도 job으로 성공 확인
- [ ] Playwright 캐시 첫 실행 → cache miss → 다음 PR에서 cache hit 확인
- [ ] sonar.yml이 type-check/lint/E2E 없이 SonarCloud 분석 완료 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)