### PR TITLE
fix(i18n): 런타임 한국어 잔여 4건 + AI 응답 locale 강제 강화 (PR 12)

### DIFF
--- a/src/__tests__/api/locale-wiring.test.ts
+++ b/src/__tests__/api/locale-wiring.test.ts
@@ -152,8 +152,9 @@ describe("locale wiring — prompt-builder language instruction", () => {
 
   it("locale='en' → English only 지시문 + JSON 키 영어 고정 명시", () => {
     const result = buildCharacterHeader(character!, undefined, "en");
-    expect(result).toContain("natural English only");
+    expect(result).toContain("natural English");
     expect(result).toContain("EXACT English JSON keys");
+    expect(result).toContain("STRICTLY FORBIDDEN");
     expect(result).not.toContain("한국어로만");
   });
 
@@ -163,9 +164,11 @@ describe("locale wiring — prompt-builder language instruction", () => {
     expect(result).toContain("英語のまま");
   });
 
-  it("buildSystemPrompt locale='en' → English only 지시문 전파", () => {
+  it("buildSystemPrompt locale='en' → English only 지시문 전파 + footer 강조", () => {
     const result = buildSystemPrompt(character!, "en");
-    expect(result).toContain("natural English only");
+    expect(result).toContain("natural English");
+    expect(result).toContain("STRICTLY FORBIDDEN");
+    expect(result).toContain("FINAL REMINDER");
   });
 
   it("미지원 locale → 빈 문자 fallback (ko와 동일 — 노이즈 없음)", () => {

--- a/src/app/tarot/session/page.tsx
+++ b/src/app/tarot/session/page.tsx
@@ -487,7 +487,7 @@ export default function TarotSessionPage() {
                 className="text-arcana-muted text-xs hover:text-arcana-purple transition-colors"
                 type="button"
               >
-                ← 상담사 다시 선택
+                {t("tarot.session.btn.back-to-character")}
               </button>
               <button
                 onClick={toggleConfirmMode}
@@ -503,7 +503,7 @@ export default function TarotSessionPage() {
                 }`}>
                   {confirmEachCard && <span className="w-1.5 h-1.5 rounded-full bg-white" />}
                 </span>
-                카드 확인 모드
+                {t("tarot.card-confirm.label")}
               </button>
             </div>
           )}

--- a/src/components/home/CharacterGallery.tsx
+++ b/src/components/home/CharacterGallery.tsx
@@ -7,8 +7,13 @@ import { ScrollReveal } from "@/components/effects/ScrollReveal";
 import { GenderFilterToggle } from "@/components/home/GenderFilter";
 import { useGenderStore } from "@/hooks/useGenderStore";
 import { getCharactersByGender } from "@/data/characters";
+import { getCharacterSpeciality } from "@/data/characters/locale-helpers";
+import { useT } from "@/i18n/useT";
+import { useLocaleStore } from "@/hooks/useLocaleStore";
 
 export function CharacterGallery() {
+  const { t } = useT();
+  const locale = useLocaleStore((s) => s.locale);
   const { genderFilter } = useGenderStore();
   const characters = getCharactersByGender(genderFilter);
 
@@ -16,9 +21,9 @@ export function CharacterGallery() {
     <section className="py-16 md:py-24 px-4">
       <div className="max-w-6xl mx-auto">
         <ScrollReveal className="text-center mb-8">
-          <h2 className="text-xl md:text-2xl font-display font-bold mb-3">당신의 상담사를 만나보세요</h2>
+          <h2 className="text-xl md:text-2xl font-display font-bold mb-3">{t("home.gallery.title")}</h2>
           <p className="text-arcana-muted text-sm md:text-base max-w-lg mx-auto">
-            각 상담사만의 특별한 리딩 스타일로 카드의 메시지를 전합니다
+            {t("home.gallery.desc")}
           </p>
         </ScrollReveal>
 
@@ -47,7 +52,7 @@ export function CharacterGallery() {
                     <h3 className="font-display font-bold text-sm truncate">{char.name}</h3>
                     <p className="text-arcana-muted text-xs mt-0.5 truncate">{char.nameJp}</p>
                     <div className="mt-1.5 inline-block max-w-full px-2 py-0.5 bg-arcana-purple/10 border border-arcana-purple/30 rounded-full">
-                      <span className="text-arcana-purple text-xs font-sans truncate block">{char.speciality}</span>
+                      <span className="text-arcana-purple text-xs font-sans truncate block">{getCharacterSpeciality(char, locale)}</span>
                     </div>
                   </div>
                 </motion.div>

--- a/src/i18n/translations/en/index.ts
+++ b/src/i18n/translations/en/index.ts
@@ -89,6 +89,8 @@ export const en: Partial<SharedKeys> = {
     "daily-card.reversed": "(Reversed)",
     "daily-card.upright": "(Upright)",
     "daily-card.share-text": "Daily Card - ArcanaInsight",
+    "gallery.title": "Meet your reader",
+    "gallery.desc": "Each reader delivers the cards' message in their own unique style",
   },
   settings: {
     "page.title": "Settings",
@@ -173,6 +175,7 @@ export const en: Partial<SharedKeys> = {
     "session.btn.try-again": "Try again",
     "session.btn.new-session": "New session",
     "session.btn.share": "Share result",
+    "session.btn.back-to-character": "← Choose another reader",
     "session.error.reading": "Something went wrong with the reading",
     "session.shuffle.fallback-text": "Choose your cards",
     "session.shuffle.skip-aria": "Skip card shuffle ceremony",

--- a/src/i18n/translations/ja/index.ts
+++ b/src/i18n/translations/ja/index.ts
@@ -76,6 +76,8 @@ export const ja: Partial<SharedKeys> = {
     "daily-card.reversed": "（逆位置）",
     "daily-card.upright": "（正位置）",
     "daily-card.share-text": "今日のカード - ArcanaInsight",
+    "gallery.title": "あなたの占い師に会ってみよう",
+    "gallery.desc": "占い師それぞれの個性的なリーディングスタイルでカードのメッセージをお伝えします",
   },
   settings: {
     "page.title": "設定",
@@ -175,6 +177,7 @@ export const ja: Partial<SharedKeys> = {
     "session.btn.try-again": "再試行",
     "session.btn.new-session": "新しい相談",
     "session.btn.share": "結果を共有",
+    "session.btn.back-to-character": "← 占い師を選び直す",
     "session.error.reading": "解釈に問題が発生しました",
     "session.shuffle.fallback-text": "カードを選んでください",
     "session.shuffle.skip-aria": "カードシャッフル儀式をスキップ",

--- a/src/i18n/translations/ko/index.ts
+++ b/src/i18n/translations/ko/index.ts
@@ -84,6 +84,8 @@ export const ko: SharedKeys = {
     "daily-card.reversed": "(역방향)",
     "daily-card.upright": "(정방향)",
     "daily-card.share-text": "오늘의 카드 - ArcanaInsight",
+    "gallery.title": "당신의 상담사를 만나보세요",
+    "gallery.desc": "각 상담사만의 특별한 리딩 스타일로 카드의 메시지를 전합니다",
   },
   settings: {
     "page.title": "설정",
@@ -168,6 +170,7 @@ export const ko: SharedKeys = {
     "session.btn.try-again": "다시 시도",
     "session.btn.new-session": "새로운 상담",
     "session.btn.share": "결과 공유하기",
+    "session.btn.back-to-character": "← 상담사 다시 선택",
     "session.error.reading": "해석에 문제가 발생했어요",
     "session.shuffle.fallback-text": "카드를 선택하세요",
     "session.shuffle.skip-aria": "카드 셔플 의식 스킵",

--- a/src/i18n/translations/shared/keys.ts
+++ b/src/i18n/translations/shared/keys.ts
@@ -90,6 +90,8 @@ export interface SharedKeys {
     "daily-card.reversed": string;
     "daily-card.upright": string;
     "daily-card.share-text": string;
+    "gallery.title": string;
+    "gallery.desc": string;
   };
   settings: {
     "page.title": string;
@@ -177,6 +179,7 @@ export interface SharedKeys {
     "session.btn.try-again": string;
     "session.btn.new-session": string;
     "session.btn.share": string;
+    "session.btn.back-to-character": string;
     "session.error.reading": string;
     "session.shuffle.fallback-text": string;
     "session.shuffle.skip-aria": string;

--- a/src/services/core/prompt-builder.ts
+++ b/src/services/core/prompt-builder.ts
@@ -11,13 +11,25 @@ const topicLabels: Partial<Record<Topic, string>> = {
 /**
  * locale별 응답 언어 강제 + JSON 키 영어 고정 명시.
  * - ko: 시스템 프롬프트가 이미 한국어이므로 노이즈 최소화 (지시 생략).
- * - en/ja: 응답 본문 언어 + JSON 키는 반드시 영어 그대로 유지하도록 명시 (모델이 키 번역하면 parseJsonSafe 실패).
+ * - en/ja: **CRITICAL** 강조 + 한국어 금지 명시 + JSON 키 영어 고정. 시스템 프롬프트가 한국어로 작성되어 있어 모델이 한국어로 응답하는 회귀를 막기 위해 시스템 프롬프트 **맨 앞**과 **맨 뒤** 양쪽에 주입한다.
  */
 const LANGUAGE_INSTRUCTIONS: Record<string, string> = {
   ko: "",
-  en: "Respond in natural English only. Use the EXACT English JSON keys (cardInterpretations, cardId, position, interpretation, overallReading, topicReading, advice). Translate only the values, never the keys.",
-  ja: "回答は自然な日本語のみで行います。JSONのキー (cardInterpretations, cardId, position, interpretation, overallReading, topicReading, advice) は必ず英語のまま使用し、値のみを日本語で記述してください。",
+  en: "**CRITICAL — RESPONSE LANGUAGE**: All response text (including all JSON string values) MUST be in natural English. Korean and Japanese are STRICTLY FORBIDDEN in the response, even if the system prompt below is written in Korean. The Korean text in the system prompt is for your INSTRUCTIONS only — your output must be 100% English. Use the EXACT English JSON keys (cardInterpretations, cardId, position, interpretation, overallReading, topicReading, advice) — translate only the values, never the keys.",
+  ja: "【最重要 — 応答言語】回答本文(すべてのJSON文字列値を含む)は必ず自然な日本語のみで記述してください。下記のシステムプロンプトが韓国語で書かれていても、応答に韓国語と英語を使用することは厳禁です。システムプロンプトの韓国語はあなたへの指示用であり、出力は100%日本語でなければなりません。JSONのキー (cardInterpretations, cardId, position, interpretation, overallReading, topicReading, advice) は必ず英語のまま使用し、値のみを日本語で記述してください。",
 };
+
+/** 응답 직전 마지막 강조 — 모델은 가까운 위치의 지시를 더 강하게 따른다. */
+const LANGUAGE_FOOTER: Record<string, string> = {
+  ko: "",
+  en: "\n\n**FINAL REMINDER**: Output language MUST be English. Begin your JSON response now.",
+  ja: "\n\n【最終確認】出力言語は必ず日本語です。今すぐJSON応答を開始してください。",
+};
+
+/** locale별 시스템 프롬프트 끝에 주입되는 응답 언어 강조 footer (saju/shinjeom service에서도 재사용). */
+export function getLanguageFooter(locale: string = "ko"): string {
+  return LANGUAGE_FOOTER[locale] ?? "";
+}
 
 export function buildCharacterHeader(character: CharacterConfig, subtitle?: string, locale: string = "ko"): string {
   const subtitleLine = subtitle ? `\n${subtitle}` : "";
@@ -34,7 +46,10 @@ export function buildCharacterHeader(character: CharacterConfig, subtitle?: stri
 }
 
 export function buildSystemPrompt(character: CharacterConfig, locale: string = "ko"): string {
-  return `${buildCharacterHeader(character, undefined, locale)}
+  const langTop = LANGUAGE_INSTRUCTIONS[locale] ?? "";
+  const langTopBlock = langTop ? `${langTop}\n\n` : "";
+  const langFooter = LANGUAGE_FOOTER[locale] ?? "";
+  return `${langTopBlock}${buildCharacterHeader(character, undefined, locale)}
 - 타로 카드 해석 전문가로서, 카드의 상징과 의미를 깊이 있게 설명합니다.
 - 사용자에게 따뜻하고 공감하는 태도로 상담합니다.
 - 지나치게 부정적이거나 공포를 조장하는 해석은 피합니다.
@@ -80,7 +95,7 @@ export function buildSystemPrompt(character: CharacterConfig, locale: string = "
   ],
   "overallReading": "문단1\\n\\n문단2",
   "advice": "조언 내용"
-}`;
+}${langFooter}`;
 }
 
 export function buildReadingPrompt(topic: Topic, selectedCards: SelectedCard[], spread: SpreadDefinition): string {

--- a/src/services/saju/saju-service.ts
+++ b/src/services/saju/saju-service.ts
@@ -5,7 +5,7 @@ import { getCharacterById } from "@/data/characters";
 import { SajuResult } from "./saju-types";
 import { OhaengType, OHAENG } from "@/data/saju/constants";
 import { cleanReadingText, parseJsonSafe, extractFallbackText } from "@/services/core/text-cleaner";
-import { buildCharacterHeader } from "@/services/core/prompt-builder";
+import { buildCharacterHeader, getLanguageFooter } from "@/services/core/prompt-builder";
 import { sajuTimeOptions } from "@/data/saju/categories";
 
 const TOPIC_LABELS: Record<string, string> = {
@@ -167,7 +167,7 @@ export class SajuService implements DivinationService {
   "overallReading": "종합 해석 문단1\\n\\n문단2",
   "topicReading": "주제별 해석 문단1\\n\\n문단2",
   "advice": "조언 내용"
-}`;
+}${getLanguageFooter(locale ?? "ko")}`;
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/src/services/shinjeom/shinjeom-service.ts
+++ b/src/services/shinjeom/shinjeom-service.ts
@@ -3,7 +3,7 @@ import { CharacterConfig } from "@/types/character";
 import { Session, Topic, ChatMessage } from "@/types/session";
 import { getCharacterById } from "@/data/characters";
 import { cleanReadingText, parseJsonSafe } from "@/services/core/text-cleaner";
-import { buildCharacterHeader } from "@/services/core/prompt-builder";
+import { buildCharacterHeader, getLanguageFooter } from "@/services/core/prompt-builder";
 
 const topicLabels: Record<string, string> = {
   "shinjeom-general": "신수 (종합운)",
@@ -60,7 +60,7 @@ export class ShinjeomService implements DivinationService {
 
 중요 규칙 — 최종 결과:
 - 최종 결과는 반드시 JSON 형식으로 응답합니다.
-- 최종이 아닌 중간 대화에서는 일반 텍스트로 응답합니다.`;
+- 최종이 아닌 중간 대화에서는 일반 텍스트로 응답합니다.${getLanguageFooter(locale ?? "ko")}`;
   }
 
   buildConversationPrompt(


### PR DESCRIPTION
# 사용자 보고 (스크린샷 2장)
영어 locale인데 화면·AI 응답에 한국어 노출. "Grok LLM에서 Locale 설정은 없는건가요?"

# 화면 잔여 3건 (i18n)
1. CharacterGallery.tsx — 홈 캐릭터 섹션
   - h2 "당신의 상담사를 만나보세요"
   - p  "각 상담사만의 특별한 리딩 스타일로..."
   - char.speciality (한국어 고정) → getCharacterSpeciality(char, locale) → home.gallery.title / desc 사전 키 신규 추가
2. tarot/session/page.tsx — 카드 선택 화면
   - "← 상담사 다시 선택" 버튼
   - "카드 확인 모드" 버튼 (사전 키 tarot.card-confirm.label 이미 있는데 미사용) → tarot.session.btn.back-to-character 사전 키 신규 + card-confirm.label 적용

# AI 응답 locale 강화 — 핵심 수정
원인 분석:
- locale은 SSE 라우트에서 잘 전달됨 (tarot/saju/shinjeom getRequestLocale → service)
- 그런데 buildSystemPrompt 본문이 한국어 hard-coded인데 LANGUAGE_INSTRUCTIONS은 캐릭터 헤더 끝에 "한 줄"만 추가됐음
- 모델 입장에서 [한국어 시스템 프롬프트 본문] >> [영어 한 줄 지시] → 한국어로 응답하는 게 자연스럽다고 판단

강화 방안 (외부 번역가 비용 0):
1. LANGUAGE_INSTRUCTIONS 자체 강화
   - **CRITICAL — RESPONSE LANGUAGE** 강조 + STRICTLY FORBIDDEN
   - "system prompt is in Korean for INSTRUCTIONS only — output 100% English/Japanese" 명시
   - 모델이 한국어 시스템 프롬프트를 보고 한국어로 응답하지 않도록 명시적 분리
2. 시스템 프롬프트 **맨 앞**에 LANGUAGE_INSTRUCTIONS 배치
   - buildSystemPrompt(): langTopBlock + buildCharacterHeader + 본문 + langFooter
3. **응답 직전 마지막 위치**에 LANGUAGE_FOOTER 주입 (모델은 가까운 위치 지시를 더 강하게 따름)
   - "FINAL REMINDER: Output language MUST be English. Begin your JSON response now."
   - getLanguageFooter(locale) export → saju/shinjeom service에서도 동일 적용
4. saju-service / shinjeom-service 시스템 프롬프트 끝에 footer 주입

# 사전 변경
- shared.home.gallery.title / desc (+2)
- tarot.session.btn.back-to-character (+1)
- 사전 ko/en/ja 289 → 292/292/292 (drift 0)

# 테스트 갱신
- locale-wiring.test.ts L155/168 — 강화된 phrase에 맞춰 기대값 업데이트 ("natural English only" → "natural English" + "STRICTLY FORBIDDEN" + "FINAL REMINDER")

# 검증
- pnpm i18n:check ✅ / type-check ✅ / lint ✅ / test (793) ✅ / build ✅

# 추가 메모 — 효과 검증 필요
런타임 검증은 사용자 측 영어/일본어 실제 리딩 시도 시 가능.
효과 부족하면 "옵션 B": 시스템 프롬프트 본문 자체를 locale별 분기 (한국어 → 영어/일본어 직접 작성, 외부 번역가 불필요).