### PR TITLE
fix(i18n): 화면 노출 한국어 회귀 3건 수정 (PR 11)

### DIFF
--- a/src/__tests__/api/daily-card.test.ts
+++ b/src/__tests__/api/daily-card.test.ts
@@ -105,7 +105,7 @@ describe("POST /api/daily-card", () => {
     const res = await POST(makePostRequest(VALID_BODY));
     expect(res.status).toBe(500);
     const body = await res.json();
-    expect(body.error).toMatch(/요청이 많아/);
+    expect(body.error).toMatch(/요청이 너무 많습니다/);
   });
 
   it("isReversed 결정 — seed % 3 === 0 시 역방향", async () => {

--- a/src/app/api/daily-card/route.ts
+++ b/src/app/api/daily-card/route.ts
@@ -7,6 +7,8 @@ import { DailyCardSchema } from "@/lib/validation/api-schemas";
 import { checkRateLimit, rateLimitResponse } from "@/lib/rate-limit";
 import { getClientIp } from "@/lib/request-utils";
 import { getRequestLocale } from "@/i18n/server-locale";
+import { t as translate } from "@/i18n/translations";
+import { DEFAULT_LOCALE, isLocale, type Locale } from "@/i18n/config";
 
 const grokProvider = new FallbackProvider();
 const deckManager = new DeckManager();
@@ -23,8 +25,10 @@ function hashDateSeed(date: string, characterId: string): number {
 }
 
 export async function POST(request: NextRequest) {
+  let locale: Locale = DEFAULT_LOCALE;
   try {
-    const locale = await getRequestLocale();
+    const reqLocale = await getRequestLocale();
+    if (isLocale(reqLocale)) locale = reqLocale;
     const ip = getClientIp(request.headers);
     if (!(await checkRateLimit(`daily-card:${ip}`, 30, 60_000))) return rateLimitResponse(locale);
 
@@ -95,10 +99,10 @@ export async function POST(request: NextRequest) {
     const errMsg = error instanceof Error ? error.message : String(error);
     console.error("Daily card error:", errMsg);
     const userMessage = errMsg.includes("API_KEY") || errMsg.includes("auth")
-      ? "AI 서비스 설정에 문제가 있습니다."
+      ? translate("api.ai-config-error", locale)
       : errMsg.includes("rate limit") || errMsg.includes("429")
-      ? "요청이 많아 잠시 후 다시 시도해주세요."
-      : "일일 카드 생성에 실패했습니다. 잠시 후 다시 시도해주세요.";
+      ? translate("api.rate-limit-error", locale)
+      : translate("api.daily-card-error", locale);
     return NextResponse.json({ error: userMessage }, { status: 500 });
   }
 }

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -3,13 +3,14 @@
 import { useState, useEffect, useCallback } from "react";
 import Image from "next/image";
 import Link from "next/link";
-import { useThemeStore, themes, ThemeId } from "@/hooks/useTheme";
+import { useThemeStore, themes, getThemeName, ThemeId } from "@/hooks/useTheme";
 import { useSkinStore } from "@/hooks/useSkinStore";
 import { useGenderStore } from "@/hooks/useGenderStore";
 import { useReducedMotionStore } from "@/hooks/useReducedMotionStore";
-import { cardSkins } from "@/data/skins";
+import { cardSkins, getSkinName, getSkinDescription } from "@/data/skins";
 import { GenderFilter } from "@/types/character";
 import { useT } from "@/i18n/useT";
+import { useLocaleStore } from "@/hooks/useLocaleStore";
 
 function SaveToast({ visible, text }: { visible: boolean; text: string }) {
   return (
@@ -27,6 +28,7 @@ function SaveToast({ visible, text }: { visible: boolean; text: string }) {
 
 export default function SettingsPage() {
   const { t } = useT();
+  const locale = useLocaleStore((s) => s.locale);
   const { mode, activeTheme, setMode } = useThemeStore();
   const { selectedSkinId, setSkin } = useSkinStore();
   const { genderFilter, setGenderFilter } = useGenderStore();
@@ -119,7 +121,7 @@ export default function SettingsPage() {
           {/* 테마 */}
           <section className="bg-arcana-card/70 backdrop-blur-sm border border-arcana-border rounded-2xl p-5">
             <h2 className="font-sans font-bold text-base md:text-lg text-arcana-text mb-1">{t("settings.section.theme")}</h2>
-            <p className="text-arcana-muted text-xs mb-4">{`${t("settings.theme.current")} ${mode === "auto" ? `${t("settings.theme.auto-label")} (${themes[activeTheme].nameKo})` : themes[activeTheme].nameKo}`}</p>
+            <p className="text-arcana-muted text-xs mb-4">{`${t("settings.theme.current")} ${mode === "auto" ? `${t("settings.theme.auto-label")} (${getThemeName(themes[activeTheme], locale)})` : getThemeName(themes[activeTheme], locale)}`}</p>
             <div className="grid grid-cols-3 sm:grid-cols-4 gap-2">
               {themeOptions.map((t) => (
                 <button
@@ -141,7 +143,11 @@ export default function SettingsPage() {
           {/* 카드 스킨 */}
           <section className="bg-arcana-card/70 backdrop-blur-sm border border-arcana-border rounded-2xl p-5">
             <h2 className="font-sans font-bold text-base md:text-lg text-arcana-text mb-1">{t("settings.section.card-skin")}</h2>
-            <p className="text-arcana-muted text-xs mb-4">{`${t("settings.theme.current")} ${cardSkins.find((s) => s.id === selectedSkinId)?.nameKo || "기본"}`}</p>
+            <p className="text-arcana-muted text-xs mb-4">{(() => {
+              const cur = cardSkins.find((s) => s.id === selectedSkinId);
+              const skinLabel = cur ? getSkinName(cur, locale) : t("settings.theme.auto");
+              return `${t("settings.theme.current")} ${skinLabel}`;
+            })()}</p>
             <div className="grid grid-cols-2 md:grid-cols-3 gap-3">
               {cardSkins.map((skin) => (
                 <button
@@ -158,9 +164,9 @@ export default function SettingsPage() {
                       className="w-4 h-4 rounded-full border border-white/20"
                       style={{ background: `linear-gradient(135deg, ${skin.palette.primary}, ${skin.palette.secondary})` }}
                     />
-                    <span className="font-sans font-bold text-xs text-arcana-text">{skin.nameKo}</span>
+                    <span className="font-sans font-bold text-xs text-arcana-text">{getSkinName(skin, locale)}</span>
                   </div>
-                  <p className="text-arcana-muted text-xs leading-relaxed">{skin.description}</p>
+                  <p className="text-arcana-muted text-xs leading-relaxed">{getSkinDescription(skin, locale)}</p>
                 </button>
               ))}
             </div>

--- a/src/app/tarot/result/[id]/page.tsx
+++ b/src/app/tarot/result/[id]/page.tsx
@@ -3,7 +3,7 @@ import Image from "next/image";
 import { getAdminDb } from "@/lib/db";
 import { DeckManager } from "@/services/tarot/deck-manager";
 import { cleanReadingText } from "@/services/core/text-cleaner";
-import { spreads } from "@/data/spreads";
+import { spreads, getSpreadName } from "@/data/spreads";
 import { SpreadType } from "@/types/session";
 import { ResultShareButton } from "@/components/common/ResultShareButton";
 import { ResultCardFace } from "./ResultCardFace";
@@ -147,7 +147,7 @@ export default async function ResultPage({ params }: { params: Promise<{ id: str
           <a href="/tarot" className="px-8 py-3 rounded-full bg-gradient-to-r from-arcana-purple to-arcana-indigo text-white font-serif font-bold text-sm hover:opacity-90 transition-opacity shadow-lg shadow-arcana-purple/20">
             {t("tarot.result.cta", locale)}
           </a>
-          <ResultShareButton service="tarot" shareToken={id} spreadName={spread?.nameKo ?? "타로"} />
+          <ResultShareButton service="tarot" shareToken={id} spreadName={spread ? getSpreadName(spread, locale) : t("header.nav.tarot", locale)} />
         </div>
     </ResultPageShell>
   );

--- a/src/components/skin/SkinSelector.tsx
+++ b/src/components/skin/SkinSelector.tsx
@@ -4,7 +4,10 @@ import Image from "next/image";
 import { useState } from "react";
 import { motion } from "framer-motion";
 import type { CardSkin } from "@/data/skins";
+import { getSkinName, getSkinDescription } from "@/data/skins";
 import { getCardThumbnailUrl } from "@/lib/storage";
+import { useLocaleStore } from "@/hooks/useLocaleStore";
+import { useT } from "@/i18n/useT";
 
 interface SkinSelectorProps {
   readonly skin: CardSkin;
@@ -20,6 +23,11 @@ const FAN_CONFIGS = [
 ];
 
 export function SkinSelector({ skin, isSelected, onSelect }: SkinSelectorProps) {
+  const locale = useLocaleStore((s) => s.locale);
+  const { t } = useT();
+  const skinName = getSkinName(skin, locale);
+  const skinDesc = getSkinDescription(skin, locale);
+  const previewAlt = t("common.skin.preview-alt").replace("{name}", skinName);
   // 썸네일 이미지 에러 상태 (카드 ID별)
   const [imgErrors, setImgErrors] = useState<Record<string, boolean>>({});
 
@@ -86,7 +94,7 @@ export function SkinSelector({ skin, isSelected, onSelect }: SkinSelectorProps) 
               ) : (
                 <Image
                   src={thumbUrl}
-                  alt={`${skin.nameKo} 카드 미리보기`}
+                  alt={previewAlt}
                   width={64}
                   height={100}
                   unoptimized
@@ -107,9 +115,9 @@ export function SkinSelector({ skin, isSelected, onSelect }: SkinSelectorProps) 
             className="w-3 h-3 rounded-full flex-shrink-0 ring-1 ring-white/10"
             style={{ background: skin.palette.primary }}
           />
-          <h3 className="font-serif font-bold text-sm text-arcana-text truncate">{skin.nameKo}</h3>
+          <h3 className="font-serif font-bold text-sm text-arcana-text truncate">{skinName}</h3>
         </div>
-        <p className="text-arcana-muted text-xs leading-relaxed line-clamp-2">{skin.description}</p>
+        <p className="text-arcana-muted text-xs leading-relaxed line-clamp-2">{skinDesc}</p>
       </div>
     </motion.button>
   );

--- a/src/data/skins/index.ts
+++ b/src/data/skins/index.ts
@@ -2,7 +2,12 @@ export interface CardSkin {
   id: string;
   name: string;
   nameKo: string;
+  /** 일본어 카드 스킨명 (옵션 — 미지정 시 nameKo 사용). */
+  nameJa?: string;
+  /** 한국어 설명 (기본). 영어/일본어는 별도 필드로. */
   description: string;
+  descriptionEn?: string;
+  descriptionJa?: string;
   palette: {
     primary: string;
     secondary: string;
@@ -16,7 +21,10 @@ export const cardSkins: CardSkin[] = [
     id: "gold-luxury",
     name: "Gold Luxury",
     nameKo: "골드 럭셔리",
+    nameJa: "ゴールドラグジュアリー",
     description: "미드나잇 블루와 금박의 최고급 아르데코 타로",
+    descriptionEn: "Midnight blue and gold leaf — premium Art Deco tarot",
+    descriptionJa: "ミッドナイトブルーと金箔の最高級アール・デコ・タロット",
     palette: {
       primary: "#d4af37",
       secondary: "#1a1a3e",
@@ -28,7 +36,10 @@ export const cardSkins: CardSkin[] = [
     id: "dark-gothic",
     name: "Dark Gothic",
     nameKo: "다크 고딕",
+    nameJa: "ダークゴシック",
     description: "핏빛 악센트의 어둡고 강렬한 중세 오컬트",
+    descriptionEn: "Blood-red accents in a dark, intense medieval occult style",
+    descriptionJa: "血の赤を効かせた闇の中世オカルト",
     palette: {
       primary: "#8b3030",
       secondary: "#1a0a14",
@@ -40,7 +51,10 @@ export const cardSkins: CardSkin[] = [
     id: "celestial-mystic",
     name: "Celestial Mystic",
     nameKo: "셀레스티얼 미스틱",
+    nameJa: "セレスティアル・ミスティック",
     description: "별자리와 달빛의 고요한 천상 세계",
+    descriptionEn: "A serene celestial realm of constellations and moonlight",
+    descriptionJa: "星座と月光の静謐な天上の世界",
     palette: {
       primary: "#6880cc",
       secondary: "#162454",
@@ -52,7 +66,10 @@ export const cardSkins: CardSkin[] = [
     id: "pastel-dream",
     name: "Pastel Dream",
     nameKo: "파스텔 드림",
+    nameJa: "パステルドリーム",
     description: "수채화처럼 번지는 몽환적 라벤더 세계",
+    descriptionEn: "A dreamy lavender world that bleeds like watercolor",
+    descriptionJa: "水彩画のように滲む夢幻のラベンダーワールド",
     palette: {
       primary: "#b898e0",
       secondary: "#efe4ff",
@@ -64,7 +81,10 @@ export const cardSkins: CardSkin[] = [
     id: "neon-cyberpunk",
     name: "Neon Cyberpunk",
     nameKo: "네온 사이버펑크",
+    nameJa: "ネオンサイバーパンク",
     description: "홀로그램 회로와 네온의 미래적 디지털 오라클",
+    descriptionEn: "A futuristic digital oracle of holographic circuits and neon",
+    descriptionJa: "ホログラム回路とネオンが織りなす未来的デジタル神託",
     palette: {
       primary: "#00ffff",
       secondary: "#ff00ff",
@@ -76,7 +96,10 @@ export const cardSkins: CardSkin[] = [
     id: "emerald-enchant",
     name: "Emerald Enchant",
     nameKo: "에메랄드 인챈트",
+    nameJa: "エメラルドエンチャント",
     description: "에메랄드 보석과 숲의 자연 마법",
+    descriptionEn: "Natural magic of emerald gems and forest depths",
+    descriptionJa: "エメラルドの宝石と森の自然魔法",
     palette: {
       primary: "#3a9a70",
       secondary: "#1a5040",
@@ -90,4 +113,20 @@ export const DEFAULT_SKIN_ID = "gold-luxury";
 
 export function getSkinById(id: string): CardSkin | undefined {
   return cardSkins.find((s) => s.id === id);
+}
+
+// ─── locale 헬퍼 ─────────────────────────────────────────────────────────────
+
+/** 카드 스킨 이름 — locale별 (en: name 필드 / ja: nameJa / ko: nameKo). */
+export function getSkinName(skin: CardSkin, locale: string): string {
+  if (locale === "en") return skin.name;
+  if (locale === "ja" && skin.nameJa) return skin.nameJa;
+  return skin.nameKo;
+}
+
+/** 카드 스킨 설명 — locale별. en/ja 미설정 시 ko description 사용. */
+export function getSkinDescription(skin: CardSkin, locale: string): string {
+  if (locale === "en" && skin.descriptionEn) return skin.descriptionEn;
+  if (locale === "ja" && skin.descriptionJa) return skin.descriptionJa;
+  return skin.description;
 }

--- a/src/i18n/translations/en/index.ts
+++ b/src/i18n/translations/en/index.ts
@@ -19,6 +19,7 @@ export const en: Partial<SharedKeys> = {
     "back-arrow": "← Back",
     "modal.close-aria": "Close modal",
     "card.back-alt": "Card back",
+    "skin.preview-alt": "{name} card preview",
   },
   header: {
     "logo.alt": "ArcanaInsight",
@@ -292,6 +293,8 @@ export const en: Partial<SharedKeys> = {
   api: {
     "rate-limit-error": "Too many requests. Please try again shortly.",
     "reading-error": "An error occurred while generating the reading.",
+    "ai-config-error": "There is a problem with the AI service configuration.",
+    "daily-card-error": "Failed to generate the daily card. Please try again shortly.",
   },
   meta: {
     "site-description": "Tarot, Saju, and Shinjeom fortune-telling platform with animated AI characters",

--- a/src/i18n/translations/ja/index.ts
+++ b/src/i18n/translations/ja/index.ts
@@ -128,6 +128,7 @@ export const ja: Partial<SharedKeys> = {
     "back-arrow": "← 戻る",
     "modal.close-aria": "モーダルを閉じる",
     "card.back-alt": "カード裏面",
+    "skin.preview-alt": "{name} カードプレビュー",
   },
   locale: {
     "modal.title": "言語を選択してください",
@@ -294,6 +295,8 @@ export const ja: Partial<SharedKeys> = {
   api: {
     "rate-limit-error": "リクエストが多すぎます。しばらくしてから再度お試しください。",
     "reading-error": "鑑定の生成中にエラーが発生しました。",
+    "ai-config-error": "AIサービスの設定に問題があります。",
+    "daily-card-error": "デイリーカードの生成に失敗しました。しばらくしてから再度お試しください。",
   },
   meta: {
     "site-description": "アニメーションキャラクターと楽しむタロット・四柱推命・神占の総合占いプラットフォーム",

--- a/src/i18n/translations/ko/index.ts
+++ b/src/i18n/translations/ko/index.ts
@@ -14,6 +14,7 @@ export const ko: SharedKeys = {
     "back-arrow": "← 뒤로",
     "modal.close-aria": "모달 닫기",
     "card.back-alt": "카드 뒷면",
+    "skin.preview-alt": "{name} 카드 미리보기",
   },
   header: {
     "logo.alt": "ArcanaInsight",
@@ -287,6 +288,8 @@ export const ko: SharedKeys = {
   api: {
     "rate-limit-error": "요청이 너무 많습니다. 잠시 후 다시 시도해주세요.",
     "reading-error": "리딩 생성 중 오류가 발생했습니다.",
+    "ai-config-error": "AI 서비스 설정에 문제가 있습니다.",
+    "daily-card-error": "일일 카드 생성에 실패했습니다. 잠시 후 다시 시도해주세요.",
   },
   meta: {
     "site-description": "애니메이션 캐릭터와 함께하는 타로 리딩, 사주, 신점 종합 운세 플랫폼",

--- a/src/i18n/translations/shared/keys.ts
+++ b/src/i18n/translations/shared/keys.ts
@@ -17,6 +17,8 @@ export interface SharedKeys {
     "back-arrow": string;
     "modal.close-aria": string;
     "card.back-alt": string;
+    // PR 11
+    "skin.preview-alt": string;
   };
   header: {
     "logo.alt": string;
@@ -299,6 +301,8 @@ export interface SharedKeys {
   api: {
     "rate-limit-error": string;
     "reading-error": string;
+    "ai-config-error": string;
+    "daily-card-error": string;
   };
   meta: {
     "site-description": string;


### PR DESCRIPTION
# 회귀 — 사용자 검토 요청에 따른 정밀 스캔
사용자 의도: 외부 번역가 의뢰 없음 + 화면 문구는 PR 5~10에서 작업했으므로
잔여 한국어가 노출되면 버그. JSX 렌더링 텍스트·alt·title·placeholder 정밀 grep으로 3건의 영어/일본어 사용자 노출 한국어 잔여(=버그) 발견.

# 버그 1: tarot/result/[id]/page.tsx:150 spreadName fallback
- 변경 전: spread?.nameKo ?? "타로"
- 변경 후: spread ? getSpreadName(spread, locale) : t("header.nav.tarot", locale)
- 영향: 영어/일본어 사용자가 타로 결과 페이지에서 공유 버튼 텍스트에 "원카드", "켈틱 크로스" 같은 한국어 노출

# 버그 2: settings/page.tsx + SkinSelector.tsx — 카드 스킨 다국어 fallback 누락
- 변경 전: skin.nameKo / skin.description (한국어 고정)
- 변경 후: getSkinName(skin, locale) / getSkinDescription(skin, locale)
- src/data/skins/index.ts 확장: · CardSkin에 nameJa, descriptionEn, descriptionJa 옵션 필드 · 6개 스킨에 ja/en 라벨·설명 인라인 (캐릭터·스프레드 패턴 동일) · getSkinName/getSkinDescription 헬퍼 export
- SkinSelector 카드 미리보기 alt도 다국어화 (skin.preview-alt 사전 키)
- settings 테마 표시도 getThemeName(themes[activeTheme], locale) 적용

# 버그 3: daily-card/route.ts catch 블록 사용자 노출 에러 메시지 한국어 고정
- 변경 전: "AI 서비스 설정에 문제가 있습니다." / "요청이 많아..." / "일일 카드 생성에 실패..."
- 변경 후: translate("api.ai-config-error" / "api.rate-limit-error" / "api.daily-card-error", locale)
- locale 변수를 try 밖 outer scope로 이동 → catch에서도 접근 가능
- daily-card.test.ts 기대 메시지 업데이트

# 사전 namespace +3키
- common.skin.preview-alt: "{name} 카드 미리보기" / "{name} card preview" / "{name} カードプレビュー"
- api.ai-config-error / api.daily-card-error
- 사전 286 → **289/289/289** drift 0

# 검증
- pnpm type-check / lint (warnings 0) / test (793 passed) / i18n:check (drift 0) / build 모두 통과