### PR TITLE
fix: iOS Safari 타로 카드 선택·결과 미수신 이슈 해소

### DIFF
--- a/src/components/card/CardDeck.tsx
+++ b/src/components/card/CardDeck.tsx
@@ -133,6 +133,7 @@ export const CardDeck = React.memo(function CardDeck({ cards, isSpread, selected
             data-card-name={card.id}
             initial={{ x: 0, y: 50, rotate: 0, opacity: 0 }}
             animate={{ x: xOffset, y, rotate: angle, opacity: isSelected ? 0.3 : 1, scale }}
+            whileTap={ritualDone && !isSelected ? { scale: scale * 0.95 } : undefined}
             transition={{
               type: "spring",
               stiffness: ritualDone ? 120 : 200,
@@ -140,7 +141,12 @@ export const CardDeck = React.memo(function CardDeck({ cards, isSpread, selected
               delay: ritualDone && isSpread ? index * 0.015 : 0,
             }}
             className={`absolute ${ritualDone && !isSelected ? "cursor-pointer" : "cursor-default"}`}
-            style={{ zIndex: isSelected ? 0 : hoveredIndex === index ? 200 : index }}
+            style={{
+              zIndex: isSelected ? 0 : hoveredIndex === index ? 200 : index,
+              touchAction: "manipulation",
+              WebkitTapHighlightColor: "transparent",
+            }}
+            onPointerDown={() => { if (!isSelected && ritualDone) setHoveredIndex(index); }}
             onClick={() => { if (!isSelected && ritualDone) onCardSelect(index); }}
             onPointerEnter={() => setHoveredIndex(index)}
             onPointerLeave={() => setHoveredIndex(null)}

--- a/src/lib/request-utils.test.ts
+++ b/src/lib/request-utils.test.ts
@@ -87,9 +87,10 @@ describe("jsonError", () => {
 })
 
 describe("SSE_HEADERS", () => {
-  it("SSE 스트리밍에 필요한 헤더 3개 포함", () => {
+  it("SSE 스트리밍에 필요한 헤더 + iOS Safari/Railway 프록시 버퍼링 차단 헤더 포함", () => {
     expect(SSE_HEADERS["Content-Type"]).toBe("text/event-stream")
-    expect(SSE_HEADERS["Cache-Control"]).toBe("no-cache")
+    expect(SSE_HEADERS["Cache-Control"]).toBe("no-cache, no-transform")
     expect(SSE_HEADERS["Connection"]).toBe("keep-alive")
+    expect(SSE_HEADERS["X-Accel-Buffering"]).toBe("no")
   })
 })

--- a/src/lib/request-utils.ts
+++ b/src/lib/request-utils.ts
@@ -20,6 +20,7 @@ export function jsonError(error: string, status = 400): Response {
 
 export const SSE_HEADERS = {
   "Content-Type": "text/event-stream",
-  "Cache-Control": "no-cache",
+  "Cache-Control": "no-cache, no-transform",
   Connection: "keep-alive",
+  "X-Accel-Buffering": "no",
 } as const


### PR DESCRIPTION
- SSE_HEADERS: Cache-Control에 no-transform + X-Accel-Buffering:no 추가
  → Railway 프록시 버퍼링으로 iOS Safari가 SSE 청크 수신 못하던 이슈 해소
- CardDeck: touch-action:manipulation + WebkitTapHighlightColor 적용,
  whileTap·onPointerDown 추가 → iOS 300ms 클릭 지연·hover 미인식으로
  카드 선택 안 되던 이슈 해소