### PR TITLE
feat(i18n): API 에러 메시지 + 작은 컴포넌트 + SEO meta 다국어화 (PR 10)

### DIFF
--- a/src/app/api/daily-card/route.ts
+++ b/src/app/api/daily-card/route.ts
@@ -6,6 +6,7 @@ import { getCharacterById } from "@/data/characters";
 import { DailyCardSchema } from "@/lib/validation/api-schemas";
 import { checkRateLimit, rateLimitResponse } from "@/lib/rate-limit";
 import { getClientIp } from "@/lib/request-utils";
+import { getRequestLocale } from "@/i18n/server-locale";
 
 const grokProvider = new FallbackProvider();
 const deckManager = new DeckManager();
@@ -23,8 +24,9 @@ function hashDateSeed(date: string, characterId: string): number {
 
 export async function POST(request: NextRequest) {
   try {
+    const locale = await getRequestLocale();
     const ip = getClientIp(request.headers);
-    if (!(await checkRateLimit(`daily-card:${ip}`, 30, 60_000))) return rateLimitResponse();
+    if (!(await checkRateLimit(`daily-card:${ip}`, 30, 60_000))) return rateLimitResponse(locale);
 
     const parsed = DailyCardSchema.safeParse(await request.json());
     if (!parsed.success) {

--- a/src/app/api/saju/reading/route.ts
+++ b/src/app/api/saju/reading/route.ts
@@ -13,6 +13,7 @@ import { checkRateLimit, rateLimitResponse } from "@/lib/rate-limit"
 import { getClientIp, jsonError, SSE_HEADERS } from "@/lib/request-utils"
 import { saveSajuReading } from "@/lib/db/reading-saver";
 import { getRequestLocale } from "@/i18n/server-locale";
+import { t as translate } from "@/i18n/translations";
 
 const sajuService = new SajuService();
 const grokProvider = new FallbackProvider();
@@ -64,11 +65,10 @@ function resolveCalcOptions(timeRange: SajuTimeRange, includeMonthly: boolean) {
 
 export async function POST(request: NextRequest) {
   try {
+    const locale = await getRequestLocale();
     // Rate limiting
     const ip = getClientIp(request.headers);
-    if (!(await checkRateLimit(`saju:${ip}`, 10, 60_000))) return rateLimitResponse();
-
-    const locale = await getRequestLocale();
+    if (!(await checkRateLimit(`saju:${ip}`, 10, 60_000))) return rateLimitResponse(locale);
     const rawBody = await request.json();
 
     // Zod 입력 검증
@@ -165,7 +165,7 @@ export async function POST(request: NextRequest) {
           }
         } catch (e) {
           console.error("사주 리딩 생성 실패:", e instanceof Error ? e.message : String(e));
-          controller.enqueue(encoder.encode(`data: ${JSON.stringify({ error: "리딩 생성 중 오류가 발생했습니다." })}\n\n`));
+          controller.enqueue(encoder.encode(`data: ${JSON.stringify({ error: translate("api.reading-error", locale) })}\n\n`));
         }
         controller.close();
       },

--- a/src/app/api/shinjeom/message/route.ts
+++ b/src/app/api/shinjeom/message/route.ts
@@ -34,11 +34,10 @@ async function fetchMemoryPrompt(characterId: string, locale: string): Promise<s
 
 export async function POST(request: NextRequest) {
   try {
+    const locale = await getRequestLocale();
     // Rate limiting
     const ip = getClientIp(request.headers);
-    if (!(await checkRateLimit(`shinjeom:${ip}`, 20, 60_000))) return rateLimitResponse();
-
-    const locale = await getRequestLocale();
+    if (!(await checkRateLimit(`shinjeom:${ip}`, 20, 60_000))) return rateLimitResponse(locale);
     const rawBody = await request.json();
 
     // Zod 입력 검증 (chatHistory 100개 상한으로 토큰 과소비 방어)

--- a/src/app/api/tarot/reading/route.ts
+++ b/src/app/api/tarot/reading/route.ts
@@ -15,6 +15,7 @@ import { checkRateLimit, rateLimitResponse } from "@/lib/rate-limit"
 import { getClientIp, jsonError, SSE_HEADERS } from "@/lib/request-utils";
 import { saveTarotReading } from "@/lib/db/reading-saver";
 import { getRequestLocale } from "@/i18n/server-locale";
+import { t as translate } from "@/i18n/translations";
 
 const tarotService = new TarotService();
 const grokProvider = new FallbackProvider();
@@ -53,11 +54,10 @@ async function fetchMemoryPrompt(characterId: string, locale: string): Promise<s
 
 export async function POST(request: NextRequest) {
   try {
+    const locale = await getRequestLocale();
     // Rate limiting
     const ip = getClientIp(request.headers);
-    if (!(await checkRateLimit(`tarot:${ip}`, 10, 60_000))) return rateLimitResponse();
-
-    const locale = await getRequestLocale();
+    if (!(await checkRateLimit(`tarot:${ip}`, 10, 60_000))) return rateLimitResponse(locale);
     const rawBody = await request.json();
 
     // Zod 입력 검증
@@ -137,7 +137,7 @@ export async function POST(request: NextRequest) {
           }
         } catch (e) {
           console.error("리딩 생성 실패:", e instanceof Error ? e.message : String(e));
-          controller.enqueue(encoder.encode(`data: ${JSON.stringify({ error: "리딩 생성 중 오류가 발생했습니다." })}\n\n`));
+          controller.enqueue(encoder.encode(`data: ${JSON.stringify({ error: translate("api.reading-error", locale) })}\n\n`));
         }
         controller.close();
       },

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -31,8 +31,8 @@ export async function generateMetadata(): Promise<Metadata> {
   const locale: Locale = isLocale(cookieLocale) ? cookieLocale : DEFAULT_LOCALE;
   const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? "https://arcanainsight-production.up.railway.app";
   return {
-    title: "ArcanaInsight — 타로 & 운세 상담",
-    description: "애니메이션 캐릭터와 함께하는 타로 리딩, 사주, 신점 종합 운세 플랫폼",
+    title: `ArcanaInsight — ${translate("home.hero.title", locale)}`,
+    description: translate("meta.site-description", locale),
     alternates: {
       canonical: siteUrl,
       languages: {

--- a/src/components/card/CardBack.tsx
+++ b/src/components/card/CardBack.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import Image from "next/image";
 import { getCardBackUrl } from "@/lib/storage";
+import { useT } from "@/i18n/useT";
 
 interface CardBackProps {
   readonly size?: "sm" | "md" | "lg";
@@ -19,6 +20,7 @@ const sizeDimensions = {
 };
 
 export function CardBack({ size = "md", width, height, className = "", skinId }: CardBackProps) {
+  const { t } = useT();
   const [imageError, setImageError] = useState(false);
   const preset = sizeDimensions[size];
   const w = width ?? preset.w;
@@ -36,7 +38,7 @@ export function CardBack({ size = "md", width, height, className = "", skinId }:
       <div className={`relative rounded-lg overflow-hidden ${className}`} style={{ width: w, height: h }}>
         <Image
           src={getCardBackUrl(skinId)}
-          alt="카드 뒷면"
+          alt={t("common.card.back-alt")}
           fill
           sizes={`${Math.max(w, h)}px`}
           unoptimized

--- a/src/components/chat/DialogueBox.tsx
+++ b/src/components/chat/DialogueBox.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useRef } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { ChatMessage } from "@/types/session";
+import { useT } from "@/i18n/useT";
 
 interface DialogueBoxProps {
   readonly messages: ChatMessage[];
@@ -11,7 +12,9 @@ interface DialogueBoxProps {
   readonly className?: string;
 }
 
-export function DialogueBox({ messages, characterName = "아르카나", isTyping = false, className = "" }: DialogueBoxProps) {
+export function DialogueBox({ messages, characterName, isTyping = false, className = "" }: DialogueBoxProps) {
+  const { t } = useT();
+  const displayName = characterName ?? t("chat.default-character-name");
   const lastMessage = messages.filter((m) => m.role === "character").at(-1);
   const [displayedText, setDisplayedText] = useState("");
   const [isComplete, setIsComplete] = useState(false);
@@ -49,7 +52,7 @@ export function DialogueBox({ messages, characterName = "아르카나", isTyping
       <div className="relative z-10 p-3 md:p-5">
         <div className="flex items-center gap-2 mb-2">
           <div className="px-3 py-0.5 bg-gradient-to-r from-arcana-purple to-arcana-indigo rounded-full">
-            <span className="text-white text-xs font-serif font-bold">{characterName}</span>
+            <span className="text-white text-xs font-serif font-bold">{displayName}</span>
           </div>
           <div className="flex-1 h-px bg-gradient-to-r from-arcana-purple/40 to-transparent" />
         </div>
@@ -90,7 +93,7 @@ export function DialogueBox({ messages, characterName = "아르카나", isTyping
                 )}
               </motion.p>
             ) : (
-              <p className="text-arcana-muted text-sm italic">카드를 선택하면 상담이 시작됩니다...</p>
+              <p className="text-arcana-muted text-sm italic">{t("chat.empty-prompt")}</p>
             )}
           </AnimatePresence>
         </div>

--- a/src/components/common/PrivacyConsentModal.tsx
+++ b/src/components/common/PrivacyConsentModal.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import { motion, AnimatePresence } from "framer-motion";
+import { useT } from "@/i18n/useT";
 
 interface PrivacyConsentModalProps {
   readonly isOpen: boolean;
@@ -10,6 +11,7 @@ interface PrivacyConsentModalProps {
 }
 
 export function PrivacyConsentModal({ isOpen, onAgree, onCancel }: PrivacyConsentModalProps) {
+  const { t } = useT();
   return (
     <AnimatePresence>
       {isOpen && (
@@ -19,7 +21,7 @@ export function PrivacyConsentModal({ isOpen, onAgree, onCancel }: PrivacyConsen
           exit={{ opacity: 0 }}
           className="fixed inset-0 z-50 flex items-center justify-center px-4"
         >
-          <button type="button" aria-label="모달 닫기" onClick={onCancel} className="absolute inset-0 bg-black/60 cursor-default" />
+          <button type="button" aria-label={t("common.modal.close-aria")} onClick={onCancel} className="absolute inset-0 bg-black/60 cursor-default" />
           <motion.div
             initial={{ scale: 0.9, opacity: 0 }}
             animate={{ scale: 1, opacity: 1 }}

--- a/src/components/tarot/ShuffleCeremony.tsx
+++ b/src/components/tarot/ShuffleCeremony.tsx
@@ -4,6 +4,8 @@ import { useEffect, useRef } from "react";
 import { useLocaleStore } from "@/hooks/useLocaleStore";
 import { getWaitingLinesData } from "@/data/characters/waiting-lines-i18n";
 import { hexToRgbComponents } from "@/lib/color-utils";
+import { t as translate } from "@/i18n/translations";
+import { useT } from "@/i18n/useT";
 
 interface ShuffleCeremonyProps {
   readonly characterId: string;
@@ -46,6 +48,7 @@ function drawCard(
 }
 
 export function ShuffleCeremony({ characterId, onComplete, primaryColor = "#8b5cf6" }: ShuffleCeremonyProps) {
+  const { t } = useT();
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const calledRef = useRef(false);
   const doneRef = useRef(false);
@@ -79,8 +82,9 @@ export function ShuffleCeremony({ characterId, onComplete, primaryColor = "#8b5c
     const observer = new ResizeObserver(setSize);
     observer.observe(canvas);
 
-    const wl = getWaitingLinesData(useLocaleStore.getState().locale);
-    const charText = wl.shuffleCeremonyText[characterId] ?? "카드를 선택하세요";
+    const locale = useLocaleStore.getState().locale;
+    const wl = getWaitingLinesData(locale);
+    const charText = wl.shuffleCeremonyText[characterId] ?? translate("tarot.session.shuffle.fallback-text", locale);
     const textChars = [...charText];
     const rgb = hexToRgbComponents(primaryColor);
     let rafId: number;
@@ -185,7 +189,7 @@ export function ShuffleCeremony({ characterId, onComplete, primaryColor = "#8b5c
       onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") doneRef.current = true; }}
       role="button"
       tabIndex={0}
-      aria-label="카드 셔플 의식 스킵"
+      aria-label={t("tarot.session.shuffle.skip-aria")}
     >
       <canvas ref={canvasRef} className="w-full h-full" />
     </div>

--- a/src/i18n/translations/en/index.ts
+++ b/src/i18n/translations/en/index.ts
@@ -173,6 +173,8 @@ export const en: Partial<SharedKeys> = {
     "session.btn.new-session": "New session",
     "session.btn.share": "Share result",
     "session.error.reading": "Something went wrong with the reading",
+    "session.shuffle.fallback-text": "Choose your cards",
+    "session.shuffle.skip-aria": "Skip card shuffle ceremony",
   },
   saju: {
     "result.title": "Saju Analysis Result",
@@ -282,6 +284,17 @@ export const en: Partial<SharedKeys> = {
   share: {
     "result-button-default": "Share result",
     "copied-button": "Link copied!",
+  },
+  chat: {
+    "default-character-name": "Arcana",
+    "empty-prompt": "Choose your cards to begin the consultation...",
+  },
+  api: {
+    "rate-limit-error": "Too many requests. Please try again shortly.",
+    "reading-error": "An error occurred while generating the reading.",
+  },
+  meta: {
+    "site-description": "Tarot, Saju, and Shinjeom fortune-telling platform with animated AI characters",
   },
   shinjeom: {
     "result.title": "Shinjeom Result",

--- a/src/i18n/translations/ja/index.ts
+++ b/src/i18n/translations/ja/index.ts
@@ -175,6 +175,8 @@ export const ja: Partial<SharedKeys> = {
     "session.btn.new-session": "新しい相談",
     "session.btn.share": "結果を共有",
     "session.error.reading": "解釈に問題が発生しました",
+    "session.shuffle.fallback-text": "カードを選んでください",
+    "session.shuffle.skip-aria": "カードシャッフル儀式をスキップ",
   },
   saju: {
     "result.title": "四柱分析結果",
@@ -284,6 +286,17 @@ export const ja: Partial<SharedKeys> = {
   share: {
     "result-button-default": "結果を共有",
     "copied-button": "リンクコピー済み！",
+  },
+  chat: {
+    "default-character-name": "アルカナ",
+    "empty-prompt": "カードを選ぶと相談が始まります...",
+  },
+  api: {
+    "rate-limit-error": "リクエストが多すぎます。しばらくしてから再度お試しください。",
+    "reading-error": "鑑定の生成中にエラーが発生しました。",
+  },
+  meta: {
+    "site-description": "アニメーションキャラクターと楽しむタロット・四柱推命・神占の総合占いプラットフォーム",
   },
   shinjeom: {
     "result.title": "神占結果",

--- a/src/i18n/translations/ko/index.ts
+++ b/src/i18n/translations/ko/index.ts
@@ -168,6 +168,8 @@ export const ko: SharedKeys = {
     "session.btn.new-session": "새로운 상담",
     "session.btn.share": "결과 공유하기",
     "session.error.reading": "해석에 문제가 발생했어요",
+    "session.shuffle.fallback-text": "카드를 선택하세요",
+    "session.shuffle.skip-aria": "카드 셔플 의식 스킵",
   },
   saju: {
     "result.title": "사주 분석 결과",
@@ -277,6 +279,17 @@ export const ko: SharedKeys = {
   share: {
     "result-button-default": "결과 공유하기",
     "copied-button": "링크 복사됨!",
+  },
+  chat: {
+    "default-character-name": "아르카나",
+    "empty-prompt": "카드를 선택하면 상담이 시작됩니다...",
+  },
+  api: {
+    "rate-limit-error": "요청이 너무 많습니다. 잠시 후 다시 시도해주세요.",
+    "reading-error": "리딩 생성 중 오류가 발생했습니다.",
+  },
+  meta: {
+    "site-description": "애니메이션 캐릭터와 함께하는 타로 리딩, 사주, 신점 종합 운세 플랫폼",
   },
   shinjeom: {
     "result.title": "신점 결과",

--- a/src/i18n/translations/shared/keys.ts
+++ b/src/i18n/translations/shared/keys.ts
@@ -176,6 +176,8 @@ export interface SharedKeys {
     "session.btn.new-session": string;
     "session.btn.share": string;
     "session.error.reading": string;
+    "session.shuffle.fallback-text": string;
+    "session.shuffle.skip-aria": string;
   };
   saju: {
     "result.title": string;
@@ -289,6 +291,17 @@ export interface SharedKeys {
   share: {
     "result-button-default": string;
     "copied-button": string;
+  };
+  chat: {
+    "default-character-name": string;
+    "empty-prompt": string;
+  };
+  api: {
+    "rate-limit-error": string;
+    "reading-error": string;
+  };
+  meta: {
+    "site-description": string;
   };
   shinjeom: {
     "result.title": string;

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -1,4 +1,6 @@
 import { getUpstashRedisRestUrl, getUpstashRedisRestToken } from "@/lib/env";
+import { t as translate } from "@/i18n/translations";
+import { DEFAULT_LOCALE, type Locale } from "@/i18n/config";
 
 interface RateLimitEntry {
   count: number;
@@ -56,9 +58,9 @@ export async function checkRateLimit(key: string, limit: number, windowMs: numbe
   return checkUpstash(key, limit, windowMs);
 }
 
-export function rateLimitResponse(): Response {
+export function rateLimitResponse(locale: Locale = DEFAULT_LOCALE): Response {
   return new Response(
-    JSON.stringify({ error: "요청이 너무 많습니다. 잠시 후 다시 시도해주세요." }),
+    JSON.stringify({ error: translate("api.rate-limit-error", locale) }),
     { status: 429, headers: { "Content-Type": "application/json", "Retry-After": "60" } },
   );
 }


### PR DESCRIPTION
# 회귀 — i18n 정적 분석 후속 마무리
PR 9 머지 후 잔여 사용자 노출 한국어 ~14 라인 정리.
서버 측 SSE/HTTP 에러 응답·SEO meta·작은 클라이언트 컴포넌트.

# 변경 범위
1. **작은 클라이언트 컴포넌트** (4 파일)
   - ShuffleCeremony.tsx: aria-label "카드 셔플 의식 스킵" + fallback "카드를 선택하세요"
   - DialogueBox.tsx: default characterName "아르카나" + empty fallback
   - CardBack.tsx: alt="카드 뒷면"
   - PrivacyConsentModal.tsx: aria-label "모달 닫기"
2. **API 라우트 에러 메시지** (5 파일)
   - rate-limit.ts: rateLimitResponse(locale) 시그니처 변경 (default = ko 하위 호환)
   - tarot/saju/daily-card/shinjeom 라우트: locale 결정 → rateLimitResponse(locale) + SSE 에러 translate("api.reading-error", locale)
   - locale 결정 순서를 rate-limit 직전으로 이동
3. **SEO meta** (1 파일)
   - layout.tsx generateMetadata: title/description → translate("home.hero.title"/"meta.site-description", locale)
   - hreflang alternates 그대로 유지

# 사전 namespace 확장 (+8키)
- common.* +3: back-arrow / modal.close-aria / card.back-alt (PR 9 추가했지만 이번에 실 적용)
- tarot.session.shuffle.* +2: fallback-text / skip-aria
- chat.* +2: default-character-name / empty-prompt
- api.* 신규: rate-limit-error / reading-error
- meta.* 신규: site-description
- ko/en/ja 사전 모두 채움 — 278 → **286/286/286** drift 0

# 검증
- pnpm type-check / lint (warnings 0) / test (793 passed) / i18n:check (drift 0) / build 모두 통과

# i18n 마무리 (PR 5~10 통합)
- 사용자 노출 한국어 하드코딩 사실상 0
- AI 프롬프트 한국어(prompt-builder TOPIC_LABELS, "정방향/역방향" 등)는 LLM 이해 보조용 — 변경 불필요로 판정
- backend fallback (tarot-service.ts overallReading fallback)은 거의 도달 안 하는 경로 + UI에서 별도 처리 — 후속 검토 가능