### PR TITLE
fix: 회고 기반 품질 개선 — 신점 AbortController·SSE·i18n·React.memo·E2E (Phase 1-3)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,8 +65,7 @@ scripts/e2e-full/    # E2E 전수 검증 252 조합 (orchestrator/worker/reporte
 **API 보안**: Rate Limit → Zod safeParse → requireUser → assertSessionOwnership. → [`docs/architecture/auth-abstraction.md`](docs/architecture/auth-abstraction.md)
 - Rate Limit 범위: **세션 API**(tarot/saju/shinjeom session, 분당 20회) + **reading/message API** 모두 적용. `locale` 선언은 rate limit 호출 전 최상단에 위치.
 
-**SSE 스트리밍**: tarot/saju/shinjeom reading API. 서버: `SSE_HEADERS`+`jsonError()`(`request-utils.ts`), `readSseLines`+`withAbortTimeout`(`http-utils.ts`). 클라이언트: `fetchSSEStream()`(`useSSEStream.ts`, `AbortSignal` 지원). 클라이언트 hard timeout 180s — `AbortController`+`finished` 가드, 초과 시 `readingErrorReason="timeout"`. `/api/daily-card`는 JSON.
-- **타로·사주 세션 페이지** 모두 180s AbortController 적용. 에러/타임아웃 시 재시도 UI(`data-testid="reading-retry"`) 표시.
+**SSE 스트리밍**: tarot/saju/shinjeom reading API. 서버: `SSE_HEADERS`+`jsonError()`(`request-utils.ts`), `readSseLines`+`withAbortTimeout`(`http-utils.ts`). 클라이언트: `fetchSSEStream()`(`useSSEStream.ts`, `AbortSignal` 지원). 클라이언트 hard timeout 180s — `AbortController`+`finished` 가드 (타로·사주 세션 페이지 모두 적용), 초과 시 `readingErrorReason="timeout"` + 재시도 UI(`data-testid="reading-retry"`) 표시. `/api/daily-card`는 JSON.
 
 **share_token**: `/*/result/[id]` 공개 공유. 소유자 전용 = `assertReadingAccess("owner")`.
 
@@ -164,6 +163,8 @@ pnpm i18n:check             # ko/en/ja 번역 키 drift 검출 (orphan 발견 �
 ### SSR · Hydration (컴포넌트 작성 시)
 - **SSR 비결정 값 금지**: `new Date()`, `Math.random()`, `window` → `useEffect` 안에서만. `useState` 초기값은 `""`/`0`/`null` (React error #418 방지). `useEffect` 내 setState 직접 호출 금지 → `setTimeout(() => setState(...), 0)` + `return () => clearTimeout(t)` 필수 (`react-hooks/set-state-in-effect`).
 - **`<Image fill>` sizes 필수**: 미설정 시 Mobile Android CI 타임아웃. `sizes="(max-width: 640px) 50vw, ..."` 필수.
+- **`next/dynamic ssr:false`는 Canvas/WebGL 전용**: `ShuffleCeremony`(Canvas rAF) 같은 컴포넌트에만 사용. 일반 UI 컴포넌트는 SSR 기본값 유지.
+- **`React.memo` + `displayName`**: 무거운 렌더 컴포넌트(`SpriteAnimator`, `CardDeck`, `CardSpread`)는 `React.memo(function Name() {...})` + `Name.displayName = "Name"` 패턴. 배열 prop은 `areEqual` 커스텀 비교 함수 필수 (`revealedPositions` 등 — 참조 동일성 비교 실패 방지).
 
 ### API · 보안 (새 라우트 추가 시)
 - **API 스키마**: 새 라우트 → `api-schemas.ts` Zod 먼저 정의, `safeParse` 사용. 타입 단언 `as {...}` 금지.
@@ -177,7 +178,7 @@ pnpm i18n:check             # ko/en/ja 번역 키 drift 검출 (orphan 발견 �
 - **API 라우트 테스트 경로**: `src/app/api/` 내 `*.test.ts`는 vitest 수집 불가 → `src/__tests__/api/` 배치. → [`docs/workflow/unit-testing.md`](docs/workflow/unit-testing.md)
 - **E2E 스펙 추가 시 인증 의존성 명시**: 실 Supabase 세션 요구 spec은 파일 상단에 `// ⚠️ 실 Supabase 인증 세션 필요 — CI testIgnore 대상` 주석 필수.
 - **UI 텍스트 변경 시 E2E 셀렉터 동시 검토**: `e2e/` 내 `hasText`, `getByText`, `locator("text=")` 패턴 grep 후 같은 커밋에 수정.
-- **E2E 드롭다운**: `button:has(img)+text=` 조합 오탐 발생 → `data-testid` 필수. 데스크탑·모바일 드롭다운 반드시 별도 `ref`+별도 `testid` — 동일 `ref` 공유 시 React last-wins로 outside-click 오탐(드롭다운 선택 즉시 닫힘).
+- **E2E 드롭다운**: `button:has(img)+text=` 조합 오탐 발생 → `data-testid` 필수. 데스크탑·모바일 드롭다운 반드시 별도 `ref`+별도 `testid` — 동일 `ref` 공유 시 React last-wins로 outside-click 오탐(드롭다운 선택 즉시 닫힘). **ThemeDropdown testid**: `theme-option-${id}` (데스크탑) / `mobile-theme-option-${id}` (모바일) — `text=` 셀렉터는 i18n 변경 시 파손.
 - **Mobile Android 스크롤 테스트**: `domcontentloaded` 직후 scrollTo/scrollHeight flaky → `load`+`networkidle` 두 단계 대기 + scrollHeight polling(최대 10s) + `window.scrollTo`&`mouse.wheel` 병행 필수.
 
 - **Enum 화이트리스트 하드코딩 금지**: API 라우트에서 Zod `z.enum([...])` 검증 통과 후 일부 값만 하드코딩으로 재검증하면 나머지 값이 누락됨. `spreadResolver.getSpreadByType(val)` 처럼 유틸 메서드로 전체 enum 검증 필수. session/route.ts·reading/route.ts 모두 적용.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@
 | **DB ORM** | Supabase PostgreSQL / Drizzle ORM (DB_PROVIDER별 전환) |
 | **상태·패키지** | Zustand v5.0, pnpm 10.33.0 |
 | **다국어·i18n** | 자체 translations 모듈 + middleware locale 쿠키 (ko/en/ja) — → [`docs/architecture/i18n.md`](docs/architecture/i18n.md) |
-| **테스트** | Vitest 2.0 (804개, statements 98%), Playwright (3 디바이스, `SKIP_WEBKIT=1`로 iOS 제외 가능) |
+| **테스트** | Vitest 2.0 (819개, statements 98%), Playwright (3 디바이스, `SKIP_WEBKIT=1`로 iOS 제외 가능) |
 | **CI/CD·호스팅** | GitHub Actions → Railway |
 
 ## 프로젝트 구조
@@ -65,7 +65,7 @@ scripts/e2e-full/    # E2E 전수 검증 252 조합 (orchestrator/worker/reporte
 **API 보안**: Rate Limit → Zod safeParse → requireUser → assertSessionOwnership. → [`docs/architecture/auth-abstraction.md`](docs/architecture/auth-abstraction.md)
 - Rate Limit 범위: **세션 API**(tarot/saju/shinjeom session, 분당 20회) + **reading/message API** 모두 적용. `locale` 선언은 rate limit 호출 전 최상단에 위치.
 
-**SSE 스트리밍**: tarot/saju/shinjeom reading API. 서버: `SSE_HEADERS`+`jsonError()`(`request-utils.ts`), `readSseLines`+`withAbortTimeout`(`http-utils.ts`). 클라이언트: `fetchSSEStream()`(`useSSEStream.ts`, `AbortSignal` 지원). 클라이언트 hard timeout 180s — `AbortController`+`finished` 가드 (타로·사주 세션 페이지 모두 적용), 초과 시 `readingErrorReason="timeout"` + 재시도 UI(`data-testid="reading-retry"`) 표시. `/api/daily-card`는 JSON.
+**SSE 스트리밍**: tarot/saju/shinjeom reading API. 서버: `SSE_HEADERS`+`jsonError()`(`request-utils.ts`), `readSseLines`+`withAbortTimeout`(`http-utils.ts`). 클라이언트: `fetchSSEStream()`(`useSSEStream.ts`, `AbortSignal` 지원). 클라이언트 hard timeout 180s — `AbortController`+`finished` 가드 (타로·사주·신점 세션 페이지 모두 적용), 초과 시 `readingErrorReason="timeout"` + 재시도 UI(`data-testid="reading-retry"`) 표시. 신점 세션은 `handleSend`·`handleEndConsultation` 각각 AbortController 적용. `/api/daily-card`는 JSON.
 
 **share_token**: `/*/result/[id]` 공개 공유. 소유자 전용 = `assertReadingAccess("owner")`.
 
@@ -164,7 +164,7 @@ pnpm i18n:check             # ko/en/ja 번역 키 drift 검출 (orphan 발견 �
 - **SSR 비결정 값 금지**: `new Date()`, `Math.random()`, `window` → `useEffect` 안에서만. `useState` 초기값은 `""`/`0`/`null` (React error #418 방지). `useEffect` 내 setState 직접 호출 금지 → `setTimeout(() => setState(...), 0)` + `return () => clearTimeout(t)` 필수 (`react-hooks/set-state-in-effect`).
 - **`<Image fill>` sizes 필수**: 미설정 시 Mobile Android CI 타임아웃. `sizes="(max-width: 640px) 50vw, ..."` 필수.
 - **`next/dynamic ssr:false`는 Canvas/WebGL 전용**: `ShuffleCeremony`(Canvas rAF) 같은 컴포넌트에만 사용. 일반 UI 컴포넌트는 SSR 기본값 유지.
-- **`React.memo` + `displayName`**: 무거운 렌더 컴포넌트(`SpriteAnimator`, `CardDeck`, `CardSpread`)는 `React.memo(function Name() {...})` + `Name.displayName = "Name"` 패턴. 배열 prop은 `areEqual` 커스텀 비교 함수 필수 (`revealedPositions` 등 — 참조 동일성 비교 실패 방지).
+- **`React.memo` + `displayName`**: 무거운 렌더 컴포넌트(`SpriteAnimator`, `CardDeck`, `CardSpread`, `CharacterDisplay`, `DialogueBox`)는 `React.memo(function Name() {...})` + `Name.displayName = "Name"` 패턴. 배열 prop은 `areEqual` 커스텀 비교 함수 필수 (`revealedPositions` 등 — 참조 동일성 비교 실패 방지). Zustand 스토어 구독은 prop이 아니므로 `areEqual` 우회 — re-render 정상 발생.
 
 ### API · 보안 (새 라우트 추가 시)
 - **API 스키마**: 새 라우트 → `api-schemas.ts` Zod 먼저 정의, `safeParse` 사용. 타입 단언 `as {...}` 금지.

--- a/docs/superpowers/plans/2026-05-07-retrospective-quality-improvement.md
+++ b/docs/superpowers/plans/2026-05-07-retrospective-quality-improvement.md
@@ -1,0 +1,735 @@
+# 회고 기반 품질 개선 구현 계획
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 3-에이전트 교차 회고에서 발견된 11개 품질 이슈를 Phase별로 해결하여 신점 세션 영구 멈춤 버그 제거, 코드 일관성 확보, 테스트 커버리지 완성.
+
+**Architecture:** Phase 1(즉시 버그) → Phase 2(코드 품질) → Phase 3(중기 개선) 순으로 진행. 각 Phase는 독립 PR. Phase 1이 가장 높은 사용자 영향(신점 무한 로딩)을 가짐.
+
+**Tech Stack:** Next.js App Router, TypeScript strict, React 19, Zustand v5, Playwright, Vitest
+
+## 적용 가능 위험 항목 (CLAUDE.md 필수 주의사항)
+- [x] SSR/Hydration: useState 초기값·useEffect setState 패턴 — useRef 추가 시 SSR safe (ref는 서버/클라이언트 동일)
+- [x] UI 텍스트 변경 없음 → E2E 셀렉터 영향 없음 (testid 추가만)
+- [x] AbortController는 브라우저 전용 → "use client" 컴포넌트에서만 사용, 안전
+
+---
+
+## 파일 변경 맵
+
+| Task | 변경 파일 | 유형 |
+|------|----------|------|
+| Task 1 | `src/app/shinjeom/session/page.tsx` | Modify (핵심) |
+| Task 2 | `src/app/saju/session/page.tsx` | Modify (2행 추가) |
+| Task 3 | `src/components/layout/ThemeDropdown.tsx`, `e2e/theme.spec.ts` | Modify |
+| Task 4 | `src/components/card/CardSpread.tsx` | Modify |
+| Task 5 | `src/app/saju/page.tsx`, `src/app/shinjeom/page.tsx` | Modify |
+| Task 6 | `e2e/shinjeom-flow.spec.ts` | Modify |
+| Task 7 | `src/__tests__/lib/character-context.test.ts` | Create/Modify |
+| Task 8 | `src/components/character/CharacterDisplay.tsx`, `src/components/chat/DialogueBox.tsx` | Modify |
+| Task 9 | `src/app/tarot/session/page.tsx` | Modify |
+
+---
+
+## Phase 1 — 즉시 (버그 수정)
+
+### Task 1: 신점 세션 AbortController + fetchSSEStream 전환
+
+**맥락:** 신점 세션(`src/app/shinjeom/session/page.tsx`)은 현재 자체 구현한 `drainSseChunks()`로 SSE를 처리하며 AbortController·180s 타임아웃이 없다. AI 무응답 시 `isLoading=true` 영구 멈춤. 타로·사주는 PR-3에서 수정되었으나 신점은 누락됨.
+
+`fetchSSEStream` 인터페이스:
+```typescript
+fetchSSEStream({
+  url: string;
+  body: Record<string, unknown>;
+  onChunk: (chunk: string, fullText: string) => void;  // chunk는 string, Record 아님
+  onDone: (data: Record<string, unknown>) => void;
+  onError: (message: string) => void;
+  signal?: AbortSignal;
+})
+```
+
+**Files:**
+- Modify: `src/app/shinjeom/session/page.tsx`
+
+- [ ] **Step 1: import 수정 — fetchSSEStream 추가, 로컬 함수 제거**
+
+파일 상단의 import 블록에 추가:
+```typescript
+import { fetchSSEStream } from "@/hooks/useSSEStream";
+```
+
+파일에서 아래 두 로컬 함수 **전체 삭제** (L41~L69):
+```typescript
+function parseSseLine(line: string): Record<string, unknown> | null { ... }
+async function drainSseChunks(...): Promise<void> { ... }
+```
+
+- [ ] **Step 2: readingAbortRef 추가 + cleanup useEffect**
+
+`ShinjeomSessionPage` 컴포넌트 내부, `redirectedRef` 선언 직후에 추가:
+```typescript
+const readingAbortRef = useRef<AbortController | null>(null);
+```
+
+기존 채팅 스크롤 `useEffect` 바로 뒤에 cleanup effect 추가:
+```typescript
+useEffect(() => {
+  return () => { readingAbortRef.current?.abort(); };
+}, []);
+```
+
+- [ ] **Step 3: handleSend 전체 교체**
+
+기존 `const handleSend = async () => { ... }` (L129~L177) 전체를 아래로 교체:
+
+```typescript
+const handleSend = () => {
+  const message = inputText.trim();
+  if (!message || isLoading) return;
+
+  setInputText("");
+  setLoading(true);
+  setMood("mystical");
+
+  const messageIndex = useShinjeomSessionStore.getState().chatMessages.length;
+  addChatMessage({ id: crypto.randomUUID(), role: "user", content: message, timestamp: new Date() });
+  incrementTurn();
+
+  const msgId = crypto.randomUUID();
+  addChatMessage({ id: msgId, role: "character", content: "", mood: "mystical", timestamp: new Date() });
+
+  const abortController = new AbortController();
+  readingAbortRef.current = abortController;
+  let finished = false;
+
+  const timeoutId = setTimeout(() => {
+    if (finished) return;
+    finished = true;
+    abortController.abort();
+    updateMessageContent(msgId, getErrorMsg(characterId, "api"));
+    setMood("default");
+    setLoading(false);
+  }, 180_000);
+
+  void fetchSSEStream({
+    url: "/api/shinjeom/message",
+    signal: abortController.signal,
+    body: {
+      sessionId: useShinjeomSessionStore.getState().sessionId,
+      topic, characterId,
+      currentMessage: message,
+      chatHistory: useShinjeomSessionStore.getState().chatMessages,
+      isFinalTurn: false,
+      messageIndex,
+    },
+    onChunk: (_chunk, fullText) => {
+      updateMessageContent(msgId, fullText);
+    },
+    onDone: () => {
+      if (finished) return;
+      finished = true;
+      clearTimeout(timeoutId);
+      setLoading(false);
+    },
+    onError: () => {
+      if (finished) return;
+      finished = true;
+      clearTimeout(timeoutId);
+      updateMessageContent(msgId, getErrorMsg(characterId, "reading"));
+      setMood("default");
+      setLoading(false);
+    },
+  }).then(() => {
+    if (!finished) clearTimeout(timeoutId);
+  });
+};
+```
+
+- [ ] **Step 4: handleEndConsultation 전체 교체**
+
+기존 `const handleEndConsultation = async () => { ... }` (L179~L233) 전체를 아래로 교체:
+
+```typescript
+const handleEndConsultation = () => {
+  if (turnCount < 1 || isLoading) return;
+
+  setLoading(true);
+  setMood("mystical");
+
+  const currentChatMessages = useShinjeomSessionStore.getState().chatMessages;
+  const msgId = crypto.randomUUID();
+  addChatMessage({
+    id: msgId, role: "character",
+    content: translate("shinjeom.session.msg.preparing-result", locale),
+    mood: "mystical", timestamp: new Date(),
+  });
+
+  const abortController = new AbortController();
+  readingAbortRef.current = abortController;
+  let finished = false;
+
+  const timeoutId = setTimeout(() => {
+    if (finished) return;
+    finished = true;
+    abortController.abort();
+    updateMessageContent(msgId, getErrorMsg(characterId, "reading"));
+    setMood("default");
+    setLoading(false);
+  }, 180_000);
+
+  void fetchSSEStream({
+    url: "/api/shinjeom/message",
+    signal: abortController.signal,
+    body: {
+      sessionId: useShinjeomSessionStore.getState().sessionId,
+      topic, characterId,
+      currentMessage: undefined,
+      chatHistory: currentChatMessages,
+      isFinalTurn: true,
+      messageIndex: currentChatMessages.length,
+    },
+    onChunk: () => { /* 신점 최종 결과는 done 이벤트로 수신 */ },
+    onDone: (data) => {
+      if (finished) return;
+      finished = true;
+      clearTimeout(timeoutId);
+      const result = data.result as { parseError?: string } | undefined;
+      if (!result || result.parseError) {
+        if (result?.parseError) console.warn("[shinjeom-session] 결과 표시 불가:", { parseError: result.parseError });
+        updateMessageContent(msgId, getErrorMsg(characterId, "reading"));
+        setMood("default");
+        setLoading(false);
+        return;
+      }
+      removeMessage(msgId);
+      setReadingResult(data.result as Parameters<typeof setReadingResult>[0]);
+      setPhase("result");
+      setMood(CHARACTER_RESULT_MOODS[characterId ?? ""] ?? "smile");
+      setLoading(false);
+    },
+    onError: () => {
+      if (finished) return;
+      finished = true;
+      clearTimeout(timeoutId);
+      updateMessageContent(msgId, getErrorMsg(characterId, "reading"));
+      setMood("default");
+      setLoading(false);
+    },
+  }).then(() => {
+    if (!finished) clearTimeout(timeoutId);
+  });
+};
+```
+
+- [ ] **Step 5: 타입 검사 + 린트**
+
+```bash
+cd f:/DEVELOPMENT/SOURCE/CLAUDE/ArcanaInsight
+pnpm type-check && pnpm lint
+```
+
+Expected: 에러 없음. `parseSseLine`·`drainSseChunks` 미사용 경고가 남아 있다면 Step 1을 다시 확인.
+
+- [ ] **Step 6: 개발 서버에서 수동 검증**
+
+```bash
+pnpm dev
+```
+
+브라우저에서 `/shinjeom` → 캐릭터·주제 선택 → 세션 페이지 진입:
+1. 메시지 입력 후 전송 → 캐릭터 응답 스트리밍 확인
+2. "결과 받기" 클릭 → 결과 화면 전환 확인
+3. DevTools → Network → `/api/shinjeom/message` 요청이 Pending 없이 완료되는지 확인
+
+- [ ] **Step 7: 커밋**
+
+```bash
+git checkout -b fix/shinjeom-abort-controller
+git add src/app/shinjeom/session/page.tsx
+git commit -m "fix(shinjeom): AbortController + 180s 타임아웃 적용 — fetchSSEStream 전환"
+```
+
+---
+
+### Task 2: 사주 세션 AbortController ref 보관
+
+**맥락:** `src/app/saju/session/page.tsx`의 `startReading()`은 cleanup 함수를 반환하지만 `useEffect`에서 이 반환값이 무시된다. 컴포넌트 언마운트 시 진행 중 fetch가 abort되지 않아 경고·메모리 누수 가능.
+
+**Files:**
+- Modify: `src/app/saju/session/page.tsx`
+
+- [ ] **Step 1: readingAbortRef 추가**
+
+`resultContainerRef` 선언(L94) 바로 아래에 추가:
+```typescript
+const readingAbortRef = useRef<AbortController | null>(null);
+```
+
+- [ ] **Step 2: startReading 내 abortController ref 저장**
+
+`startReading()` 함수 내부(L143), `const abortController = new AbortController();` 바로 다음 줄에 추가:
+```typescript
+readingAbortRef.current = abortController;
+```
+
+- [ ] **Step 3: cleanup useEffect 추가**
+
+스크롤 `useEffect`(L217) 바로 뒤에 추가:
+```typescript
+useEffect(() => {
+  return () => { readingAbortRef.current?.abort(); };
+}, []);
+```
+
+- [ ] **Step 4: 타입 검사 + 커밋**
+
+```bash
+pnpm type-check && pnpm lint
+git add src/app/saju/session/page.tsx
+git commit -m "fix(saju): AbortController useRef 보관 — 언마운트 cleanup 보장"
+```
+
+---
+
+## Phase 2 — 단기 (코드 품질)
+
+### Task 3: ThemeDropdown auto 버튼 data-testid 추가
+
+**맥락:** `ThemeDropdown.tsx`에서 7개 테마 버튼은 `theme-option-${id}` testid를 가지지만 auto 버튼(L33)은 없다. `e2e/theme.spec.ts`에서 `text=자동 (시간/계절)` 셀렉터를 사용 중 — i18n 변경 시 파손됨.
+
+**Files:**
+- Modify: `src/components/layout/ThemeDropdown.tsx:33`
+- Modify: `e2e/theme.spec.ts`
+
+- [ ] **Step 1: ThemeDropdown auto 버튼에 testid 추가**
+
+`src/components/layout/ThemeDropdown.tsx` L33~L44의 `<button` 여는 태그에 속성 추가:
+```typescript
+<button
+  data-testid={isDesktop ? "theme-option-auto" : "mobile-theme-option-auto"}
+  onClick={() => { setMode("auto"); onClose(); }}
+  className={...}
+>
+```
+
+- [ ] **Step 2: e2e/theme.spec.ts 셀렉터 업데이트**
+
+`e2e/theme.spec.ts`에서 auto 버튼을 `text=` 셀렉터로 참조하는 부분을 검색:
+```bash
+grep -n "자동" e2e/theme.spec.ts
+```
+
+찾은 모든 `text=자동 (시간/계절)` 패턴을 `[data-testid='theme-option-auto']` 또는 `[data-testid='mobile-theme-option-auto']`로 교체. 데스크탑(1280px viewport) 컨텍스트는 `theme-option-auto`, 모바일(390px) 컨텍스트는 `mobile-theme-option-auto`.
+
+- [ ] **Step 3: 타입 검사 + 커밋**
+
+```bash
+pnpm type-check && pnpm lint
+git add src/components/layout/ThemeDropdown.tsx e2e/theme.spec.ts
+git commit -m "fix(e2e): ThemeDropdown auto 버튼 data-testid 추가 — i18n 독립 셀렉터"
+```
+
+---
+
+### Task 4: CardSpread labelKo → getPositionLabel i18n 적용
+
+**맥락:** `src/components/card/CardSpread.tsx` L176, L188에서 `pos.labelKo`를 하드코딩 사용. en/ja 사용자에게 카드 위치 라벨이 항상 한국어로 표시됨. `getPositionLabel(pos, locale)` 함수가 이미 `src/data/spreads/index.ts`에 존재하며 타로 세션 페이지에서 사용 중.
+
+**Files:**
+- Modify: `src/components/card/CardSpread.tsx`
+
+- [ ] **Step 1: import 추가**
+
+파일 상단 import 블록에 추가 (기존 `hexToRgbBase` import 아래):
+```typescript
+import { getPositionLabel } from "@/data/spreads";
+import { useLocaleStore } from "@/hooks/useLocaleStore";
+```
+
+- [ ] **Step 2: locale 구독 추가**
+
+`CardSpread` 컴포넌트 함수 내부 최상단 (기존 `const containerRef = useRef...` 바로 위)에 추가:
+```typescript
+const locale = useLocaleStore((s) => s.locale);
+```
+
+- [ ] **Step 3: pos.labelKo 두 곳 교체**
+
+L176 (카드 공개 후 라벨):
+```typescript
+// 변경 전
+{pos.labelKo}
+// 변경 후
+{getPositionLabel(pos, locale)}
+```
+
+L188 (카드 미선택 플레이스홀더 라벨):
+```typescript
+// 변경 전
+{pos.labelKo}
+// 변경 후
+{getPositionLabel(pos, locale)}
+```
+
+- [ ] **Step 4: 타입 검사 + 수동 검증**
+
+```bash
+pnpm type-check && pnpm lint
+```
+
+브라우저 `/tarot` → 상담사·주제·스프레드 선택 → 카드 선택 화면: 위치 라벨이 정상 표시되는지 확인.
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add src/components/card/CardSpread.tsx
+git commit -m "fix(i18n): CardSpread 위치 라벨 locale 적용 — labelKo 하드코딩 제거"
+```
+
+---
+
+### Task 5: saju/shinjeom 버튼 data-testid 표준화
+
+**맥락:** PR-9에서 타로 페이지에 `topic-btn-*`, `spread-btn-*` testid가 추가되었지만 사주·신점 페이지의 선택 버튼에는 testid가 없다. E2E 작성 시 텍스트 셀렉터에 의존해야 함.
+
+**Files:**
+- Modify: `src/app/saju/page.tsx`
+- Modify: `src/app/shinjeom/page.tsx`
+
+- [ ] **Step 1: saju/page.tsx 시간 범위 버튼 testid 추가**
+
+`SajuSelectStep` 컴포넌트의 `sajuTimeOptions.map()` 내부 `<button` 태그에 추가:
+```typescript
+<button
+  key={opt.id}
+  data-testid={`saju-time-btn-${opt.id}`}
+  onClick={() => onTimeSelect(opt.id, !!opt.allowMonthly)}
+  ...
+>
+```
+
+- [ ] **Step 2: saju/page.tsx 영역 버튼 testid 추가**
+
+`SajuSelectStep`의 `sajuAreaOptions.map()` 내부 `<button` 태그에 추가:
+```typescript
+<button
+  key={opt.id}
+  data-testid={`saju-area-btn-${opt.id}`}
+  onClick={() => onAreaSelect(opt.id)}
+  ...
+>
+```
+
+- [ ] **Step 3: shinjeom/page.tsx 주제 버튼 testid 추가**
+
+`TopicSelectStep`의 `TOPIC_CONFIGS.map()` 내부 `<motion.button` 태그에 추가:
+```typescript
+<motion.button
+  key={topic.id}
+  data-testid={`shinjeom-topic-btn-${topic.id}`}
+  ...
+>
+```
+
+- [ ] **Step 4: 타입 검사 + 커밋**
+
+```bash
+pnpm type-check && pnpm lint
+git add src/app/saju/page.tsx src/app/shinjeom/page.tsx
+git commit -m "feat(e2e): saju/shinjeom 선택 버튼 data-testid 표준화"
+```
+
+---
+
+## Phase 3 — 중기 (개선)
+
+### Task 6: 신점 E2E 세션 플로우 추가
+
+**맥락:** `e2e/shinjeom-flow.spec.ts`는 캐릭터·주제 선택까지만 검증하며 메시지 전송 → AI 응답 플로우가 없다. Task 1 이후 AbortController가 추가되었으므로 E2E 커버리지도 확보한다.
+
+⚠️ **실 Supabase 인증 세션 필요 — 이 spec은 CI `testIgnore` 대상으로 등록하지 않음** (세션 생성 API는 인증 없이도 동작하고 결과 저장 실패 시 graceful fallback).
+
+**Files:**
+- Modify: `e2e/shinjeom-flow.spec.ts`
+
+- [ ] **Step 1: 기존 spec 파일 확인**
+
+```bash
+cat e2e/shinjeom-flow.spec.ts
+```
+
+마지막 `test.describe` 블록 끝에 추가할 위치 파악.
+
+- [ ] **Step 2: 메시지 전송 플로우 test 추가**
+
+```typescript
+test.describe("신점 세션 — 메시지 전송 플로우", () => {
+  test.beforeEach(async ({ page }) => {
+    // 신점 세션 진입: 첫 번째 캐릭터 선택 → 첫 번째 주제 선택
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.goto("/shinjeom");
+    await page.waitForLoadState("domcontentloaded");
+    // 캐릭터 선택
+    const firstChar = page.locator("[data-testid='character-card']").first();
+    if (await firstChar.isVisible()) {
+      await firstChar.click();
+    }
+    // 주제 선택
+    const firstTopic = page.locator("[data-testid^='shinjeom-topic-btn-']").first();
+    await expect(firstTopic).toBeVisible({ timeout: 5000 });
+    await firstTopic.click();
+    await page.waitForURL("**/shinjeom/session", { timeout: 10000 });
+  });
+
+  test("입력창 표시 + 메시지 전송 가능", async ({ page }) => {
+    const input = page.locator("input[type='text']").first();
+    await expect(input).toBeVisible({ timeout: 5000 });
+    await expect(input).not.toBeDisabled();
+
+    await input.fill("안녕하세요");
+    const sendBtn = page.locator("button:has-text('전송')").first();
+    await expect(sendBtn).not.toBeDisabled();
+  });
+
+  test("메시지 전송 후 isLoading 해제 (타임아웃 없음)", async ({ page }) => {
+    const input = page.locator("input[type='text']").first();
+    await input.fill("오늘 운세는 어때요?");
+
+    const sendBtn = page.locator("button:has-text('전송')").first();
+    await sendBtn.click();
+
+    // 전송 후 입력창 비워짐 확인
+    await expect(input).toHaveValue("", { timeout: 3000 });
+
+    // 로딩 완료 후 입력 재활성화 (최대 30초 AI 응답 대기)
+    await expect(input).not.toBeDisabled({ timeout: 30000 });
+  });
+});
+```
+
+- [ ] **Step 3: lint + 커밋**
+
+```bash
+pnpm lint
+git add e2e/shinjeom-flow.spec.ts
+git commit -m "test(e2e): 신점 세션 메시지 전송 플로우 E2E 추가"
+```
+
+---
+
+### Task 7: fetchMemoryPrompt 직접 테스트 추가
+
+**맥락:** `src/lib/db/character-context.ts`의 `fetchMemoryPrompt()` 함수가 PR-5에서 추가되었지만 테스트가 없다. `getCurrentUser()` 실패·`null` 반환·최외부 catch 분기가 미커버.
+
+**Files:**
+- Modify or Create: `src/__tests__/lib/character-context.test.ts`
+
+- [ ] **Step 1: 기존 파일 확인**
+
+```bash
+cat src/__tests__/lib/character-context.test.ts 2>/dev/null || echo "file not found"
+```
+
+파일이 있으면 기존 `describe` 블록 뒤에 추가. 없으면 새로 생성.
+
+- [ ] **Step 2: fetchMemoryPrompt 테스트 추가**
+
+파일에 추가할 내용:
+
+```typescript
+import { vi, describe, it, expect, beforeEach } from "vitest";
+import { fetchMemoryPrompt } from "@/lib/db/character-context";
+
+// 모킹 설정
+vi.mock("@/lib/auth", () => ({
+  getCurrentUser: vi.fn(),
+}));
+vi.mock("@/lib/db", () => ({
+  getDb: vi.fn(),
+}));
+
+import { getCurrentUser } from "@/lib/auth";
+import { getDb } from "@/lib/db";
+
+describe("fetchMemoryPrompt", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("비인증 사용자 → 빈 문자열 반환", async () => {
+    vi.mocked(getCurrentUser).mockResolvedValue(null);
+    const result = await fetchMemoryPrompt("arcana", "ko");
+    expect(result).toBe("");
+    expect(getDb).not.toHaveBeenCalled();
+  });
+
+  it("인증 사용자 + 메모리 없음 → 빈 문자열 반환", async () => {
+    vi.mocked(getCurrentUser).mockResolvedValue({ id: "user-123" } as Awaited<ReturnType<typeof getCurrentUser>>);
+    const mockDb = { query: { characterMemories: { findMany: vi.fn().mockResolvedValue([]) } } };
+    vi.mocked(getDb).mockReturnValue(mockDb as ReturnType<typeof getDb>);
+
+    const result = await fetchMemoryPrompt("arcana", "ko");
+    expect(result).toBe("");
+  });
+
+  it("getCurrentUser 예외 → 빈 문자열 반환 (crash 없음)", async () => {
+    vi.mocked(getCurrentUser).mockRejectedValue(new Error("auth error"));
+    const result = await fetchMemoryPrompt("arcana", "ko");
+    expect(result).toBe("");
+  });
+});
+```
+
+- [ ] **Step 3: 실제 fetchMemoryPrompt 시그니처 확인 후 코드 조정**
+
+```bash
+cat src/lib/db/character-context.ts | grep -A 10 "fetchMemoryPrompt"
+```
+
+함수 시그니처·의존 import 경로를 확인하고 위 테스트 코드의 vi.mock 경로를 실제 경로로 맞춤.
+
+- [ ] **Step 4: 테스트 실행**
+
+```bash
+pnpm test --reporter=verbose src/__tests__/lib/character-context.test.ts
+```
+
+Expected: 3개 테스트 PASS.
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add src/__tests__/lib/character-context.test.ts
+git commit -m "test: fetchMemoryPrompt 직접 테스트 추가 — getCurrentUser 실패 분기 커버"
+```
+
+---
+
+### Task 8: CharacterDisplay·DialogueBox React.memo 적용
+
+**맥락:** PR-10에서 SpriteAnimator, CardDeck, CardSpread에 React.memo를 적용했으나 유사 규모의 `CharacterDisplay`(114줄)·`DialogueBox`(114줄)는 누락. 세션 페이지에서 이 컴포넌트들이 모든 상태 변경 시 재렌더됨.
+
+**Files:**
+- Modify: `src/components/character/CharacterDisplay.tsx`
+- Modify: `src/components/chat/DialogueBox.tsx`
+
+- [ ] **Step 1: CharacterDisplay.tsx 파일 내용 확인**
+
+```bash
+head -30 src/components/character/CharacterDisplay.tsx
+```
+
+현재 export 방식 확인 (`export function` vs `const` vs 이미 `React.memo`인지).
+
+- [ ] **Step 2: CharacterDisplay React.memo 적용**
+
+현재 `export function CharacterDisplay(...)` 형태라면:
+
+```typescript
+// 변경 전
+export function CharacterDisplay({ character, mood, className }: CharacterDisplayProps) {
+  ...
+}
+
+// 변경 후
+export const CharacterDisplay = React.memo(function CharacterDisplay({ character, mood, className }: CharacterDisplayProps) {
+  ...
+});
+CharacterDisplay.displayName = "CharacterDisplay";
+```
+
+파일 상단 import에 `React`가 없으면 추가:
+```typescript
+import React from "react";
+```
+
+- [ ] **Step 3: DialogueBox React.memo 적용**
+
+```bash
+head -30 src/components/chat/DialogueBox.tsx
+```
+
+동일 패턴으로 `React.memo` + `displayName` 적용.
+
+- [ ] **Step 4: 타입 검사 + 커밋**
+
+```bash
+pnpm type-check && pnpm lint
+git add src/components/character/CharacterDisplay.tsx src/components/chat/DialogueBox.tsx
+git commit -m "perf(components): CharacterDisplay·DialogueBox React.memo 적용"
+```
+
+---
+
+### Task 9: CardSpread loading skeleton 개선
+
+**맥락:** `src/app/tarot/session/page.tsx`의 `next/dynamic`에서 CardSpread는 `loading: () => null`로 설정되어 있어 로딩 중 레이아웃 시프트 발생. CardDeck은 적절한 플레이스홀더를 제공하는 것과 대비됨.
+
+**Files:**
+- Modify: `src/app/tarot/session/page.tsx` (CardSpread dynamic import, L23~L27)
+
+- [ ] **Step 1: 현재 dynamic import 확인**
+
+```bash
+grep -A 4 "CardSpread = dynamic" src/app/tarot/session/page.tsx
+```
+
+- [ ] **Step 2: CardSpread loading 플레이스홀더 교체**
+
+```typescript
+// 변경 전
+const CardSpread = dynamic(
+  () => import("@/components/card/CardSpread").then((m) => ({ default: m.CardSpread })),
+  { loading: () => null },
+);
+
+// 변경 후
+const CardSpread = dynamic(
+  () => import("@/components/card/CardSpread").then((m) => ({ default: m.CardSpread })),
+  { loading: () => <div className="w-full flex-1 min-h-[200px] md:min-h-[360px]" /> },
+);
+```
+
+- [ ] **Step 3: 타입 검사 + 커밋**
+
+```bash
+pnpm type-check && pnpm lint
+git add src/app/tarot/session/page.tsx
+git commit -m "perf(ux): CardSpread loading skeleton 추가 — 레이아웃 시프트 방지"
+```
+
+---
+
+## 자기 검토 (Self-Review)
+
+### 스펙 커버리지 확인
+- [x] Task 1: 신점 AbortController + 180s → 타로/사주와 동일 패턴
+- [x] Task 2: 사주 cleanup → readingAbortRef ref 저장
+- [x] Task 3: ThemeDropdown auto testid → 데스크탑/모바일 각각
+- [x] Task 4: CardSpread labelKo → getPositionLabel locale 적용
+- [x] Task 5: saju/shinjeom 버튼 testid 표준화
+- [x] Task 6: 신점 E2E 세션 플로우
+- [x] Task 7: fetchMemoryPrompt 테스트 (getCurrentUser 실패 분기 포함)
+- [x] Task 8: CharacterDisplay·DialogueBox React.memo
+- [x] Task 9: CardSpread loading skeleton
+
+### 플레이스홀더 스캔
+- Task 7 Step 2의 vi.mock 경로는 실제 파일 확인 후 조정 필수 (Step 3에서 안내)
+- Task 8의 현재 export 형태는 파일마다 다를 수 있으므로 Step 1에서 확인 필수
+
+### 타입 일관성
+- `fetchSSEStream` onChunk 시그니처: `(chunk: string, fullText: string) => void` — Task 1에서 `(_chunk, fullText)`로 올바르게 사용
+- `getPositionLabel(pos, locale)` — `pos: SpreadPosition`, `locale: Locale` — Task 4에서 `useLocaleStore`로 locale 공급
+
+---
+
+## Phase 실행 순서
+
+```
+Phase 1 완료 후 → PR-A 머지 → Phase 2 진행
+Phase 2 완료 후 → PR-B 머지 → Phase 3 진행
+Phase 3 각 Task는 독립 PR 가능
+```
+
+Phase 1은 반드시 먼저 배포해야 신점 영구 멈춤 버그가 프로덕션에서 해소됨.

--- a/e2e/shinjeom-flow.spec.ts
+++ b/e2e/shinjeom-flow.spec.ts
@@ -90,3 +90,46 @@ test.describe("신점 서비스 플로우", () => {
     expect(await cards.count()).toBeLessThanOrEqual(6);
   });
 });
+
+test.describe("신점 세션 — 메시지 전송 플로우", () => {
+  test.beforeEach(async ({ page }) => {
+    // 신점 세션 진입: 첫 번째 캐릭터 선택 → 첫 번째 주제 선택
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.goto("/shinjeom");
+    await page.waitForLoadState("domcontentloaded");
+    // 캐릭터 선택
+    const firstChar = page.locator("[data-testid='character-card']").first();
+    if (await firstChar.isVisible()) {
+      await firstChar.click();
+    }
+    // 주제 선택
+    const firstTopic = page.locator("[data-testid^='shinjeom-topic-btn-']").first();
+    await expect(firstTopic).toBeVisible({ timeout: 5000 });
+    await firstTopic.click();
+    await page.waitForURL("**/shinjeom/session", { timeout: 10000 });
+  });
+
+  test("입력창 표시 + 메시지 전송 가능", async ({ page }) => {
+    const input = page.locator("input[type='text']").first();
+    await expect(input).toBeVisible({ timeout: 5000 });
+    await expect(input).not.toBeDisabled();
+
+    await input.fill("안녕하세요");
+    const sendBtn = page.locator("button:has-text('전송')").first();
+    await expect(sendBtn).not.toBeDisabled();
+  });
+
+  test("메시지 전송 후 isLoading 해제 (타임아웃 없음)", async ({ page }) => {
+    const input = page.locator("input[type='text']").first();
+    await input.fill("오늘 운세는 어때요?");
+
+    const sendBtn = page.locator("button:has-text('전송')").first();
+    await sendBtn.click();
+
+    // 전송 후 입력창 비워짐 확인
+    await expect(input).toHaveValue("", { timeout: 3000 });
+
+    // 로딩 완료 후 입력 재활성화 (최대 30초 AI 응답 대기)
+    await expect(input).not.toBeDisabled({ timeout: 30000 });
+  });
+});

--- a/e2e/shinjeom-flow.spec.ts
+++ b/e2e/shinjeom-flow.spec.ts
@@ -99,9 +99,8 @@ test.describe("신점 세션 — 메시지 전송 플로우", () => {
     await page.waitForLoadState("domcontentloaded");
     // 캐릭터 선택
     const firstChar = page.locator("[data-testid='character-card']").first();
-    if (await firstChar.isVisible()) {
-      await firstChar.click();
-    }
+    await expect(firstChar).toBeVisible({ timeout: 5000 });
+    await firstChar.click();
     // 주제 선택
     const firstTopic = page.locator("[data-testid^='shinjeom-topic-btn-']").first();
     await expect(firstTopic).toBeVisible({ timeout: 5000 });

--- a/e2e/shinjeom-flow.spec.ts
+++ b/e2e/shinjeom-flow.spec.ts
@@ -97,9 +97,9 @@ test.describe("신점 세션 — 메시지 전송 플로우", () => {
     await page.setViewportSize({ width: 390, height: 844 });
     await page.goto("/shinjeom");
     await page.waitForLoadState("domcontentloaded");
-    // 캐릭터 선택
-    const firstChar = page.locator("[data-testid='character-card']").first();
-    await expect(firstChar).toBeVisible({ timeout: 5000 });
+    // 캐릭터 선택 (기존 spec 패턴 — shinjeom 페이지는 character-card testid 없음)
+    const firstChar = page.locator("button").filter({ hasText: /아르카나|루나|미코/ }).first();
+    await expect(firstChar).toBeVisible({ timeout: 10_000 });
     await firstChar.click();
     // 주제 선택
     const firstTopic = page.locator("[data-testid^='shinjeom-topic-btn-']").first();

--- a/e2e/theme.spec.ts
+++ b/e2e/theme.spec.ts
@@ -33,18 +33,18 @@ test.describe("테마 드롭다운 — 데스크탑 기본 동작", () => {
     await expect(btn).toBeVisible();
     await btn.click();
 
-    // 드롭다운 내 자동 모드 항목 표시 확인 (데스크탑: first)
-    const autoOption = page.locator("text=자동 (시간/계절)").first();
+    // 드롭다운 내 자동 모드 항목 표시 확인 (데스크탑: data-testid)
+    const autoOption = page.locator("[data-testid='theme-option-auto']");
     await expect(autoOption).toBeVisible({ timeout: 3000 });
   });
 
   test("외부 클릭 시 드롭다운 닫힘", async ({ page }) => {
     const btn = page.locator("button[aria-label='테마 변경']").first();
     await btn.click();
-    await expect(page.locator("text=자동 (시간/계절)").first()).toBeVisible({ timeout: 3000 });
+    await expect(page.locator("[data-testid='theme-option-auto']")).toBeVisible({ timeout: 3000 });
 
     await page.locator("body").click({ position: { x: 100, y: 400 } });
-    await expect(page.locator("text=자동 (시간/계절)").first()).not.toBeVisible({ timeout: 2000 });
+    await expect(page.locator("[data-testid='theme-option-auto']")).not.toBeVisible({ timeout: 2000 });
   });
 });
 
@@ -59,7 +59,7 @@ test.describe("테마 드롭다운 — 7개 테마 선택 + localStorage + CSS �
     test(`테마 선택: ${nameKo} (${id})`, async ({ page }) => {
       const btn = page.locator("button[aria-label='테마 변경']").first();
       await btn.click();
-      await expect(page.locator("text=자동 (시간/계절)").first()).toBeVisible({ timeout: 3000 });
+      await expect(page.locator("[data-testid='theme-option-auto']")).toBeVisible({ timeout: 3000 });
 
       // data-testid 기반 — auto 버튼 오탐 완전 차단
       await themeOptionBtn(page, id).evaluate((el) => (el as HTMLElement).click());
@@ -87,13 +87,13 @@ test.describe("테마 드롭다운 — auto 모드 선택", () => {
 
     const btn = page.locator("button[aria-label='테마 변경']").first();
     await btn.click();
-    await expect(page.locator("text=자동 (시간/계절)").first()).toBeVisible({ timeout: 3000 });
+    await expect(page.locator("[data-testid='theme-option-auto']")).toBeVisible({ timeout: 3000 });
     await themeOptionBtn(page, "midnight").evaluate((el) => (el as HTMLElement).click());
     await page.waitForFunction(() => localStorage.getItem("arcana-theme-mode") === "midnight", { timeout: 3000 });
 
     await btn.click();
-    await expect(page.locator("text=자동 (시간/계절)").first()).toBeVisible({ timeout: 3000 });
-    await page.locator("text=자동 (시간/계절)").first().evaluate((el) => (el as HTMLElement).click());
+    await expect(page.locator("[data-testid='theme-option-auto']")).toBeVisible({ timeout: 3000 });
+    await page.locator("[data-testid='theme-option-auto']").evaluate((el) => (el as HTMLElement).click());
     await page.waitForFunction(() => localStorage.getItem("arcana-theme-mode") === "auto", { timeout: 3000 });
 
     const saved = await page.evaluate(() => localStorage.getItem("arcana-theme-mode"));
@@ -111,8 +111,8 @@ test.describe("테마 드롭다운 — 모바일 390px", () => {
     const btn = page.locator("button[aria-label='테마 변경']").last();
     await btn.click();
 
-    // 모바일 드롭다운은 DOM 순서상 두 번째(last) — 첫 번째는 데스크탑(md:flex → 390px hidden)
-    await expect(page.locator("text=자동 (시간/계절)").last()).toBeVisible({ timeout: 3000 });
+    // 모바일 드롭다운 — mobile-theme-option-auto testid 사용
+    await expect(page.locator("[data-testid='mobile-theme-option-auto']")).toBeVisible({ timeout: 3000 });
 
     // 모바일 드롭다운 버튼 — mobile-theme-option-* testid 사용
     await mobileThemeOptionBtn(page, "midnight").evaluate((el) => (el as HTMLElement).click());
@@ -133,7 +133,7 @@ test.describe("테마 — 새로고침 후 유지", () => {
 
     const btn = page.locator("button[aria-label='테마 변경']").first();
     await btn.click();
-    await expect(page.locator("text=자동 (시간/계절)").first()).toBeVisible({ timeout: 3000 });
+    await expect(page.locator("[data-testid='theme-option-auto']")).toBeVisible({ timeout: 3000 });
     await themeOptionBtn(page, "sunset").evaluate((el) => (el as HTMLElement).click());
     await page.waitForFunction(() => localStorage.getItem("arcana-theme-mode") === "sunset", { timeout: 3000 });
 
@@ -159,7 +159,7 @@ test.describe("테마 — 설정 페이지 상태 일치", () => {
 
     const btn = page.locator("button[aria-label='테마 변경']").first();
     await btn.click();
-    await expect(page.locator("text=자동 (시간/계절)").first()).toBeVisible({ timeout: 3000 });
+    await expect(page.locator("[data-testid='theme-option-auto']")).toBeVisible({ timeout: 3000 });
     await themeOptionBtn(page, "summer").evaluate((el) => (el as HTMLElement).click());
     await page.waitForFunction(() => localStorage.getItem("arcana-theme-mode") === "summer", { timeout: 3000 });
 

--- a/src/__tests__/lib/character-context.test.ts
+++ b/src/__tests__/lib/character-context.test.ts
@@ -1,6 +1,20 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { makeMockDb } from "@/test-helpers/mock-db";
-import { getRecentCharacterMemory } from "@/lib/db/character-context";
+import { getRecentCharacterMemory, fetchMemoryPrompt } from "@/lib/db/character-context";
+
+vi.mock("@/lib/auth", () => ({
+  getCurrentUser: vi.fn(),
+}));
+
+vi.mock("@/lib/db", () => ({
+  getDb: vi.fn(),
+}));
+
+vi.mock("@/services/core/prompt-builder", () => ({
+  buildCharacterMemoryPrompt: vi.fn((memories: unknown[]) =>
+    memories.length === 0 ? "" : `메모리-프롬프트(${memories.length}개)`,
+  ),
+}));
 
 describe("getRecentCharacterMemory", () => {
   it("세션 + 리딩 조회 → 메모리 반환", async () => {
@@ -87,5 +101,73 @@ describe("getRecentCharacterMemory", () => {
     db.findManyIn.mockResolvedValue([{ session_id: "s1", overall_reading: longText }]);
     const result = await getRecentCharacterMemory(db, "user-1", "arcana");
     expect(result[0].overallReading).toHaveLength(150);
+  });
+});
+
+describe("fetchMemoryPrompt", () => {
+  let getCurrentUserMock: ReturnType<typeof vi.fn>;
+  let getDbMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const authModule = await import("@/lib/auth");
+    const dbModule = await import("@/lib/db");
+    getCurrentUserMock = authModule.getCurrentUser as ReturnType<typeof vi.fn>;
+    getDbMock = dbModule.getDb as ReturnType<typeof vi.fn>;
+  });
+
+  it("비인증 사용자(null) → 빈 문자열 반환", async () => {
+    getCurrentUserMock.mockResolvedValue(null);
+    const result = await fetchMemoryPrompt("arcana", "ko");
+    expect(result).toBe("");
+    expect(getDbMock).not.toHaveBeenCalled();
+  });
+
+  it("id 없는 사용자 객체 → 빈 문자열 반환", async () => {
+    getCurrentUserMock.mockResolvedValue({ email: "test@example.com" });
+    const result = await fetchMemoryPrompt("arcana", "ko");
+    expect(result).toBe("");
+    expect(getDbMock).not.toHaveBeenCalled();
+  });
+
+  it("인증된 사용자 + 메모리 없음 → 빈 문자열 반환", async () => {
+    getCurrentUserMock.mockResolvedValue({ id: "user-123", email: "test@example.com" });
+    const db = makeMockDb();
+    db.findMany.mockResolvedValue([]);
+    db.findManyIn.mockResolvedValue([]);
+    getDbMock.mockReturnValue(db);
+
+    const result = await fetchMemoryPrompt("arcana", "ko");
+    expect(result).toBe("");
+  });
+
+  it("인증된 사용자 + 메모리 있음 → 프롬프트 문자열 반환", async () => {
+    getCurrentUserMock.mockResolvedValue({ id: "user-123", email: "test@example.com" });
+    const db = makeMockDb();
+    db.findMany.mockResolvedValue([
+      { id: "s1", service_type: "tarot", created_at: "2026-04-01T00:00:00Z" },
+    ]);
+    db.findManyIn.mockResolvedValue([
+      { session_id: "s1", overall_reading: "운이 좋다" },
+    ]);
+    getDbMock.mockReturnValue(db);
+
+    const result = await fetchMemoryPrompt("arcana", "ko");
+    expect(result).toBe("메모리-프롬프트(1개)");
+  });
+
+  it("getCurrentUser throws → 빈 문자열 반환 (충돌 방지)", async () => {
+    getCurrentUserMock.mockRejectedValue(new Error("Auth service down"));
+    const result = await fetchMemoryPrompt("arcana", "ko");
+    expect(result).toBe("");
+  });
+
+  it("getDb throws → 빈 문자열 반환 (충돌 방지)", async () => {
+    getCurrentUserMock.mockResolvedValue({ id: "user-123", email: "test@example.com" });
+    getDbMock.mockImplementation(() => {
+      throw new Error("DB init failed");
+    });
+    const result = await fetchMemoryPrompt("arcana", "ko");
+    expect(result).toBe("");
   });
 });

--- a/src/app/saju/page.tsx
+++ b/src/app/saju/page.tsx
@@ -139,7 +139,7 @@ function SajuSelectStep({ selectedCharacter, dialogueMessages, selectedTime, sel
           </div>
           <div className="flex flex-wrap gap-2">
             {sajuTimeOptions.map((opt) => (
-              <button key={opt.id} onClick={() => onTimeSelect(opt.id, !!opt.allowMonthly)}
+              <button key={opt.id} data-testid={`saju-time-btn-${opt.id}`} onClick={() => onTimeSelect(opt.id, !!opt.allowMonthly)}
                 className={`flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-display font-bold border transition-all ${
                   selectedTime === opt.id
                     ? "border-arcana-purple bg-arcana-purple/20 text-arcana-purple shadow-sm shadow-arcana-purple/20"
@@ -174,7 +174,7 @@ function SajuSelectStep({ selectedCharacter, dialogueMessages, selectedTime, sel
           </div>
           <div className="grid grid-cols-2 gap-2">
             {sajuAreaOptions.map((opt) => (
-              <button key={opt.id} onClick={() => onAreaSelect(opt.id)}
+              <button key={opt.id} data-testid={`saju-area-btn-${opt.id}`} onClick={() => onAreaSelect(opt.id)}
                 className={`flex items-center gap-2 px-3 py-2 rounded-xl text-left border transition-all ${
                   selectedArea === opt.id
                     ? "border-arcana-purple bg-arcana-purple/15 shadow-sm shadow-arcana-purple/20"

--- a/src/app/saju/session/page.tsx
+++ b/src/app/saju/session/page.tsx
@@ -93,6 +93,7 @@ export default function SajuSessionPage() {
   const [readingErrorReason, setReadingErrorReason] = useState<"timeout" | "generic">("generic");
   const resultContainerRef = useRef<HTMLDivElement>(null);
   const redirectedRef = useRef(false);
+  const readingAbortRef = useRef<AbortController | null>(null);
 
   useEffect(() => {
     if (!topic || !character || !userInfo || !timeRange) {
@@ -141,6 +142,7 @@ export default function SajuSessionPage() {
 
     // 클라이언트 hard timeout (180초). 서버 SSE가 hung되거나 done 이벤트가 도달 못 하는 경우 강제 종료.
     const abortController = new AbortController();
+    readingAbortRef.current = abortController;
     let finished = false;
     const timeoutId = setTimeout(() => {
       if (finished) return;
@@ -221,6 +223,10 @@ export default function SajuSessionPage() {
       if (container) container.scrollTop = container.scrollHeight;
     }
   }, [chatMessages, phase]);
+
+  useEffect(() => {
+    return () => { readingAbortRef.current?.abort(); };
+  }, []);
 
   const birthYear = userInfo ? parseInt(userInfo.birthDate.split("-")[0]) : 2000;
 

--- a/src/app/shinjeom/page.tsx
+++ b/src/app/shinjeom/page.tsx
@@ -92,7 +92,7 @@ function TopicSelectStep({ selectedCharacter, onBack, onTopicSelect }: Readonly<
       <p className="text-arcana-muted text-xs mb-6">{t("shinjeom.page.topic-select.sub")}</p>
       <div className="grid grid-cols-1 gap-3">
         {TOPIC_CONFIGS.map((topic, index) => (
-          <motion.button key={topic.id} initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }}
+          <motion.button key={topic.id} data-testid={`shinjeom-topic-btn-${topic.id}`} initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }}
             transition={{ delay: index * 0.1 }} whileTap={{ scale: 0.97 }}
             onClick={() => onTopicSelect(topic.id)}
             className="bg-arcana-card/70 backdrop-blur-sm border border-arcana-border rounded-xl p-4 text-left hover:border-arcana-purple transition-all hover:shadow-lg hover:shadow-arcana-purple/10">

--- a/src/app/shinjeom/session/page.tsx
+++ b/src/app/shinjeom/session/page.tsx
@@ -119,6 +119,7 @@ export default function ShinjeomSessionPage() {
     addChatMessage({ id: msgId, role: "character", content: "", mood: "mystical", timestamp: new Date() });
 
     const abortController = new AbortController();
+    readingAbortRef.current?.abort();
     readingAbortRef.current = abortController;
     let finished = false;
 
@@ -179,6 +180,7 @@ export default function ShinjeomSessionPage() {
     });
 
     const abortController = new AbortController();
+    readingAbortRef.current?.abort();
     readingAbortRef.current = abortController;
     let finished = false;
 
@@ -369,6 +371,7 @@ export default function ShinjeomSessionPage() {
                 </div>
                 {turnCount >= 1 && (
                   <button
+                    data-testid="shinjeom-get-result-btn"
                     onClick={handleEndConsultation}
                     disabled={isLoading}
                     className="w-full mt-2 py-2.5 rounded-full border border-arcana-gold/60 text-arcana-gold font-serif font-bold text-sm disabled:opacity-40 transition-opacity hover:bg-arcana-gold/10"

--- a/src/app/shinjeom/session/page.tsx
+++ b/src/app/shinjeom/session/page.tsx
@@ -17,6 +17,7 @@ import { getCharacterGreeting } from "@/data/characters/locale-helpers";
 import { useLocaleStore } from "@/hooks/useLocaleStore";
 import { useT } from "@/i18n/useT";
 import { t as translate } from "@/i18n/translations";
+import { fetchSSEStream } from "@/hooks/useSSEStream";
 
 function getErrorMsg(charId: string | null | undefined, type: "api" | "reading"): string {
   const wl = getWaitingLinesData(useLocaleStore.getState().locale);
@@ -38,35 +39,6 @@ function removeMessage(msgId: string) {
   }));
 }
 
-function parseSseLine(line: string): Record<string, unknown> | null {
-  if (!line.startsWith("data: ")) return null;
-  try {
-    return JSON.parse(line.slice(6)) as Record<string, unknown>;
-  } catch {
-    return null;
-  }
-}
-
-async function drainSseChunks(
-  reader: ReadableStreamDefaultReader<Uint8Array>,
-  onChunk: (data: Record<string, unknown>) => boolean
-): Promise<void> {
-  const decoder = new TextDecoder();
-  let sseBuffer = "";
-  while (true) {
-    const { done, value } = await reader.read();
-    if (done) break;
-    sseBuffer += decoder.decode(value, { stream: true });
-    const lines = sseBuffer.split("\n");
-    sseBuffer = lines.pop() ?? "";
-    for (const line of lines) {
-      const data = parseSseLine(line);
-      if (data === null) continue;
-      const stop = onChunk(data);
-      if (stop) return;
-    }
-  }
-}
 
 export default function ShinjeomSessionPage() {
   const router = useRouter();
@@ -82,6 +54,7 @@ export default function ShinjeomSessionPage() {
   const [inputText, setInputText] = useState("");
   const [sessionCreated, setSessionCreated] = useState(false);
   const redirectedRef = useRef(false);
+  const readingAbortRef = useRef<AbortController | null>(null);
 
   // 세션 생성
   useEffect(() => {
@@ -126,7 +99,11 @@ export default function ShinjeomSessionPage() {
     }
   }, [chatMessages.length]);
 
-  const handleSend = async () => {
+  useEffect(() => {
+    return () => { readingAbortRef.current?.abort(); };
+  }, []);
+
+  const handleSend = () => {
     const message = inputText.trim();
     if (!message || isLoading) return;
 
@@ -134,102 +111,127 @@ export default function ShinjeomSessionPage() {
     setLoading(true);
     setMood("mystical");
 
-    // messageIndex: addChatMessage 호출 전 현재 길이를 캡처
     const messageIndex = useShinjeomSessionStore.getState().chatMessages.length;
-
     addChatMessage({ id: crypto.randomUUID(), role: "user", content: message, timestamp: new Date() });
     incrementTurn();
 
-    try {
-      const response = await fetch("/api/shinjeom/message", {
-        method: "POST", headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          sessionId: useShinjeomSessionStore.getState().sessionId,
-          topic, characterId,
-          currentMessage: message,
-          chatHistory: useShinjeomSessionStore.getState().chatMessages,
-          isFinalTurn: false,
-          messageIndex,
-        }),
-      });
+    const msgId = crypto.randomUUID();
+    addChatMessage({ id: msgId, role: "character", content: "", mood: "mystical", timestamp: new Date() });
 
-      if (!response.ok || !response.body) {
-        addChatMessage({ id: crypto.randomUUID(), role: "character", content: getErrorMsg(characterId, "api"), mood: "default", timestamp: new Date() });
+    const abortController = new AbortController();
+    readingAbortRef.current = abortController;
+    let finished = false;
+
+    const timeoutId = setTimeout(() => {
+      if (finished) return;
+      finished = true;
+      abortController.abort();
+      updateMessageContent(msgId, getErrorMsg(characterId, "api"));
+      setMood("default");
+      setLoading(false);
+    }, 180_000);
+
+    void fetchSSEStream({
+      url: "/api/shinjeom/message",
+      signal: abortController.signal,
+      body: {
+        sessionId: useShinjeomSessionStore.getState().sessionId,
+        topic, characterId,
+        currentMessage: message,
+        chatHistory: useShinjeomSessionStore.getState().chatMessages,
+        isFinalTurn: false,
+        messageIndex,
+      },
+      onChunk: (_chunk, fullText) => {
+        updateMessageContent(msgId, fullText);
+      },
+      onDone: () => {
+        if (finished) return;
+        finished = true;
+        clearTimeout(timeoutId);
+        setLoading(false);
+      },
+      onError: () => {
+        if (finished) return;
+        finished = true;
+        clearTimeout(timeoutId);
+        updateMessageContent(msgId, getErrorMsg(characterId, "reading"));
         setMood("default");
         setLoading(false);
-        return;
-      }
-
-      const msgId = crypto.randomUUID();
-      addChatMessage({ id: msgId, role: "character", content: "", mood: "mystical", timestamp: new Date() });
-
-      let fullText = "";
-      await drainSseChunks(response.body.getReader(), (data) => {
-        if (data.error) { updateMessageContent(msgId, getErrorMsg(characterId, "reading")); return true; }
-        if (data.chunk) { fullText += data.chunk as string; updateMessageContent(msgId, fullText); }
-        return false;
-      });
-    } catch {
-      addChatMessage({ id: crypto.randomUUID(), role: "character", content: getErrorMsg(characterId, "api"), mood: "default", timestamp: new Date() });
-      setMood("default");
-    }
-    setLoading(false);
+      },
+    }).then(() => {
+      if (!finished) clearTimeout(timeoutId);
+    });
   };
 
-  const handleEndConsultation = async () => {
+  const handleEndConsultation = () => {
     if (turnCount < 1 || isLoading) return;
 
     setLoading(true);
     setMood("mystical");
 
-    try {
-      const currentChatMessages = useShinjeomSessionStore.getState().chatMessages;
+    const currentChatMessages = useShinjeomSessionStore.getState().chatMessages;
+    const msgId = crypto.randomUUID();
+    addChatMessage({
+      id: msgId, role: "character",
+      content: translate("shinjeom.session.msg.preparing-result", locale),
+      mood: "mystical", timestamp: new Date(),
+    });
 
-      const response = await fetch("/api/shinjeom/message", {
-        method: "POST", headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          sessionId: useShinjeomSessionStore.getState().sessionId,
-          topic, characterId,
-          currentMessage: undefined,
-          chatHistory: currentChatMessages,
-          isFinalTurn: true,
-          messageIndex: currentChatMessages.length,
-        }),
-      });
+    const abortController = new AbortController();
+    readingAbortRef.current = abortController;
+    let finished = false;
 
-      if (!response.ok || !response.body) {
-        addChatMessage({ id: crypto.randomUUID(), role: "character", content: getErrorMsg(characterId, "reading"), mood: "default", timestamp: new Date() });
+    const timeoutId = setTimeout(() => {
+      if (finished) return;
+      finished = true;
+      abortController.abort();
+      updateMessageContent(msgId, getErrorMsg(characterId, "reading"));
+      setMood("default");
+      setLoading(false);
+    }, 180_000);
+
+    void fetchSSEStream({
+      url: "/api/shinjeom/message",
+      signal: abortController.signal,
+      body: {
+        sessionId: useShinjeomSessionStore.getState().sessionId,
+        topic, characterId,
+        currentMessage: undefined,
+        chatHistory: currentChatMessages,
+        isFinalTurn: true,
+        messageIndex: currentChatMessages.length,
+      },
+      onChunk: () => { /* 신점 최종 결과는 done 이벤트로 수신 */ },
+      onDone: (data) => {
+        if (finished) return;
+        finished = true;
+        clearTimeout(timeoutId);
+        const result = data.result as { parseError?: string } | undefined;
+        if (!result || result.parseError) {
+          if (result?.parseError) console.warn("[shinjeom-session] 결과 표시 불가:", { parseError: result.parseError });
+          updateMessageContent(msgId, getErrorMsg(characterId, "reading"));
+          setMood("default");
+          setLoading(false);
+          return;
+        }
+        removeMessage(msgId);
+        setReadingResult(data.result as Parameters<typeof setReadingResult>[0]);
+        setPhase("result");
+        setMood(CHARACTER_RESULT_MOODS[characterId ?? ""] ?? "smile");
+        setLoading(false);
+      },
+      onError: () => {
+        if (finished) return;
+        finished = true;
+        clearTimeout(timeoutId);
+        updateMessageContent(msgId, getErrorMsg(characterId, "reading"));
         setMood("default");
         setLoading(false);
-        return;
-      }
-
-      const msgId = crypto.randomUUID();
-      addChatMessage({ id: msgId, role: "character", content: translate("shinjeom.session.msg.preparing-result", locale), mood: "mystical", timestamp: new Date() });
-
-      await drainSseChunks(response.body.getReader(), (data) => {
-        if (data.error) { updateMessageContent(msgId, getErrorMsg(characterId, "reading")); return true; }
-        if (data.done && data.isFinal && data.result) {
-          const result = data.result as { parseError?: string };
-          // 결과 표시 불가 — DB 저장도 차단된 상태 → 사용자에게 재시도 안내
-          if (result.parseError) {
-            console.warn("[shinjeom-session] 결과 표시 불가:", { parseError: result.parseError });
-            updateMessageContent(msgId, getErrorMsg(characterId, "reading"));
-            setMood("default");
-            return true;
-          }
-          removeMessage(msgId);
-          setReadingResult(data.result as Parameters<typeof setReadingResult>[0]);
-          setPhase("result");
-          setMood(CHARACTER_RESULT_MOODS[characterId ?? ""] ?? "smile");
-        }
-        return false;
-      });
-    } catch {
-      addChatMessage({ id: crypto.randomUUID(), role: "character", content: getErrorMsg(characterId, "api"), mood: "default", timestamp: new Date() });
-      setMood("default");
-    }
-    setLoading(false);
+      },
+    }).then(() => {
+      if (!finished) clearTimeout(timeoutId);
+    });
   };
 
   if (!character) return null;

--- a/src/app/tarot/session/page.tsx
+++ b/src/app/tarot/session/page.tsx
@@ -22,7 +22,7 @@ const CardDeck = dynamic(
 );
 const CardSpread = dynamic(
   () => import("@/components/card/CardSpread").then((m) => ({ default: m.CardSpread })),
-  { loading: () => null },
+  { loading: () => <div className="w-full flex-1 min-h-[200px] md:min-h-[360px]" /> },
 );
 const ReadingProgressIndicator = dynamic(
   () => import("@/components/tarot/ReadingProgressIndicator").then((m) => ({ default: m.ReadingProgressIndicator })),

--- a/src/components/card/CardSpread.tsx
+++ b/src/components/card/CardSpread.tsx
@@ -6,7 +6,9 @@ import { SelectedCard } from "@/types/card";
 import { SpreadDefinition, SpreadPosition } from "@/types/session";
 import { CardItem } from "./CardItem";
 import { useSkinStore } from "@/hooks/useSkinStore";
+import { useLocaleStore } from "@/hooks/useLocaleStore";
 import { hexToRgbBase } from "@/lib/color-utils";
+import { getPositionLabel } from "@/data/spreads";
 
 interface CardSpreadProps {
   readonly selectedCards: SelectedCard[];
@@ -96,6 +98,7 @@ function computeLayout(
 export const CardSpread = React.memo(
   function CardSpread({ selectedCards, spread, revealedPositions, glowColor }: CardSpreadProps) {
   const { selectedSkinId } = useSkinStore();
+  const locale = useLocaleStore((s) => s.locale);
   const rgb = glowColor ? hexToRgbBase(glowColor) : "212, 175, 55";
   const containerRef = useRef<HTMLDivElement>(null);
   const [containerWidth, setContainerWidth] = useState(0);
@@ -173,7 +176,7 @@ export const CardSpread = React.memo(
                   className="text-arcana-gold font-serif font-bold drop-shadow-[0_0_4px_rgba(212,175,55,0.4)] truncate text-center"
                   style={{ fontSize: Math.max(layout.cardW * 0.18, 8), maxWidth: layout.cardW * 1.5 }}
                 >
-                  {pos.labelKo}
+                  {getPositionLabel(pos, locale)}
                 </span>
               </div>
             ) : (
@@ -185,7 +188,7 @@ export const CardSpread = React.memo(
                   className="text-arcana-gold/60 font-serif font-bold truncate"
                   style={{ fontSize: Math.max(layout.cardW * 0.18, 8) }}
                 >
-                  {pos.labelKo}
+                  {getPositionLabel(pos, locale)}
                 </span>
               </div>
             )}

--- a/src/components/character/CharacterDisplay.tsx
+++ b/src/components/character/CharacterDisplay.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { CharacterConfig, Mood } from "@/types/character";
 import { SpriteAnimator } from "./SpriteAnimator";
@@ -43,7 +43,7 @@ function GlowBurstRing({ mood, primaryColor }: { readonly mood: Mood; readonly p
   );
 }
 
-export function CharacterDisplay({ character, mood, className = "" }: CharacterDisplayProps) {
+export const CharacterDisplay = React.memo(function CharacterDisplay({ character, mood, className = "" }: CharacterDisplayProps) {
   const { setMood } = useCharacterStore();
   const [isTransitioning, setIsTransitioning] = useState(false);
   const isMountedRef = useRef(false);
@@ -111,4 +111,5 @@ export function CharacterDisplay({ character, mood, className = "" }: CharacterD
       </div>
     </div>
   );
-}
+});
+CharacterDisplay.displayName = "CharacterDisplay";

--- a/src/components/chat/DialogueBox.tsx
+++ b/src/components/chat/DialogueBox.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useRef } from "react";
+import React, { useState, useEffect, useRef } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { ChatMessage } from "@/types/session";
 import { useT } from "@/i18n/useT";
@@ -12,7 +12,7 @@ interface DialogueBoxProps {
   readonly className?: string;
 }
 
-export function DialogueBox({ messages, characterName, isTyping = false, className = "" }: DialogueBoxProps) {
+export const DialogueBox = React.memo(function DialogueBox({ messages, characterName, isTyping = false, className = "" }: DialogueBoxProps) {
   const { t } = useT();
   const displayName = characterName ?? t("chat.default-character-name");
   const lastMessage = messages.filter((m) => m.role === "character").at(-1);
@@ -111,4 +111,5 @@ export function DialogueBox({ messages, characterName, isTyping = false, classNa
       </div>
     </div>
   );
-}
+});
+DialogueBox.displayName = "DialogueBox";

--- a/src/components/layout/ThemeDropdown.tsx
+++ b/src/components/layout/ThemeDropdown.tsx
@@ -31,6 +31,7 @@ export function ThemeDropdown({ variant, onClose }: ThemeDropdownProps) {
         </div>
       )}
       <button
+        data-testid={isDesktop ? "theme-option-auto" : "mobile-theme-option-auto"}
         onClick={() => { setMode("auto"); onClose(); }}
         className={`w-full text-left px-3 py-2.5 text-sm flex items-center gap-2 transition-colors ${
           mode === "auto" ? "bg-arcana-purple/15 text-arcana-purple" : "text-arcana-text hover:bg-arcana-purple/10"


### PR DESCRIPTION
## Summary

3-에이전트 교차 회고에서 발견된 11개 품질 이슈를 Phase별로 해결한 PR입니다.

### Phase 1 — 즉시 버그 수정
- **신점 세션 영구 멈춤 버그 제거**: 자체 구현 `drainSseChunks()` → `fetchSSEStream` 전환 + AbortController + 180s 타임아웃 (`fix/shinjeom-abort-controller`)
- **사주 세션 AbortController ref 보관**: `startReading()` 언마운트 cleanup 보장

### Phase 2 — 코드 품질
- **ThemeDropdown auto 버튼 data-testid**: `theme-option-auto` / `mobile-theme-option-auto` 추가 + E2E 셀렉터 11개 text→testid 변환
- **CardSpread i18n**: `pos.labelKo` → `getPositionLabel(pos, locale)` 교체 (en/ja 사용자 한국어 표시 버그 수정)
- **saju/shinjeom 버튼 data-testid 표준화**: `saju-time-btn-*`, `saju-area-btn-*`, `shinjeom-topic-btn-*`

### Phase 3 — 중기 개선
- **신점 E2E 메시지 전송 플로우**: `shinjeom-flow.spec.ts`에 세션 진입→메시지 전송→로딩 해제 검증 추가
- **fetchMemoryPrompt 테스트**: 6개 케이스 추가 (null user, 메모리 없음, getCurrentUser 예외 등)
- **CharacterDisplay·DialogueBox React.memo**: SpriteAnimator·CardDeck·CardSpread와 동일 패턴 적용
- **CardSpread loading skeleton**: `loading: () => null` → 플레이스홀더 div (레이아웃 시프트 방지)

## Test plan

- [ ] `pnpm type-check` — 통과 (이미 확인)
- [ ] `pnpm lint` — 통과 (이미 확인)
- [ ] CI E2E 통과 확인
- [ ] 신점 세션: 메시지 전송 → 캐릭터 응답 스트리밍 확인 (영구 멈춤 없음)
- [ ] 사주 세션: 빠른 네비게이션 시 콘솔 abort 경고 없음
- [ ] ThemeDropdown auto 버튼 클릭 → localStorage 'auto' 저장 확인
- [ ] 타로 카드 선택 화면: en/ja 로케일에서 위치 라벨 정상 표시

🤖 Generated with [Claude Code](https://claude.com/claude-code)