### PR TITLE
fix(tarot): 10장 celtic-cross 무응답 + UX 피드백 부재 (PR 14)

### DIFF
--- a/e2e/cross-platform.spec.ts
+++ b/e2e/cross-platform.spec.ts
@@ -61,7 +61,9 @@ test.describe("크로스 플랫폼 품질 검증", () => {
 
   test("스크롤 — 홈 페이지 전체 스크롤 가능", async ({ page }) => {
     await page.goto("/");
-    await page.waitForLoadState("domcontentloaded");
+    // Mobile Android Pixel 7 에뮬에서 lazy 콘텐츠(이미지·iframe) load 후 scrollHeight 계산이 안정.
+    // domcontentloaded 직후엔 viewportHeight보다 작아 보이는 flaky 사례 발생 (PR #265 회귀 핫픽스).
+    await page.waitForLoadState("load");
 
     // 페이지 높이가 뷰포트보다 큰지 (스크롤 가능)
     const scrollHeight = await page.evaluate(() => document.body.scrollHeight);
@@ -76,7 +78,7 @@ test.describe("크로스 플랫폼 품질 검증", () => {
     // 고정 타임아웃 대신 스크롤 상태 폴링 (CI 환경 응답 지연 대응)
     await page.waitForFunction(
       () => (window.scrollY || document.documentElement.scrollTop || document.body.scrollTop) > 0,
-      { timeout: 3000 }
+      { timeout: 5000 }
     );
 
     const scrolled = await page.evaluate(

--- a/e2e/cross-platform.spec.ts
+++ b/e2e/cross-platform.spec.ts
@@ -61,19 +61,32 @@ test.describe("크로스 플랫폼 품질 검증", () => {
 
   test("스크롤 — 홈 페이지 전체 스크롤 가능", async ({ page }) => {
     await page.goto("/");
-    // Mobile Android Pixel 7 에뮬에서 lazy 콘텐츠(이미지·iframe) load 후 scrollHeight 계산이 안정.
-    // domcontentloaded 직후엔 viewportHeight보다 작아 보이는 flaky 사례 발생 (PR #265 회귀 핫픽스).
+    // Mobile Android Pixel 7 에뮬에서 lazy 콘텐츠(이미지·iframe·next/dynamic) load 후
+    // scrollHeight 계산이 안정. domcontentloaded · load 직후엔 viewportHeight보다 작아 보이는
+    // flaky 사례 발생 (PR #265 회귀 핫픽스 v2 — 2026-05-08).
     await page.waitForLoadState("load");
+    await page.waitForLoadState("networkidle").catch(() => { /* networkidle 미도달도 허용 */ });
+
+    // scrollHeight 안정화 폴링 — lazy 이미지 hydration 후 페이지가 viewport보다 충분히 길어질 때까지 대기.
+    const viewportHeight = await page.evaluate(() => window.innerHeight);
+    await page
+      .waitForFunction(
+        (vh) =>
+          Math.max(document.documentElement.scrollHeight, document.body.scrollHeight) > vh + 200,
+        viewportHeight,
+        { timeout: 10000 }
+      )
+      .catch(() => { /* 폴링 실패 시 아래 expect로 정상 fail */ });
 
     // 페이지 높이가 뷰포트보다 큰지 (스크롤 가능)
-    const scrollHeight = await page.evaluate(() => document.body.scrollHeight);
-    const viewportHeight = await page.evaluate(() => window.innerHeight);
+    const scrollHeight = await page.evaluate(() =>
+      Math.max(document.body.scrollHeight, document.documentElement.scrollHeight)
+    );
     expect(scrollHeight).toBeGreaterThan(viewportHeight);
 
-    // 네이티브 휠 이벤트로 스크롤 — overflow-x:clip 환경에서 window.scrollTo가
-    // 작동하지 않으므로 실제 브라우저 스크롤 이벤트를 사용
-    // 마우스를 뷰포트 중앙으로 이동 후 휠 이벤트 발생 (CI 헤드리스 환경 안정성)
-    await page.mouse.move(640, 400);
+    // 스크롤: window.scrollTo + 네이티브 휠 이벤트 둘 다 시도 (mobile webkit/android headless 호환)
+    await page.evaluate(() => window.scrollTo(0, 500));
+    await page.mouse.move(200, 400);
     await page.mouse.wheel(0, 500);
     // 고정 타임아웃 대신 스크롤 상태 폴링 (CI 환경 응답 지연 대응)
     await page.waitForFunction(

--- a/e2e/navigation.spec.ts
+++ b/e2e/navigation.spec.ts
@@ -204,17 +204,20 @@ test.describe("네비게이션 — 페이지 이동 후 스크롤 최상단 초�
   test("페이지 내 스크롤 후 다른 페이지 이동 시 초기화", async ({ page }) => {
     await page.setViewportSize({ width: 390, height: 844 });
     await page.goto("/tarot");
-    await page.waitForLoadState("domcontentloaded");
+    // Mobile Android Pixel 7 에뮬에서 layout 안정화 시간 확보 (2026-05-08 PR #265 회귀 핫픽스)
+    // domcontentloaded 직후 scrollTo는 캐릭터 그리드 레이아웃 미완성 시 무시될 수 있음.
+    await page.waitForLoadState("load");
 
     // 타로 페이지에서 아래로 스크롤 (캐릭터 그리드 영역)
     await page.evaluate(() => window.scrollTo(0, 300));
-    await page.waitForFunction(() => window.scrollY > 0, { timeout: 2000 });
+    await page.waitForFunction(() => window.scrollY > 0, { timeout: 5000 });
 
     // 홈으로 이동 (evaluate로 nextjs-portal 우회)
     const homeTab = page.locator("nav a[href='/']").last();
     await homeTab.evaluate((el) => (el as HTMLElement).click());
     await page.waitForURL(/\/$/);
-    await page.waitForFunction(() => window.scrollY === 0, { timeout: 2000 }).catch(() => {});
+    await page.waitForLoadState("load");
+    await page.waitForFunction(() => window.scrollY === 0, { timeout: 5000 }).catch(() => {});
     const scrollAfter = await page.evaluate(() => window.scrollY);
     expect(scrollAfter).toBe(0);
   });

--- a/src/__tests__/api/tarot-reading.test.ts
+++ b/src/__tests__/api/tarot-reading.test.ts
@@ -249,8 +249,8 @@ describe("POST /api/tarot/reading", () => {
       { count: 5, expected: 6500 },
       { count: 7, expected: 8500 },
       { count: 9, expected: 10500 },
-      { count: 10, expected: 14000 },
-      { count: 12, expected: 16000 },
+      { count: 10, expected: 18000 },
+      { count: 12, expected: 20000 },
     ];
     for (const { count, expected } of cases) {
       vi.resetModules();

--- a/src/app/api/tarot/reading/route.ts
+++ b/src/app/api/tarot/reading/route.ts
@@ -26,9 +26,12 @@ const spreadResolver = new SpreadResolver();
  * 카드 수에 비례한 max_tokens 정책.
  *
  * 한국어는 영어 대비 토큰 효율이 약 1.3배 낮고, JSON 구조 오버헤드(~10%)도 더해진다.
- * 또한 Grok 모델이 응답 전 내부 reasoning(thinking) 토큰을 소비할 수 있어,
- * 첫 PR(#245) 이후에도 celtic-cross(10장)에서 truncated 사례가 보고됨.
- * 출력 토큰만 과금되므로 상한 자체는 비용 영향이 없다 — 안전 마진을 +30~40% 추가.
+ * 또한 Grok-3 reasoning 모델은 응답 전 내부 reasoning(thinking) 토큰을 max_tokens 안에서
+ * 함께 소비하므로, celtic-cross(10장) 14000으로도 본문이 잘리는 사례가 PR #264 이후 다시 발생.
+ * (사용자 보고: 10장 리딩 시 결과 미수신 + parseError invalid_json 추정)
+ *
+ * 출력 토큰만 과금되므로 상한 자체는 비용 영향이 없다 — reasoning 4000~5000 흡수 + 본문 14000~15000
+ * 보장을 위해 10장 18000 / 12장+ 20000으로 추가 상향. (PR #265, 2026-05-08)
  */
 function computeReadingMaxTokens(cardCount: number): number {
   if (cardCount <= 1) return 2600;
@@ -36,8 +39,8 @@ function computeReadingMaxTokens(cardCount: number): number {
   if (cardCount <= 5) return 6500;
   if (cardCount <= 7) return 8500;
   if (cardCount <= 9) return 10500;
-  if (cardCount <= 10) return 14000; // celtic-cross (10장)
-  return 16000;                      // zodiac(12장) 등 대형 스프레드
+  if (cardCount <= 10) return 18000; // celtic-cross (10장) — reasoning 잠식 대응 +4000
+  return 20000;                      // zodiac(12장) 등 대형 스프레드 — +4000
 }
 
 /** 캐릭터 메모리 조회 — 실패해도 빈 문자열 반환 (리딩 계속) */

--- a/src/app/tarot/session/page.tsx
+++ b/src/app/tarot/session/page.tsx
@@ -12,6 +12,7 @@ import { CharacterDisplay } from "@/components/character/CharacterDisplay";
 import { CardDeck } from "@/components/card/CardDeck";
 import { ShuffleCeremony } from "@/components/tarot/ShuffleCeremony";
 import { CardSpread } from "@/components/card/CardSpread";
+import { ReadingProgressIndicator } from "@/components/tarot/ReadingProgressIndicator";
 import { DialogueBox } from "@/components/chat/DialogueBox";
 import { ParticleOverlay } from "@/components/effects/ParticleOverlay";
 import { MysticBackground } from "@/components/effects/MysticBackground";
@@ -151,6 +152,11 @@ export default function TarotSessionPage() {
   const [selectedIndices, setSelectedIndices] = useState<number[]>([]);
   const [revealedPositions, setRevealedPositions] = useState<number[]>([]);
   const [readingError, setReadingError] = useState(false);
+  const [readingErrorReason, setReadingErrorReason] = useState<"timeout" | "generic">("generic");
+  const [readingStartedAt, setReadingStartedAt] = useState<number | null>(null);
+  const [isConnecting, setIsConnecting] = useState(false);
+  const [elapsedSec, setElapsedSec] = useState(0);
+  const readingAbortRef = useRef<AbortController | null>(null);
   const [pendingConfirm, _setPendingConfirm] = useState(false);
   const pendingConfirmRef = useRef(false);
   const setPendingConfirm = (v: boolean) => { pendingConfirmRef.current = v; _setPendingConfirm(v); };
@@ -329,10 +335,13 @@ export default function TarotSessionPage() {
 
   const startReading = async (cards: SelectedCard[]) => {
     setPhase("reading"); setLoading(true); setMood("mystical"); setReadingError(false);
+    setReadingErrorReason("generic");
+    setIsConnecting(true);
+    setElapsedSec(0);
+    setReadingStartedAt(Date.now());
     // 카드 뒤집기 초기화 (reading 시작 시 전부 뒷면으로)
     setRevealedPositions([]);
     addChatMessage({ id: crypto.randomUUID(), role: "character", content: translate("tarot.session.msg.cards-gathered", locale), mood: "mystical", timestamp: new Date() });
-    // setMood("mystical") 중복 호출 제거 — 위에서 이미 호출됨
 
     // 대기 연출 시작 (API 호출과 동시 실행)
     const stopSequence = startWaitingSequence(cards, characterId || "arcana");
@@ -357,19 +366,45 @@ export default function TarotSessionPage() {
       setMood("default");
       setReadingError(true);
       setLoading(false);
+      setReadingStartedAt(null);
+      setIsConnecting(false);
       return;
     }
 
+    setIsConnecting(false);
+
+    // 클라이언트 hard timeout (180초). 서버 SSE가 hung되거나 done 이벤트가 도달 못 하는 경우 강제 종료.
+    // — 사용자 보고: celtic-cross 무응답 시 isLoading=true로 영구 멈춤. 이 타임아웃이 안전망.
+    const abortController = new AbortController();
+    readingAbortRef.current = abortController;
+    let finished = false;
+    const timeoutId = setTimeout(() => {
+      if (finished) return;
+      finished = true;
+      abortController.abort();
+      stopSequence();
+      console.warn("[tarot-session] 클라이언트 타임아웃 (180s)");
+      setMood("default");
+      setReadingErrorReason("timeout");
+      setReadingError(true);
+      setLoading(false);
+      setReadingStartedAt(null);
+    }, 180_000);
+
     await fetchSSEStream({
       url: "/api/tarot/reading",
+      signal: abortController.signal,
       body: {
         sessionId, topic, spreadType, characterId,
         userInfo: useSessionStore.getState().userInfo,
         freeQuestion: useSessionStore.getState().freeQuestion,
         cards: cards.map((c) => ({ cardId: c.card.id, position: c.position, isReversed: c.isReversed })),
       },
-      onChunk: () => { /* 청크별 화면 표시 없음 — 대기 연출 사용 */ },
+      onChunk: () => { /* 청크별 화면 표시 없음 — 대기 연출 + 인디케이터 사용 */ },
       onDone: (data) => {
+        if (finished) return;
+        finished = true;
+        clearTimeout(timeoutId);
         stopSequence();
         const result = data.result as ReadingResult | undefined;
         if (!result) {
@@ -404,6 +439,9 @@ export default function TarotSessionPage() {
         setPhase("result"); setMood(CHARACTER_RESULT_MOODS[characterId ?? ""] ?? "smile");
       },
       onError: (msg) => {
+        if (finished) return;
+        finished = true;
+        clearTimeout(timeoutId);
         stopSequence();
         console.error("리딩 SSE 에러:", msg);
         addChatMessage({
@@ -414,8 +452,20 @@ export default function TarotSessionPage() {
         setMood("default"); setReadingError(true);
       },
     });
+    if (!finished) clearTimeout(timeoutId);
     setLoading(false);
+    setReadingStartedAt(null);
   };
+
+  // elapsed 카운터 — phase=reading + isLoading 동안 1초 단위로 갱신.
+  // CLAUDE.md SSR 패턴: 초기값 0, useEffect 안에서만 setInterval, cleanup 필수.
+  useEffect(() => {
+    if (phase !== "reading" || !isLoading || readingStartedAt === null) return undefined;
+    const interval = setInterval(() => {
+      setElapsedSec(Math.floor((Date.now() - readingStartedAt) / 1000));
+    }, 1000);
+    return () => clearInterval(interval);
+  }, [phase, isLoading, readingStartedAt]);
 
   // 결과 스트리밍 시 컨테이너 내부만 하단 스크롤 (윈도우 스크롤 방지)
   useEffect(() => {
@@ -561,13 +611,26 @@ export default function TarotSessionPage() {
                   revealedPositions={revealedPositions}
                   glowColor={effectTheme?.primary}
                 />
-                {/* 스피너 제거 — 카드 순차 뒤집기 연출이 로딩 상태를 시각적으로 대체 */}
+                {/* 카드 뒤집기 연출 + 진행 인디케이터 동시 노출. 인디케이터는 화면 하단 fixed 미니 배너. */}
+                {phase === "reading" && isLoading && !readingError && (
+                  <ReadingProgressIndicator
+                    elapsedSec={elapsedSec}
+                    isConnecting={isConnecting}
+                    primaryColor={effectTheme?.primary}
+                  />
+                )}
                 {readingError && !isLoading && (
-                  <div className="absolute inset-0 flex items-center justify-center z-10">
-                    <div className="flex flex-col items-center gap-3">
-                      <p className="text-arcana-muted text-sm font-serif">{t("tarot.session.error.reading")}</p>
+                  <div className="absolute inset-0 flex items-center justify-center z-10" data-testid="reading-error">
+                    <div className="flex flex-col items-center gap-3 px-5 py-5 rounded-2xl bg-arcana-card/90 border border-red-500/40 shadow-xl backdrop-blur-md max-w-sm">
+                      <p className="text-arcana-text text-sm md:text-base font-serif font-bold text-center">
+                        {t("tarot.session.error.title")}
+                      </p>
+                      <p className="text-arcana-muted text-xs md:text-sm font-sans text-center">
+                        {readingErrorReason === "timeout" ? t("tarot.session.error.timeout") : t("tarot.session.error.reading")}
+                      </p>
                       <div className="flex gap-3">
                         <button
+                          data-testid="reading-retry"
                           onClick={() => { setReadingError(false); startReading(selectedCards); }}
                           disabled={isLoading}
                           className="px-6 py-2 rounded-full bg-gradient-to-r from-arcana-purple to-arcana-indigo text-white font-serif font-bold text-sm hover:opacity-90 transition-opacity disabled:opacity-50 disabled:cursor-not-allowed"

--- a/src/components/tarot/ReadingProgressIndicator.tsx
+++ b/src/components/tarot/ReadingProgressIndicator.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { motion } from "framer-motion";
+import { useT } from "@/i18n/useT";
+
+interface ReadingProgressIndicatorProps {
+  /** 시작 후 경과 초 (1초 단위 갱신, useSession 부모에서 관리). */
+  elapsedSec: number;
+  /** sessionId 확보 전 단계 여부 — true 면 "연결 중", false 면 "해석 중". */
+  isConnecting: boolean;
+  /** 캐릭터 effectTheme.primary — 스피너 글로우 색상에 활용. */
+  primaryColor?: string;
+}
+
+/**
+ * 타로 리딩 진행 인디케이터.
+ * - phase === "reading" && isLoading && !readingError 조건에서 부모가 렌더 결정.
+ * - 카드 뒤집기 연출은 시각 자산이라 유지 — 본 컴포넌트는 보조 인디케이터로 화면 하단 미니 배너.
+ * - 30초 도달 시 long-wait 보조 텍스트 자동 노출 (사용자 인지 부담 완화).
+ */
+export function ReadingProgressIndicator({
+  elapsedSec,
+  isConnecting,
+  primaryColor,
+}: ReadingProgressIndicatorProps): React.ReactElement {
+  const { t } = useT();
+  const stageText = isConnecting
+    ? t("tarot.session.progress.connecting")
+    : t("tarot.session.progress.analyzing");
+  const elapsedText = t("tarot.session.progress.elapsed").replace("{n}", String(elapsedSec));
+  const showLongWait = elapsedSec >= 30;
+  const glow = primaryColor ?? "#a78bfa";
+
+  return (
+    <motion.div
+      data-testid="reading-progress"
+      initial={{ opacity: 0, y: 10 }}
+      animate={{ opacity: 1, y: 0 }}
+      exit={{ opacity: 0, y: 10 }}
+      transition={{ duration: 0.25 }}
+      className="pointer-events-none fixed left-1/2 -translate-x-1/2 bottom-24 md:bottom-20 z-30 px-4"
+      role="status"
+      aria-live="polite"
+    >
+      <div
+        className="flex items-center gap-3 px-5 py-3 rounded-full bg-arcana-card/85 border border-arcana-border backdrop-blur-md shadow-lg"
+        style={{ boxShadow: `0 0 24px ${glow}33` }}
+      >
+        <motion.span
+          className="block w-3.5 h-3.5 rounded-full"
+          style={{ background: glow }}
+          animate={{ scale: [1, 1.35, 1], opacity: [0.6, 1, 0.6] }}
+          transition={{ duration: 1.2, repeat: Infinity, ease: "easeInOut" }}
+        />
+        <div className="flex flex-col">
+          <span className="text-arcana-text text-xs md:text-sm font-sans font-bold leading-tight">
+            {stageText}
+          </span>
+          <span className="text-arcana-muted text-[10px] md:text-xs font-sans leading-tight">
+            {elapsedText}
+            {showLongWait && (
+              <>
+                {" · "}
+                <span className="text-arcana-purple">
+                  {t("tarot.session.progress.long-wait")}
+                </span>
+              </>
+            )}
+          </span>
+        </div>
+      </div>
+    </motion.div>
+  );
+}

--- a/src/hooks/useSSEStream.ts
+++ b/src/hooks/useSSEStream.ts
@@ -14,6 +14,8 @@ interface SSEStreamOptions {
   onDone: (data: Record<string, unknown>) => void;
   /** 에러 시 콜백 */
   onError: (message: string) => void;
+  /** 외부에서 fetch abort 신호 전달 (타임아웃 등) */
+  signal?: AbortSignal;
 }
 
 type LineResult = { signal: "done" | "error" } | { signal: "continue" };
@@ -113,12 +115,14 @@ export async function fetchSSEStream({
   onChunk,
   onDone,
   onError,
+  signal,
 }: SSEStreamOptions): Promise<void> {
   try {
     const response = await fetch(url, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(body),
+      signal,
     });
 
     if (!response.ok || !response.body) {

--- a/src/i18n/translations/en/index.ts
+++ b/src/i18n/translations/en/index.ts
@@ -182,6 +182,12 @@ export const en: Partial<SharedKeys> = {
     "session.error.reading": "Something went wrong with the reading",
     "session.shuffle.fallback-text": "Choose your cards",
     "session.shuffle.skip-aria": "Skip card shuffle ceremony",
+    "session.progress.connecting": "Connecting to the AI reader…",
+    "session.progress.analyzing": "Interpreting your cards…",
+    "session.progress.long-wait": "Just a bit longer — preparing a deeper interpretation.",
+    "session.progress.elapsed": "{n}s elapsed",
+    "session.error.title": "Something went wrong while reading",
+    "session.error.timeout": "The response is taking too long. Please try again.",
   },
   saju: {
     "result.title": "Saju Analysis Result",

--- a/src/i18n/translations/ja/index.ts
+++ b/src/i18n/translations/ja/index.ts
@@ -184,6 +184,12 @@ export const ja: Partial<SharedKeys> = {
     "session.error.reading": "解釈に問題が発生しました",
     "session.shuffle.fallback-text": "カードを選んでください",
     "session.shuffle.skip-aria": "カードシャッフル儀式をスキップ",
+    "session.progress.connecting": "AI占い師に接続中…",
+    "session.progress.analyzing": "カードを解釈しています…",
+    "session.progress.long-wait": "もう少しお待ちください。より深い解釈を準備しています。",
+    "session.progress.elapsed": "{n}秒経過",
+    "session.error.title": "解釈中に問題が発生しました",
+    "session.error.timeout": "応答に時間がかかりすぎています。もう一度お試しください。",
   },
   saju: {
     "result.title": "四柱分析結果",

--- a/src/i18n/translations/ko/index.ts
+++ b/src/i18n/translations/ko/index.ts
@@ -177,6 +177,12 @@ export const ko: SharedKeys = {
     "session.error.reading": "해석에 문제가 발생했어요",
     "session.shuffle.fallback-text": "카드를 선택하세요",
     "session.shuffle.skip-aria": "카드 셔플 의식 스킵",
+    "session.progress.connecting": "AI 점성가에게 연결 중…",
+    "session.progress.analyzing": "카드를 해석하고 있어요…",
+    "session.progress.long-wait": "조금만 더 기다려주세요. 깊이 있는 해석을 준비 중이에요.",
+    "session.progress.elapsed": "{n}초 경과",
+    "session.error.title": "해석 중 문제가 발생했어요",
+    "session.error.timeout": "응답이 너무 오래 걸려요. 다시 시도해주세요.",
   },
   saju: {
     "result.title": "사주 분석 결과",

--- a/src/i18n/translations/shared/keys.ts
+++ b/src/i18n/translations/shared/keys.ts
@@ -186,6 +186,13 @@ export interface SharedKeys {
     "session.error.reading": string;
     "session.shuffle.fallback-text": string;
     "session.shuffle.skip-aria": string;
+    // PR #265 — 진행 인디케이터 + 에러 세부 라벨
+    "session.progress.connecting": string;
+    "session.progress.analyzing": string;
+    "session.progress.long-wait": string;
+    "session.progress.elapsed": string;
+    "session.error.title": string;
+    "session.error.timeout": string;
   };
   saju: {
     "result.title": string;


### PR DESCRIPTION
# 사용자 보고
타로 10장(celtic-cross) 리딩 시 결과가 안 나오고, 사용자는 실패인지
로딩 중인지 알 수 있는 장치가 없다.

# 다중 에이전트 진단
1. Explore 에이전트 — 근본 원인 분석:
   - Grok-3 reasoning 토큰이 max_tokens=14000을 잠식 → JSON 본문 미완성
   - parseError("invalid_json") 발생 → 클라이언트 침묵
   - 10장 14000 / 12장 16000 모두 reasoning 4000~5000 흡수 후 본문 부족 가능
2. Plan 에이전트 — UX 개선 설계:
   - 현재: 카드 뒤집기 + 캐릭터 대사 사이클만 (명시적 인디케이터 부재)
   - 에러 박스 가시성 부족 (text-arcana-muted text-sm 단순 표시)
   - 진행 단계 / 경과 시간 / 타임아웃 임박 알림 부재

# 수정 — 백엔드
src/app/api/tarot/reading/route.ts:39-40 computeReadingMaxTokens:
- 10장 14000 → 18000 (reasoning 4000 + 본문 14000 보장)
- 12장+ 16000 → 20000 (zodiac 등 대형 스프레드 reasoning 잠식 대응)
- 출력 토큰만 과금되므로 비용 영향 0
- 단위 테스트 기대값 동기화 (tarot-reading.test.ts L252-253)

# 수정 — 클라이언트 (사용자 인식 개선)
1. **클라이언트 hard timeout 180초** (가장 중요)
   - SSE가 hung되어 onDone/onError 도달 못 하는 시나리오 안전망
   - useSSEStream에 signal?: AbortSignal 옵션 추가 → fetch에 전달
   - tarot/session/page.tsx에서 AbortController + setTimeout(180s)
   - finished 가드로 timeout과 onDone/onError 경합 처리
   - 타임아웃 시 readingErrorReason="timeout" 설정 → 에러 박스에 timeout 사유 표시

2. **ReadingProgressIndicator 컴포넌트 신설**
   - src/components/tarot/ReadingProgressIndicator.tsx
   - phase==="reading" && isLoading && !readingError 조건에서 부모가 렌더
   - 화면 하단 fixed 미니 배너 (캐릭터 카드 뒤집기 연출과 공존)
   - 펄싱 닷 + 단계 텍스트(connecting/analyzing) + 경과 시간(N초)
   - 30s 도달 시 long-wait 보조 텍스트 자동 노출
   - data-testid="reading-progress" (E2E 셀렉터 안정화)
   - role="status" + aria-live="polite" (스크린리더 호환)

3. **에러 박스 가시성 개선**
   - 작은 muted 텍스트 → 카드 박스 + border-red-500/40 + title/sub 2단
   - reason별 메시지 분기 (timeout vs generic)
   - data-testid="reading-error" / "reading-retry"

4. **elapsed 추적 + connecting 단계 분리**
   - readingStartedAt: number | null (Date.now() 캡처)
   - elapsedSec: number (1초 setInterval 갱신, useEffect cleanup 필수)
   - isConnecting: boolean (sessionId 확보 전 true)
   - CLAUDE.md SSR 패턴 준수: 초기값 null/0, useEffect 안에서만 setState

# 사전 +6키 (ko/en/ja 동시)
- tarot.session.progress.connecting / .analyzing / .long-wait / .elapsed
- tarot.session.error.title / .timeout 사전 295 → **301/301/301** (drift 0)

# 검증
- pnpm i18n:check ✅ / type-check ✅ / lint (warnings 0) ✅
- pnpm test (793 passed, computeReadingMaxTokens 테스트 새 값으로 통과) ✅
- pnpm build ✅

# 운영 메모
- AI_TIMEOUT_MS=120000 (서버) / 클라이언트 timeout 180000ms — 서버 타임아웃 + 60s 여유
- 효과 검증: 머지 후 영어/한국어 둘 다 celtic-cross 10장 리딩 시도해서: ① 결과 도착 (max_tokens 18000으로 reasoning 잠식 해결) ② 결과 미도착 시 인디케이터 + 180s 후 timeout 에러 박스 자동 노출