### PR TITLE
fix(i18n): LanguageSwitcher router.refresh + LocaleProvider hydration…

### DIFF
--- a/src/components/common/LocaleConfirmModal.tsx
+++ b/src/components/common/LocaleConfirmModal.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
 import { useLocaleStore } from "@/hooks/useLocaleStore";
 import { LOCALE_COOKIE, isLocale, type Locale } from "@/i18n/config";
 import { t as translate } from "@/i18n/translations";
@@ -20,6 +21,7 @@ function detectBrowserLocale(): Locale | null {
 }
 
 export function LocaleConfirmModal() {
+  const router = useRouter();
   const setLocale = useLocaleStore((s) => s.setLocale);
   const [suggested, setSuggested] = useState<Locale | null>(null);
 
@@ -66,6 +68,8 @@ export function LocaleConfirmModal() {
       // 쿠키는 클라이언트에서 이미 설정됨
     }
     dismiss();
+    // 서버 컴포넌트가 새 locale 쿠키로 재요청되도록 router.refresh() — 입력 상태 보존.
+    router.refresh();
   };
 
   if (!suggested) return null;

--- a/src/components/layout/LanguageSwitcher.tsx
+++ b/src/components/layout/LanguageSwitcher.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
 import { useLocaleStore } from "@/hooks/useLocaleStore";
 import { useT } from "@/i18n/useT";
 import { LOCALES, type Locale } from "@/i18n/config";
@@ -25,6 +26,7 @@ interface Props {
 }
 
 export function LanguageSwitcher({ variant, onSelect }: Props) {
+  const router = useRouter();
   const locale = useLocaleStore((s) => s.locale);
   const setLocale = useLocaleStore((s) => s.setLocale);
   const { t } = useT();
@@ -40,6 +42,11 @@ export function LanguageSwitcher({ variant, onSelect }: Props) {
   }, []);
 
   const handleSelect = async (next: Locale) => {
+    // 동일 locale 클릭 시 no-op — 불필요한 router.refresh + 토스트 발사 방지
+    if (next === locale) {
+      setOpen(false);
+      return;
+    }
     setLocale(next);
     setOpen(false);
     showToast(translate("common.language.changed", next));
@@ -53,6 +60,9 @@ export function LanguageSwitcher({ variant, onSelect }: Props) {
       // 쿠키는 클라이언트에서 이미 설정됨
     }
     onSelect?.(next);
+    // 서버 컴포넌트(layout, mypage 등)가 새 locale 쿠키로 재요청되도록 router.refresh().
+    // window.location.reload()와 달리 SPA 입력 상태(폼·스크롤·진행 중 세션)를 보존.
+    router.refresh();
   };
 
   const testidPrefix = variant === "desktop" ? "lang-option" : "mobile-lang-option";

--- a/src/i18n/LocaleProvider.tsx
+++ b/src/i18n/LocaleProvider.tsx
@@ -8,7 +8,10 @@ export function LocaleProvider({ initial, children }: { initial: Locale; childre
   const setLocale = useLocaleStore((s) => s.setLocale);
 
   useEffect(() => {
-    // SSR 결정 locale을 client store에 동기화 (CLAUDE.md SSR 규칙: useEffect 내 setState는 setTimeout 래핑)
+    // 이미 동일 locale이면 store 갱신 건너뜀 — 불필요한 useT 컴포넌트 재렌더 방지.
+    // 초방문(쿠키 없음 → 'ko')처럼 store 초기값과 SSR initial이 일치하면 깜빡임 0.
+    if (useLocaleStore.getState().locale === initial) return;
+    // SSR 결정 locale을 client store에 동기화 (CLAUDE.md SSR 규칙: useEffect 내 setState는 setTimeout 래핑).
     const t = setTimeout(() => setLocale(initial), 0);
     return () => clearTimeout(t);
   }, [initial, setLocale]);


### PR DESCRIPTION
… guard (P0)

# 회귀 — 4개 에이전트 전수 감사 합치
사용자 보고 "다국어 옵션이 메뉴 및 각 페이지, 캐릭터 대사 및 모든 내용에서 변환 안 됨".

Phase 1 정정:
- 사전 자체는 ko/en/ja 141/141 완전 (i18n:check drift 0)
- 캐릭터 페르소나·waiting-lines·AI 응답 locale도 100% 정상
- 진짜 회귀의 80%는 페이지·컴포넌트 한국어 하드코딩 (별도 PR 5·6에서 처리)
- 본 PR은 가장 큰 체감 효과(35%)인 P0 두 결함 수정

# Fix 1 — LanguageSwitcher router.refresh
- 파일: src/components/layout/LanguageSwitcher.tsx
- 현재: setLocale + cookie set + fetch /api/locale → 토스트만 뜨고 SSR 컴포넌트(layout, mypage) 그대로
- 변경: handleSelect 마지막에 router.refresh() 호출 → 서버 컴포넌트가 새 locale 쿠키로 재요청·재렌더 (SPA 입력 상태 보존, reload 대신)
- 동일 locale 클릭 시 no-op 추가 (불필요한 refresh + 토스트 발사 방지)

# Fix 1b — LocaleConfirmModal accept도 동반 수정
- 파일: src/components/common/LocaleConfirmModal.tsx
- 첫 방문 ja/en 사용자 자동 감지 시 동일 패턴 (accept 후 router.refresh)

# Fix 2 — LocaleProvider hydration race guard
- 파일: src/i18n/LocaleProvider.tsx
- 현재: SSR locale=en/ja인데 store 초기값="ko" → setTimeout(0) 후 setLocale → 0ms 깜빡임
- 변경: useEffect에서 useLocaleStore.getState().locale === initial이면 early return → 초방문 ko 사용자 깜빡임 0, en/ja는 한 번만 동기화
- CLAUDE.md SSR 규칙(setTimeout 래핑) 유지

# 검증
- pnpm type-check / lint / test (46 files, 793 passed) / i18n:check (141/141 drift 0) / build 모두 통과
- 단위 테스트: vitest node env + src/components/** exclude 제약으로 컴포넌트 직접 테스트 불가 (E2E 커버)
- 후속 검증: 실테스트로 언어 전환 시 메뉴/Footer 즉시 변경 확인 권장

# 후속 PR 예정 (사용자 승인 후)
- PR 3: Header 잔존 + theme nameEn/Ja
- PR 4: 홈 보조 컴포넌트 (CharacterGallery/SkinGallery/GenderFilter)
- PR 5: tarot/saju/mypage 페이지 토픽·스프레드 라벨 마이그레이션 (40% 효과)
- PR 6: 세션 페이지 (25% 효과)
- PR 7: 사주 차트 한자 transliteration