### PR TITLE
fix: 리딩 truncated 잔존 회귀 — max_tokens 추가 상향 + 프롬프트에 thinking 자제 명시

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,10 +122,10 @@ scripts/
 
 **ShuffleCeremony**: 타로 카드 선택 진입 시 2.2초 Canvas rAF 의식 애니메이션. `phase === "card-shuffle"` 조건부 렌더 → `onComplete` 시 `setPhase("card-select")`. 4단계: ① 덱 컷(0–500ms) ② 글로우 폭발(500–700ms) ③ 타이프라이터(700–1400ms, 58ms/자) ④ 부채꼴 펼침(1400–2200ms, spring). 클릭·키보드(Enter/Space) 스킵, `prefers-reduced-motion` 즉시 스킵. `shuffleCeremonyText` 12캐릭터 텍스트 → `getWaitingLinesData(locale)` (`waiting-lines-i18n.ts`) — ko/en/ja 분기. N=9 고정(시각 효과, 실제 스프레드 크기 무관).
 
-**리딩 max_tokens 정책 (3개 서비스 통일)**: 한국어 토큰 효율 영어 대비 1.3배 낮음 + JSON 오버헤드 반영 — 4000 토큰 고정은 truncated 빈번 → JSON 파싱 실패 → result 빈 화면 유발. 출력 토큰만 과금되므로 상한 자체는 비용 영향 없음.
-- **타로**: `computeReadingMaxTokens(cardCount)` (`src/app/api/tarot/reading/route.ts`) — 1장→2000, 3장→3500, 5장→5000, 7장→6500, 9장→8000, 10장→11000(celtic-cross), 12장+→13000(zodiac 등).
-- **사주**: `computeSajuReadingMaxTokens(timeRange, includeMonthly)` (`src/app/api/saju/reading/route.ts`) — includeMonthly→16000, full-fortune→13000, five-year→12000, three/next-year→10000, 기본 8000.
-- **신점**: `SHINJEOM_TOKENS_FINAL=6500` / `SHINJEOM_TOKENS_CHAT=1200` (`src/app/api/shinjeom/message/route.ts`).
+**리딩 max_tokens 정책 (3개 서비스 통일)**: 한국어 토큰 효율 영어 대비 1.3배 낮음 + JSON 오버헤드 + Grok 내부 reasoning(thinking) 토큰 흡수까지 고려한 안전 마진 — 4000 토큰 고정·11000 토큰 고정도 truncated 발견되어 +30~40% 추가 상향. 출력 토큰만 과금되므로 상한 자체는 비용 영향 없음. 시스템 프롬프트에 "내부 reasoning·생각 단계를 출력하지 마세요. 첫 토큰부터 곧바로 JSON을 시작합니다." 명시(prompt-builder, saju-service, shinjeom-service)로 thinking 토큰 소비도 차단.
+- **타로**: `computeReadingMaxTokens(cardCount)` (`src/app/api/tarot/reading/route.ts`) — 1장→2600, 3장→4500, 5장→6500, 7장→8500, 9장→10500, 10장→14000(celtic-cross), 12장+→16000(zodiac 등).
+- **사주**: `computeSajuReadingMaxTokens(timeRange, includeMonthly)` (`src/app/api/saju/reading/route.ts`) — includeMonthly→20000, full-fortune→17000, five-year→15000, three/next-year→13000, 기본 10000.
+- **신점**: `SHINJEOM_TOKENS_FINAL=8500` / `SHINJEOM_TOKENS_CHAT=1500` (`src/app/api/shinjeom/message/route.ts`).
 
 **parseError 시그널 통일 (3개 서비스)**: `ReadingResult.parseError` union = `"truncated" | "invalid_json" | "fallback_text" | "missing_fields"` (`src/types/service.ts`). saju/shinjeom service `parseResult`도 핵심 필드(`overallReading`/`advice`) 빈 문자 시 `missing_fields` 부여, JSON 파싱 실패 + raw 텍스트 추출 성공 시 `fallback_text` 부여. 라우트는 `parseError` 있는 결과를 SSE done에 그대로 송신하지만 **DB INSERT는 차단** (result/[id] 빈 화면 방지). 클라이언트 session/page.tsx는 parseError 감지 시 캐릭터 에러 메시지 + 재시도 안내 (타로 `truncated`만 부분 결과 표시 유지).
 

--- a/src/__tests__/api/saju-reading.test.ts
+++ b/src/__tests__/api/saju-reading.test.ts
@@ -239,24 +239,24 @@ describe("POST /api/saju/reading", () => {
       return provider.streamReading.mock.calls[0]?.[2] as number | undefined;
     }
 
-    it("includeMonthly=true → max_tokens 16000", async () => {
-      expect(await captureMaxTokens({ timeRange: "this-month", includeMonthly: true })).toBe(16000);
+    it("includeMonthly=true → max_tokens 20000", async () => {
+      expect(await captureMaxTokens({ timeRange: "this-month", includeMonthly: true })).toBe(20000);
     });
 
-    it("timeRange='full-fortune' → max_tokens 13000", async () => {
-      expect(await captureMaxTokens({ timeRange: "full-fortune", includeMonthly: false })).toBe(13000);
+    it("timeRange='full-fortune' → max_tokens 17000", async () => {
+      expect(await captureMaxTokens({ timeRange: "full-fortune", includeMonthly: false })).toBe(17000);
     });
 
-    it("timeRange='five-year' → max_tokens 12000", async () => {
-      expect(await captureMaxTokens({ timeRange: "five-year", includeMonthly: false })).toBe(12000);
+    it("timeRange='five-year' → max_tokens 15000", async () => {
+      expect(await captureMaxTokens({ timeRange: "five-year", includeMonthly: false })).toBe(15000);
     });
 
-    it("timeRange='three-year' → max_tokens 10000", async () => {
-      expect(await captureMaxTokens({ timeRange: "three-year", includeMonthly: false })).toBe(10000);
+    it("timeRange='three-year' → max_tokens 13000", async () => {
+      expect(await captureMaxTokens({ timeRange: "three-year", includeMonthly: false })).toBe(13000);
     });
 
-    it("기본 (this-month, monthly 미포함) → max_tokens 8000", async () => {
-      expect(await captureMaxTokens({ timeRange: "this-month", includeMonthly: false })).toBe(8000);
+    it("기본 (this-month, monthly 미포함) → max_tokens 10000", async () => {
+      expect(await captureMaxTokens({ timeRange: "this-month", includeMonthly: false })).toBe(10000);
     });
   });
 

--- a/src/__tests__/api/shinjeom-message.test.ts
+++ b/src/__tests__/api/shinjeom-message.test.ts
@@ -276,12 +276,12 @@ describe("POST /api/shinjeom/message", () => {
       return provider.streamReading.mock.calls[0]?.[2] as number | undefined;
     }
 
-    it("isFinalTurn=true → max_tokens 6500 (truncated 방지 상향)", async () => {
-      expect(await captureMaxTokens({ isFinalTurn: true })).toBe(6500);
+    it("isFinalTurn=true → max_tokens 8500 (truncated 방지 상향)", async () => {
+      expect(await captureMaxTokens({ isFinalTurn: true })).toBe(8500);
     });
 
-    it("isFinalTurn=false → max_tokens 1200 (중간 대화)", async () => {
-      expect(await captureMaxTokens({ isFinalTurn: false })).toBe(1200);
+    it("isFinalTurn=false → max_tokens 1500 (중간 대화)", async () => {
+      expect(await captureMaxTokens({ isFinalTurn: false })).toBe(1500);
     });
   });
 

--- a/src/__tests__/api/tarot-reading.test.ts
+++ b/src/__tests__/api/tarot-reading.test.ts
@@ -242,11 +242,15 @@ describe("POST /api/tarot/reading", () => {
     expect(text).toContain("error");
   });
 
-  it("computeReadingMaxTokens 정책 — 1장→2600, 5장→6500, 10장→14000이 streamReading에 전달", async () => {
+  it("computeReadingMaxTokens 정책 — 모든 분기가 streamReading에 정확히 전달", async () => {
     const cases: { count: number; expected: number }[] = [
       { count: 1, expected: 2600 },
+      { count: 3, expected: 4500 },
       { count: 5, expected: 6500 },
+      { count: 7, expected: 8500 },
+      { count: 9, expected: 10500 },
       { count: 10, expected: 14000 },
+      { count: 12, expected: 16000 },
     ];
     for (const { count, expected } of cases) {
       vi.resetModules();

--- a/src/__tests__/api/tarot-reading.test.ts
+++ b/src/__tests__/api/tarot-reading.test.ts
@@ -242,11 +242,11 @@ describe("POST /api/tarot/reading", () => {
     expect(text).toContain("error");
   });
 
-  it("computeReadingMaxTokens 정책 — 1장→2000, 5장→5000, 10장→11000이 streamReading에 전달", async () => {
+  it("computeReadingMaxTokens 정책 — 1장→2600, 5장→6500, 10장→14000이 streamReading에 전달", async () => {
     const cases: { count: number; expected: number }[] = [
-      { count: 1, expected: 2000 },
-      { count: 5, expected: 5000 },
-      { count: 10, expected: 11000 },
+      { count: 1, expected: 2600 },
+      { count: 5, expected: 6500 },
+      { count: 10, expected: 14000 },
     ];
     for (const { count, expected } of cases) {
       vi.resetModules();

--- a/src/app/api/saju/reading/route.ts
+++ b/src/app/api/saju/reading/route.ts
@@ -31,16 +31,15 @@ async function fetchMemoryPrompt(characterId: string, locale: string): Promise<s
 
 /**
  * 사주 max_tokens 정책 — 한국어 토큰 비효율(영어 대비 1.3배) + JSON 오버헤드 + 사주명리 깊이 반영.
- * 4000/8000 고정은 truncated 빈번 → JSON 파싱 실패 → 빈 결과 표시 유발.
- * timeRange·includeMonthly 기반으로 단계화 (타로 computeReadingMaxTokens 사상과 동일).
- * 출력 토큰만 과금되므로 상한 자체는 비용을 늘리지 않는다.
+ * Grok 내부 reasoning(thinking) 토큰 소비까지 흡수하도록 안전 마진 +30~40% 추가.
+ * 출력 토큰만 과금되므로 상한 자체는 비용 영향이 없다.
  */
 function computeSajuReadingMaxTokens(timeRange: SajuTimeRange, includeMonthly: boolean): number {
-  if (includeMonthly) return 16000;          // 월운 12개월 상세 포함
-  if (timeRange === "five-year") return 12000;
-  if (timeRange === "three-year" || timeRange === "next-year") return 10000;
-  if (timeRange === "full-fortune") return 13000;
-  return 8000;                               // this-week / this-month / this-year 기본
+  if (includeMonthly) return 20000;          // 월운 12개월 상세 포함
+  if (timeRange === "five-year") return 15000;
+  if (timeRange === "three-year" || timeRange === "next-year") return 13000;
+  if (timeRange === "full-fortune") return 17000;
+  return 10000;                              // this-week / this-month / this-year 기본
 }
 
 const VALID_TOPICS: Topic[] = [

--- a/src/app/api/shinjeom/message/route.ts
+++ b/src/app/api/shinjeom/message/route.ts
@@ -16,9 +16,9 @@ const shinjeomService = new ShinjeomService();
 const aiProvider = new FallbackProvider();
 
 // 최종 턴(결과 요청) vs 일반 대화 max_tokens 상수
-// 한국어 토큰 비효율(영어 대비 1.3배) + JSON 오버헤드 반영해 final 상향 (truncated 방지)
-const SHINJEOM_TOKENS_FINAL = 6500;
-const SHINJEOM_TOKENS_CHAT = 1200;
+// 한국어 토큰 비효율 + JSON 오버헤드 + Grok 내부 reasoning(thinking) 토큰 흡수까지 고려한 안전 마진.
+const SHINJEOM_TOKENS_FINAL = 8500;
+const SHINJEOM_TOKENS_CHAT = 1500;
 
 /** 캐릭터 메모리 조회 — 실패해도 빈 문자열 반환 (리딩 계속) */
 async function fetchMemoryPrompt(characterId: string, locale: string): Promise<string> {

--- a/src/app/api/tarot/reading/route.ts
+++ b/src/app/api/tarot/reading/route.ts
@@ -25,18 +25,18 @@ const spreadResolver = new SpreadResolver();
  * 카드 수에 비례한 max_tokens 정책.
  *
  * 한국어는 영어 대비 토큰 효율이 약 1.3배 낮고, JSON 구조 오버헤드(~10%)도 더해진다.
- * 이전 정책(4단)에서는 5장 이상에서 잘림이 발생해 cardInterpretations가 누락되었음.
- * 출력 토큰만 과금되므로 max_tokens 상한 자체는 비용을 늘리지 않는다.
- * celtic-cross(10장)·zodiac(12장) 등 대형 스프레드는 상한을 분리해 잘림을 방지한다.
+ * 또한 Grok 모델이 응답 전 내부 reasoning(thinking) 토큰을 소비할 수 있어,
+ * 첫 PR(#245) 이후에도 celtic-cross(10장)에서 truncated 사례가 보고됨.
+ * 출력 토큰만 과금되므로 상한 자체는 비용 영향이 없다 — 안전 마진을 +30~40% 추가.
  */
 function computeReadingMaxTokens(cardCount: number): number {
-  if (cardCount <= 1) return 2000;
-  if (cardCount <= 3) return 3500;
-  if (cardCount <= 5) return 5000;
-  if (cardCount <= 7) return 6500;
-  if (cardCount <= 9) return 8000;
-  if (cardCount <= 10) return 11000; // celtic-cross (10장)
-  return 13000;                      // zodiac(12장) 등 대형 스프레드
+  if (cardCount <= 1) return 2600;
+  if (cardCount <= 3) return 4500;
+  if (cardCount <= 5) return 6500;
+  if (cardCount <= 7) return 8500;
+  if (cardCount <= 9) return 10500;
+  if (cardCount <= 10) return 14000; // celtic-cross (10장)
+  return 16000;                      // zodiac(12장) 등 대형 스프레드
 }
 
 /** 캐릭터 메모리 조회 — 실패해도 빈 문자열 반환 (리딩 계속) */

--- a/src/services/core/prompt-builder.ts
+++ b/src/services/core/prompt-builder.ts
@@ -71,6 +71,8 @@ export function buildSystemPrompt(character: CharacterConfig, locale: string = "
 - 반드시 아래 JSON 형식으로만 응답합니다.
 - JSON 앞뒤에 어떤 텍스트도 추가하지 않습니다.
 - 마크다운 코드블록을 사용하지 않습니다.
+- 내부 reasoning·생각·계획 단계를 출력하지 마세요. 첫 토큰부터 곧바로 JSON을 시작합니다.
+- <think> 같은 태그·메타 텍스트도 출력 금지 (응답 토큰 한도 내에 JSON 본문이 모두 들어가야 함).
 - JSON 문자열 값 안의 줄바꿈은 반드시 \\n 이스케이프로 표현합니다. 실제 줄바꿈 문자를 사용하지 않습니다.
 {
   "cardInterpretations": [

--- a/src/services/saju/saju-service.ts
+++ b/src/services/saju/saju-service.ts
@@ -160,6 +160,8 @@ export class SajuService implements DivinationService {
 - 반드시 아래 JSON 형식으로만 응답합니다.
 - JSON 앞뒤에 어떤 텍스트도 추가하지 않습니다.
 - 마크다운 코드블록을 사용하지 않습니다.
+- 내부 reasoning·생각·계획 단계를 출력하지 마세요. 첫 토큰부터 곧바로 JSON을 시작합니다.
+- <think> 같은 태그·메타 텍스트도 출력 금지 (응답 토큰 한도 내에 JSON 본문이 모두 들어가야 함).
 - JSON 문자열 값 안의 줄바꿈은 반드시 \\n 이스케이프로 표현합니다. 실제 줄바꿈 문자를 사용하지 않습니다.
 {
   "overallReading": "종합 해석 문단1\\n\\n문단2",

--- a/src/services/shinjeom/shinjeom-service.ts
+++ b/src/services/shinjeom/shinjeom-service.ts
@@ -105,7 +105,8 @@ ${historyText}
 }
 
 JSON 문자열 값 안의 줄바꿈은 반드시 \\n으로 표현합니다.
-JSON 앞뒤에 어떤 텍스트도 추가하지 않습니다.`;
+JSON 앞뒤에 어떤 텍스트도 추가하지 않습니다.
+내부 reasoning·생각·계획 단계를 출력하지 마세요 — 첫 토큰부터 곧바로 JSON을 시작하고 <think> 같은 태그도 출력 금지.`;
   }
 
   getReadingPrompt(context: SessionContext): string {


### PR DESCRIPTION
PR #245 머지 후 실테스트에서 celtic-cross(10장) 결과 화면이 여전히
"해석에 문제가 발생했어요" 분기로 떨어짐 (parseError로 안전망은 동작).

원인: max_tokens 11000(celtic-cross) 안에 Grok 내부 reasoning(thinking) 토큰 + 한국어 깊이 있는 카드별 해석이 모두 들어가야 하는데, thinking이 길어지면
JSON 본문이 잘려 parseJsonSafe → null → fallback 분기.

수정 — 두 가설을 동시에 해소:

1. max_tokens 전반 +30~40% 상향 (출력 토큰 과금이라 비용 영향 없음):
   - 타로: 1장 2000→2600, 5장 5000→6500, 7장 6500→8500, 9장 8000→10500, 10장(celtic-cross) 11000→14000, 12장+ 13000→16000
   - 사주: includeMonthly 16000→20000, full-fortune 13000→17000, five-year 12000→15000, three/next-year 10000→13000, 기본 8000→10000
   - 신점: final 6500→8500, chat 1200→1500

2. 시스템 프롬프트에 thinking 자제 명시 (prompt-builder + saju + shinjeom): "내부 reasoning·생각·계획 단계를 출력하지 마세요. 첫 토큰부터 곧바로 JSON을 시작합니다. <think> 같은 태그·메타 텍스트도 출력 금지" → 모델이 thinking 토큰을 소비하지 않고 즉시 JSON 출력 → 토큰 한도 내 JSON 본문이 모두 들어감

검증:
- pnpm type-check / lint / test (46 files, 786 passed) / build 모두 통과
- 단위 테스트 분기값을 새 max_tokens에 맞춰 일괄 업데이트