### PR TITLE
fix: 10장+ 타로 리딩 결과 실패 — 토큰 정책 일반화 + 타임아웃 240s + 진단 로깅

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,7 +65,7 @@ scripts/e2e-full/    # E2E 전수 검증 252 조합 (orchestrator/worker/reporte
 **API 보안**: Rate Limit → Zod safeParse → requireUser → assertSessionOwnership. → [`docs/architecture/auth-abstraction.md`](docs/architecture/auth-abstraction.md)
 - Rate Limit 범위: **세션 API**(tarot/saju/shinjeom session, 분당 20회) + **reading/message API** 모두 적용. `locale` 선언은 rate limit 호출 전 최상단에 위치.
 
-**SSE 스트리밍**: tarot/saju/shinjeom reading API. 서버: `SSE_HEADERS`+`jsonError()`(`request-utils.ts`), `readSseLines`+`withAbortTimeout`(`http-utils.ts`). 클라이언트: `fetchSSEStream()`(`useSSEStream.ts`, `AbortSignal` 지원). 클라이언트 hard timeout 180s — `AbortController`+`finished` 가드 (타로·사주·신점 세션 페이지 모두 적용), 초과 시 `readingErrorReason="timeout"` + 재시도 UI(`data-testid="reading-retry"`) 표시. 신점 세션은 `handleSend`·`handleEndConsultation` 각각 AbortController 적용. `/api/daily-card`는 JSON.
+**SSE 스트리밍**: tarot/saju/shinjeom reading API. 서버: `SSE_HEADERS`+`jsonError()`(`request-utils.ts`), `readSseLines`+`withAbortTimeout`(`http-utils.ts`). 클라이언트: `fetchSSEStream()`(`useSSEStream.ts`, `AbortSignal` 지원). 클라이언트 hard timeout 240s — `AI_TIMEOUT_MS`와 동조 (10장+ 타로·full-fortune 사주 reasoning+truncation 대응). `AbortController`+`finished` 가드 (타로·사주·신점 세션 페이지 모두 적용), 초과 시 `readingErrorReason="timeout"` + 재시도 UI(`data-testid="reading-retry"`) 표시. 신점 세션은 `handleSend`·`handleEndConsultation` 각각 AbortController 적용. `/api/daily-card`는 JSON.
 
 **share_token**: `/*/result/[id]` 공개 공유. 소유자 전용 = `assertReadingAccess("owner")`.
 
@@ -73,8 +73,8 @@ scripts/e2e-full/    # E2E 전수 검증 252 조합 (orchestrator/worker/reporte
 
 **ShuffleCeremony**: `src/components/tarot/ShuffleCeremony.tsx` — 카드 선택 진입 시 2.2s Canvas rAF 의식 4단계(덱컷→글로우→타이프라이터→부채꼴). 클릭/Enter/Space·`prefers-reduced-motion` 스킵. `getWaitingLinesData(locale)` 경유 ko/en/ja 분기. N=9 고정.
 
-**리딩 max_tokens**: Grok-3 reasoning 토큰 흡수 + 한국어 1.3배 비효율 고려해 +30~40% 상향. `reasoning_effort:"low"` 주입(`buildReasoningOption(model)` — grok-3 계열만), `AI_TIMEOUT_MS=120000`, 빈 응답 throw→Claude fallback 자동 전환. `GROK_REASONING_EFFORT`·`GROK_MODEL` 환경변수로 제어.
-- **타로**: `computeReadingMaxTokens(cardCount)` (`src/app/api/tarot/reading/route.ts`) — 1장→2600, 3장→4500, 5장→6500, 7장→8500, 9장→10500, 10장→18000(celtic-cross), 12장+→20000(zodiac 등).
+**리딩 max_tokens**: Grok-3 reasoning 토큰 흡수 + 한국어 1.3배 비효율 고려해 +30~40% 상향. `reasoning_effort:"low"` 주입(`buildReasoningOption(model)` — grok-3 계열만), `AI_TIMEOUT_MS=240000`(10장+ 응답 시간 200~400s 대응), 빈 응답 throw→Claude fallback 자동 전환. `GROK_REASONING_EFFORT`·`GROK_MODEL` 환경변수로 제어. **Grok/Claude provider는 streaming 종료 시 `finish_reason`/`stop_reason`+`usage`를 콘솔에 로깅** — `length`/`max_tokens`이면 truncated 경고로 운영 진단 가능.
+- **타로**: `computeReadingMaxTokens(cardCount)` (`src/app/api/tarot/reading/route.ts`) — 1장→2600, 3장→4500, 5장→6500, 7장→8500, 9장→10500, **10장+은 `Math.min(2500 + cardCount*1700 + 5000, 60000)` 동적 산정** (10장→24500, 12장→27900/zodiac, 15장→33000, 20장→41500). 미래 spread 자동 대응.
 - **사주**: `computeSajuReadingMaxTokens(timeRange, includeMonthly)` (`src/app/api/saju/reading/route.ts`) — includeMonthly→20000, full-fortune→17000, five-year→15000, three/next-year→13000, 기본 10000.
 - **신점**: `SHINJEOM_TOKENS_FINAL=8500` / `SHINJEOM_TOKENS_CHAT=1500` (`src/app/api/shinjeom/message/route.ts`).
 

--- a/docs/architecture/ai-infrastructure.md
+++ b/docs/architecture/ai-infrastructure.md
@@ -140,12 +140,12 @@ for (let i = start; i < text.length; i++) {
 const abortController = new AbortController();
 let finished = false;
 
-// 180s 하드 타임아웃
+// 240s 하드 타임아웃 — 10장+ 타로/full-fortune 사주의 reasoning+stream 시간 대응
 const timer = setTimeout(() => {
   if (finished) return;
   abortController.abort();
   setReadingErrorReason("timeout");
-}, 180_000);
+}, 240_000);
 
 await fetchSSEStream({ signal: abortController.signal, ... });
 finished = true;

--- a/docs/operations/env-variables.md
+++ b/docs/operations/env-variables.md
@@ -77,7 +77,7 @@
 | `GROK_BASE_URL` | Grok API 엔드포인트 | `https://api.x.ai/v1` |
 | `CLAUDE_MODEL` | Claude 모델 ID | `claude-opus-4-7` |
 | `CLAUDE_BASE_URL` | Claude API 엔드포인트 오버라이드 | `https://api.anthropic.com/v1` |
-| `AI_TIMEOUT_MS` | AI 스트림 타임아웃 | `60000` |
+| `AI_TIMEOUT_MS` | AI 스트림 타임아웃 (10장+ 타로 / full-fortune 사주 등 대형 응답 대응) | `240000` |
 | `AI_DEFAULT_MAX_TOKENS` | AI 응답 최대 토큰 기본값 | `4000` |
 | `AI_TEMPERATURE` | AI 온도 파라미터 | `0.7` |
 | `AI_FALLBACK_COOLDOWN_MS` | Fallback 쿨다운 — 5xx/network | `300000` (5분) |

--- a/src/__tests__/api/tarot-reading.test.ts
+++ b/src/__tests__/api/tarot-reading.test.ts
@@ -243,14 +243,17 @@ describe("POST /api/tarot/reading", () => {
   });
 
   it("computeReadingMaxTokens 정책 — 모든 분기가 streamReading에 정확히 전달", async () => {
+    // 1~9장: 기존 검증된 고정값. 10장+: 2500 + cardCount*1700 + 5000 (모델 cap 60000)
     const cases: { count: number; expected: number }[] = [
       { count: 1, expected: 2600 },
       { count: 3, expected: 4500 },
       { count: 5, expected: 6500 },
       { count: 7, expected: 8500 },
       { count: 9, expected: 10500 },
-      { count: 10, expected: 18000 },
-      { count: 12, expected: 20000 },
+      { count: 10, expected: 24500 },  // 2500 + 17000 + 5000
+      { count: 12, expected: 27900 },  // 2500 + 20400 + 5000 (zodiac)
+      { count: 15, expected: 33000 },  // 2500 + 25500 + 5000 (미래 spread)
+      { count: 20, expected: 41500 },  // 2500 + 34000 + 5000 (미래 spread)
     ];
     for (const { count, expected } of cases) {
       vi.resetModules();

--- a/src/app/api/tarot/reading/route.ts
+++ b/src/app/api/tarot/reading/route.ts
@@ -23,15 +23,19 @@ const deckManager = new DeckManager();
 const spreadResolver = new SpreadResolver();
 
 /**
- * 카드 수에 비례한 max_tokens 정책.
+ * 카드 수에 비례한 max_tokens 정책 — 확장 가능한 동적 산정.
  *
- * 한국어는 영어 대비 토큰 효율이 약 1.3배 낮고, JSON 구조 오버헤드(~10%)도 더해진다.
- * 또한 Grok-3 reasoning 모델은 응답 전 내부 reasoning(thinking) 토큰을 max_tokens 안에서
- * 함께 소비하므로, celtic-cross(10장) 14000으로도 본문이 잘리는 사례가 PR #264 이후 다시 발생.
- * (사용자 보고: 10장 리딩 시 결과 미수신 + parseError invalid_json 추정)
+ * 한국어는 영어 대비 토큰 효율 ~1.3x 낮고, JSON 구조 오버헤드 ~15%, Grok-3 reasoning 모델은
+ * 내부 reasoning(thinking) 토큰을 max_tokens 안에서 함께 소비한다. 사용자 보고: 10장+ 리딩
+ * 시 결과 실패 (parseError invalid_json/truncated 추정) → 본문 잘림이 빈 화면을 유발.
  *
- * 출력 토큰만 과금되므로 상한 자체는 비용 영향이 없다 — reasoning 4000~5000 흡수 + 본문 14000~15000
- * 보장을 위해 10장 18000 / 12장+ 20000으로 추가 상향. (PR #265, 2026-05-08)
+ * 1~9장: 기존 검증된 값 보존 (충분한 안전마진).
+ * 10장+: 선형 일반화로 확장 가능 — `base + cardCount * perCard + reasoningBuffer`.
+ *   - perCard 1700 = 한국어 평균 카드별 해석(키워드+본문+조언) 분량
+ *   - reasoningBuffer 5000 = Grok-3 reasoning low 흡수 마진
+ *   - base 2500 = system + overallReading + advice 오버헤드
+ * 모델 cap 60000은 Claude Sonnet 4.6/Haiku 4.5 max output 64K 안전마진. Grok·Opus는 더 여유.
+ * 출력 토큰만 과금되므로 상한 자체는 비용 영향 없음.
  */
 function computeReadingMaxTokens(cardCount: number): number {
   if (cardCount <= 1) return 2600;
@@ -39,8 +43,8 @@ function computeReadingMaxTokens(cardCount: number): number {
   if (cardCount <= 5) return 6500;
   if (cardCount <= 7) return 8500;
   if (cardCount <= 9) return 10500;
-  if (cardCount <= 10) return 18000; // celtic-cross (10장) — reasoning 잠식 대응 +4000
-  return 20000;                      // zodiac(12장) 등 대형 스프레드 — +4000
+  // 10장+ 동적 산정 — 12장(zodiac), 미래 15·20장 spread도 자동 대응
+  return Math.min(2500 + cardCount * 1700 + 5000, 60000);
 }
 
 export async function POST(request: NextRequest) {

--- a/src/app/saju/session/page.tsx
+++ b/src/app/saju/session/page.tsx
@@ -140,7 +140,8 @@ export default function SajuSessionPage() {
     });
     const stopTimers = () => timers.forEach(clearTimeout);
 
-    // 클라이언트 hard timeout (180초). 서버 SSE가 hung되거나 done 이벤트가 도달 못 하는 경우 강제 종료.
+    // 클라이언트 hard timeout (240초). 서버 AI_TIMEOUT_MS와 동조 — full-fortune/includeMonthly(max_tokens
+    // 17000~20000)는 reasoning 흡수까지 200~400s 소요 가능. 120s/180s에서는 본문 잘림 빈발.
     const abortController = new AbortController();
     readingAbortRef.current = abortController;
     let finished = false;
@@ -149,12 +150,12 @@ export default function SajuSessionPage() {
       finished = true;
       abortController.abort();
       stopTimers();
-      console.warn("[saju-session] 클라이언트 타임아웃 180s");
+      console.warn("[saju-session] 클라이언트 타임아웃 240s");
       setMood("default");
       setReadingErrorReason("timeout");
       setReadingError(true);
       setLoading(false);
-    }, 180_000);
+    }, 240_000);
 
     void fetchSSEStream({
       url: "/api/saju/reading",

--- a/src/app/shinjeom/session/page.tsx
+++ b/src/app/shinjeom/session/page.tsx
@@ -130,7 +130,7 @@ export default function ShinjeomSessionPage() {
       updateMessageContent(msgId, getErrorMsg(characterId, "api"));
       setMood("default");
       setLoading(false);
-    }, 180_000);
+    }, 240_000);
 
     void fetchSSEStream({
       url: "/api/shinjeom/message",
@@ -191,7 +191,7 @@ export default function ShinjeomSessionPage() {
       updateMessageContent(msgId, getErrorMsg(characterId, "reading"));
       setMood("default");
       setLoading(false);
-    }, 180_000);
+    }, 240_000);
 
     void fetchSSEStream({
       url: "/api/shinjeom/message",

--- a/src/app/tarot/session/page.tsx
+++ b/src/app/tarot/session/page.tsx
@@ -387,8 +387,8 @@ export default function TarotSessionPage() {
 
     setIsConnecting(false);
 
-    // 클라이언트 hard timeout (180초). 서버 SSE가 hung되거나 done 이벤트가 도달 못 하는 경우 강제 종료.
-    // — 사용자 보고: celtic-cross 무응답 시 isLoading=true로 영구 멈춤. 이 타임아웃이 안전망.
+    // 클라이언트 hard timeout (240초). 서버 AI_TIMEOUT_MS와 동조 — 10장+ 카드 리딩(max_tokens 24500+)은
+    // reasoning 흡수 + 한국어 비효율 + JSON stream으로 200~400s 소요 가능. 120s/180s에서는 본문 잘림 빈발.
     const abortController = new AbortController();
     readingAbortRef.current = abortController;
     let finished = false;
@@ -397,13 +397,13 @@ export default function TarotSessionPage() {
       finished = true;
       abortController.abort();
       stopSequence();
-      console.warn("[tarot-session] 클라이언트 타임아웃 (180s)");
+      console.warn("[tarot-session] 클라이언트 타임아웃 (240s)");
       setMood("default");
       setReadingErrorReason("timeout");
       setReadingError(true);
       setLoading(false);
       setReadingStartedAt(null);
-    }, 180_000);
+    }, 240_000);
 
     await fetchSSEStream({
       url: "/api/tarot/reading",

--- a/src/lib/env.test.ts
+++ b/src/lib/env.test.ts
@@ -129,8 +129,8 @@ describe("getGrokBaseUrl", () => {
 // ─────────────────────────── 숫자 반환 함수 ───────────────────────────
 
 describe("getAiTimeoutMs", () => {
-  it("env 미설정 시 기본값 120000을 반환한다 (Grok-3 reasoning 모델 timeout 대응)", () => {
-    expect(getAiTimeoutMs()).toBe(120000);
+  it("env 미설정 시 기본값 240000을 반환한다 (10장+ 타로/full-fortune 사주 reasoning+truncation 대응)", () => {
+    expect(getAiTimeoutMs()).toBe(240000);
   });
 
   it("env 설정 시 정수로 파싱하여 반환한다", () => {

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -14,8 +14,10 @@ export function getClaudeBaseUrl(): string { return process.env.CLAUDE_BASE_URL 
 export function getGrokBaseUrl(): string { return process.env.GROK_BASE_URL ?? "https://api.x.ai/v1" }
 
 // AI 동작 튜닝
-// AI_TIMEOUT_MS — 60s 기본은 reasoning 모델(grok-3 등)에서 timeout 빈번 → 120s로 상향
-export function getAiTimeoutMs(): number { return parseInt(process.env.AI_TIMEOUT_MS ?? "120000", 10) }
+// AI_TIMEOUT_MS — 120s는 10장+ 타로/full-fortune 사주(max_tokens 18000~20000)에서 부족 →
+// reasoning 토큰 흡수 + 한국어 1.3x 비효율 + JSON 구조 오버헤드 고려해 240s로 상향.
+// 클라이언트 hard timeout과 동일.
+export function getAiTimeoutMs(): number { return parseInt(process.env.AI_TIMEOUT_MS ?? "240000", 10) }
 export function getDefaultMaxTokens(): number { return parseInt(process.env.AI_DEFAULT_MAX_TOKENS ?? "4000", 10) }
 export function getAiTemperature(): number { return parseFloat(process.env.AI_TEMPERATURE ?? "0.7") }
 

--- a/src/services/core/claude-provider.test.ts
+++ b/src/services/core/claude-provider.test.ts
@@ -226,5 +226,24 @@ describe("ClaudeProvider", () => {
       const chunks = await collectStream(provider.streamReading("s", "u"));
       expect(chunks).toEqual(["첫 번째"]);
     });
+
+    it("message_delta stop_reason='max_tokens' 시 TRUNCATED 경고 로그 (10장+ truncation 진단)", async () => {
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const sseLines = [
+        'data: {"type":"content_block_delta","delta":{"text":"부분"}}',
+        'data: {"type":"message_delta","delta":{"stop_reason":"max_tokens"},"usage":{"output_tokens":24500}}',
+        "data: [DONE]",
+      ];
+      mockFetch.mockResolvedValue(makeSseResponse(sseLines));
+
+      const chunks = await collectStream(provider.streamReading("s", "u", 24500));
+      expect(chunks).toEqual(["부분"]);
+      const truncatedCall = warnSpy.mock.calls.find(
+        (c) => typeof c[0] === "string" && c[0].includes("TRUNCATED")
+      );
+      expect(truncatedCall).toBeDefined();
+      expect(truncatedCall?.[0]).toContain("24500");
+      warnSpy.mockRestore();
+    });
   });
 });

--- a/src/services/core/claude-provider.ts
+++ b/src/services/core/claude-provider.ts
@@ -66,13 +66,15 @@ export class ClaudeProvider implements AIProvider {
   async *streamReading(systemPrompt: string, userPrompt: string, maxTokens?: number): AsyncGenerator<string, void, unknown> {
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), getAiTimeoutMs());
+    const effectiveMaxTokens = maxTokens ?? getDefaultMaxTokens();
+    const startedAt = Date.now();
     try {
       const response = await fetch(`${this.baseUrl}/messages`, {
         method: "POST",
         headers: this.anthropicHeaders,
         body: JSON.stringify({
           model: this.model,
-          max_tokens: maxTokens ?? getDefaultMaxTokens(),
+          max_tokens: effectiveMaxTokens,
           stream: true,
           system: systemPrompt,
           messages: [{ role: "user", content: userPrompt }],
@@ -84,15 +86,33 @@ export class ClaudeProvider implements AIProvider {
         console.error(`[ClaudeProvider] 스트림 API 오류 (${response.status}):`, errorBody);
         throw new Error(`Claude API 요청이 실패했습니다. (HTTP ${response.status})`);
       }
-      // Anthropic SSE: content_block_delta 이벤트에서 텍스트 추출
-      yield* readSseLines(
+      // Anthropic SSE: content_block_delta(텍스트) + message_delta(stop_reason+usage) 캡처
+      // closure 내 할당은 TS control-flow narrowing 대상이 아니므로 ref 객체로 wrap (never 좁힘 회피)
+      const ref: { yielded: number; firstChunkAt: number | null; stopReason: string | null; outputTokens: number | null } = {
+        yielded: 0, firstChunkAt: null, stopReason: null, outputTokens: null,
+      };
+      for await (const chunk of readSseLines(
         response,
         (p) => {
-          const e = p as { type?: string; delta?: { text?: string } };
+          const e = p as { type?: string; delta?: { text?: string; stop_reason?: string }; usage?: { output_tokens?: number } };
+          if (e.type === "message_delta") {
+            if (e.delta?.stop_reason) ref.stopReason = e.delta.stop_reason;
+            if (typeof e.usage?.output_tokens === "number") ref.outputTokens = e.usage.output_tokens;
+          }
           return e.type === "content_block_delta" && e.delta?.text ? e.delta.text : null;
         },
         "Claude"
-      );
+      )) {
+        if (ref.firstChunkAt === null) ref.firstChunkAt = Date.now();
+        ref.yielded++;
+        yield chunk;
+      }
+      const totalMs = Date.now() - startedAt;
+      const ttfbMs = ref.firstChunkAt !== null ? ref.firstChunkAt - startedAt : null;
+      console.log(`[Claude] stream done — chunks=${ref.yielded} ttfb=${ttfbMs}ms total=${totalMs}ms stop=${ref.stopReason ?? "?"} max_tokens=${effectiveMaxTokens} output_tokens=${ref.outputTokens ?? "?"}`);
+      if (ref.stopReason === "max_tokens") {
+        console.warn(`[Claude] ⚠️ TRUNCATED: max_tokens(${effectiveMaxTokens}) 초과로 본문 잘림 — output_tokens=${ref.outputTokens ?? "?"}`);
+      }
     } finally {
       clearTimeout(timer);
     }

--- a/src/services/core/grok-provider.test.ts
+++ b/src/services/core/grok-provider.test.ts
@@ -365,5 +365,33 @@ describe("GrokProvider", () => {
       const body = JSON.parse(mockFetch.mock.calls[0][1]?.body as string);
       expect(body.reasoning_effort).toBeUndefined();
     });
+
+    it("finish_reason='length' 시 TRUNCATED 경고 로그 + chunks 정상 yield (10장+ truncation 진단)", async () => {
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const sseLines = [
+        'data: {"choices":[{"delta":{"content":"부분"}}]}',
+        'data: {"choices":[{"delta":{},"finish_reason":"length"}],"usage":{"completion_tokens":18000,"completion_tokens_details":{"reasoning_tokens":4500}}}',
+        "data: [DONE]",
+      ];
+      mockFetch.mockResolvedValue(makeSseResponse(sseLines));
+
+      const chunks = await collectStream(provider.streamReading("s", "u", 18000));
+      expect(chunks).toEqual(["부분"]);
+      // TRUNCATED warn은 yield 종료 후 호출됨
+      const truncatedCall = warnSpy.mock.calls.find(
+        (c) => typeof c[0] === "string" && c[0].includes("TRUNCATED")
+      );
+      expect(truncatedCall).toBeDefined();
+      expect(truncatedCall?.[0]).toContain("18000");
+      warnSpy.mockRestore();
+    });
+
+    it("stream_options.include_usage가 body에 포함된다 (xAI usage capture)", async () => {
+      const sseLines = ['data: {"choices":[{"delta":{"content":"x"}}]}', "data: [DONE]"];
+      mockFetch.mockResolvedValue(makeSseResponse(sseLines));
+      await collectStream(provider.streamReading("s", "u"));
+      const body = JSON.parse(mockFetch.mock.calls[0][1]?.body as string);
+      expect(body.stream_options).toEqual({ include_usage: true });
+    });
   });
 });

--- a/src/services/core/grok-provider.ts
+++ b/src/services/core/grok-provider.ts
@@ -102,6 +102,8 @@ export class GrokProvider implements AIProvider {
   async *streamReading(systemPrompt: string, userPrompt: string, maxTokens?: number): AsyncGenerator<string, void, unknown> {
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), getAiTimeoutMs());
+    const effectiveMaxTokens = maxTokens ?? getDefaultMaxTokens();
+    const startedAt = Date.now();
     try {
       const response = await fetch(`${this.baseUrl}/chat/completions`, {
         method: "POST",
@@ -109,7 +111,8 @@ export class GrokProvider implements AIProvider {
         body: JSON.stringify({
           model: this.model,
           messages: [{ role: "system", content: systemPrompt }, { role: "user", content: userPrompt }],
-          temperature: getAiTemperature(), max_tokens: maxTokens ?? getDefaultMaxTokens(), stream: true,
+          temperature: getAiTemperature(), max_tokens: effectiveMaxTokens, stream: true,
+          stream_options: { include_usage: true },
           ...buildReasoningOption(this.model),
         }),
         signal: controller.signal,
@@ -117,16 +120,34 @@ export class GrokProvider implements AIProvider {
       if (!response.ok) { await this.handleErrorResponse(response); return; }
       // reasoning 모델이 reasoning_content 채널로만 응답하고 content는 비어있는 경우를 감지하기 위해
       // yield 횟수를 추적. 0회면 throw → FallbackProvider가 Claude로 전환할 수 있도록.
-      let yielded = 0;
+      type GrokUsage = { completion_tokens?: number; prompt_tokens?: number; completion_tokens_details?: { reasoning_tokens?: number } };
+      // closure 내 할당은 TS control-flow narrowing 대상이 아니므로 ref 객체로 wrap (never 좁힘 회피)
+      const ref: { yielded: number; firstChunkAt: number | null; finishReason: string | null; usage: GrokUsage | null } = {
+        yielded: 0, firstChunkAt: null, finishReason: null, usage: null,
+      };
       for await (const chunk of readSseLines(
         response,
-        (p) => (p as { choices?: [{ delta?: { content?: string } }] }).choices?.[0]?.delta?.content ?? null,
+        (p) => {
+          const ev = p as { choices?: [{ delta?: { content?: string }, finish_reason?: string | null }], usage?: GrokUsage };
+          if (ev.choices?.[0]?.finish_reason) ref.finishReason = ev.choices[0].finish_reason ?? null;
+          if (ev.usage) ref.usage = ev.usage;
+          return ev.choices?.[0]?.delta?.content ?? null;
+        },
         "Grok",
         controller.signal
       )) {
-        yielded++;
+        if (ref.firstChunkAt === null) ref.firstChunkAt = Date.now();
+        ref.yielded++;
         yield chunk;
       }
+      const totalMs = Date.now() - startedAt;
+      const ttfbMs = ref.firstChunkAt !== null ? ref.firstChunkAt - startedAt : null;
+      const reasoningTokens = ref.usage?.completion_tokens_details?.reasoning_tokens;
+      console.log(`[Grok] stream done — chunks=${ref.yielded} ttfb=${ttfbMs}ms total=${totalMs}ms finish=${ref.finishReason ?? "?"} max_tokens=${effectiveMaxTokens} usage=${JSON.stringify(ref.usage)}`);
+      if (ref.finishReason === "length") {
+        console.warn(`[Grok] ⚠️ TRUNCATED: max_tokens(${effectiveMaxTokens}) 초과로 본문 잘림 — reasoning=${reasoningTokens ?? "?"} completion=${ref.usage?.completion_tokens ?? "?"}`);
+      }
+      const yielded = ref.yielded;
       if (yielded === 0) throw new Error("Grok API가 빈 응답을 반환했습니다 (reasoning 토큰만 소비됨 가능성).");
     } finally {
       clearTimeout(timer);


### PR DESCRIPTION
## 배경

PR #282(iOS Safari 카드 선택/SSE 헤더 fix) 머지 후에도 사용자 보고: **10장 이상 카드 리딩에서 결과 실패**. 12장(zodiac) 케이스 존재, 추후 더 많은 spread 추가 예정.

## 다중 에이전트 분석 결과 — Root Cause 3가지

| 우선순위 | 원인 | 코드 근거 |
|---|---|---|
| ★★★★★ | `AI_TIMEOUT_MS=120s`가 18000+ 토큰 응답(reasoning 5~30s + stream 200~400s 추정) abort → JSON 미완료 → `parseError: invalid_json` → 빈 화면 | `src/lib/env.ts:18` |
| ★★★★☆ | `computeReadingMaxTokens` 12장 이상 고정 20000 → 미래 15·20장 spread 미대응 + 카드당 토큰 압박 | `src/app/api/tarot/reading/route.ts:43` |
| ★★★★☆ | Grok-3 reasoning 토큰이 `max_tokens` 잠식하지만 **운영 로그에 가시성 전무** → 실측 진단 불가 | grok/claude provider streamReading |

> **모델 한도는 문제 아님**: Grok 전 모델(131K~) / Claude Opus 4.7(128K) / Sonnet 4.6·Haiku 4.5(64K) 모두 18000~60000에서 안전 (xAI/Anthropic 공식 docs 확인).

## 변경 내용

### 핵심 코드 (6 파일)
- **`src/lib/env.ts`** — `AI_TIMEOUT_MS` 기본값 120s → **240s**
- **`src/app/api/tarot/reading/route.ts`** — `computeReadingMaxTokens()` 10장+ 동적 산정으로 일반화
  ```
  10장+: Math.min(2500 + cardCount * 1700 + 5000, 60000)
  10장 → 24500 (기존 18000)
  12장 → 27900 (기존 20000, zodiac)
  15장 → 33000 (미래 spread)
  20장 → 41500 (미래 spread)
  ```
  - `perCard 1700` = 한국어 평균 카드별 해석 분량
  - `reasoningBuffer 5000` = Grok-3 reasoning low 흡수 마진
  - 모델 cap `60000` = Claude Sonnet 4.6/Haiku 4.5 max output 64K 안전마진
- **`src/app/tarot/session/page.tsx`**, **`saju/session/page.tsx`**, **`shinjeom/session/page.tsx`** (2곳) — 클라이언트 hard timeout 180s → **240s** (서버 `AI_TIMEOUT_MS`와 동조)
- **`src/services/core/grok-provider.ts`** — `stream_options.include_usage` 활성화 + streaming 종료 시 `finish_reason` / `usage(reasoning_tokens·completion_tokens)` / `ttfb` / `total_ms` 로깅
  - `finish_reason: "length"` 이면 ⚠️ TRUNCATED warn — 실측 reasoning 흡수량 가시화
- **`src/services/core/claude-provider.ts`** — `message_delta`로 `stop_reason` / `output_tokens` 캡처 + 동일 로깅
  - `stop_reason: "max_tokens"` 이면 ⚠️ TRUNCATED warn

### 테스트·문서 (5 파일)
- `src/lib/env.test.ts` — `getAiTimeoutMs` 단언 240000 갱신
- `src/__tests__/api/tarot-reading.test.ts` — 10·12·15·20장 케이스 추가 (확장 가능 검증)
- `CLAUDE.md` — SSE 240s + 동적 토큰 정책 + provider 진단 로깅 반영
- `docs/operations/env-variables.md` — `AI_TIMEOUT_MS` 기본값 240000
- `docs/architecture/ai-infrastructure.md` — 클라이언트 hard timeout 240s 예시

## 검증

- ✅ `pnpm type-check`
- ✅ `pnpm lint`
- ✅ `pnpm vitest run` — **819/819 통과**

## 운영 진단 강화 효과

머지 후 Railway 로그에 다음과 같은 라인이 추가됩니다:
```
[Grok] stream done — chunks=412 ttfb=18234ms total=187432ms finish=stop max_tokens=27900 usage={"completion_tokens":15820,"completion_tokens_details":{"reasoning_tokens":4320}}
[Grok] ⚠️ TRUNCATED: max_tokens(27900) 초과로 본문 잘림 — reasoning=8200 completion=27900
```
실측 reasoning 흡수량이 보이므로, 또 다시 truncated 발생 시 `perCard` 또는 `reasoningBuffer` 계수를 정확히 조정 가능.

## Test plan
- [ ] 10장 celtic-cross 리딩 실행 → 결과 정상 표시
- [ ] 12장 zodiac 리딩 실행 → 결과 정상 표시
- [ ] iPhone Safari에서도 동일 검증
- [ ] Railway 로그에서 `[Grok] stream done — ...` 라인 확인 (reasoning_tokens 가시화)
- [ ] full-fortune 사주 리딩에서도 timeout 없이 완료
- [ ] 짧은 리딩(1·3·5장)은 회귀 없는지 확인 (정책 보존)

## 미적용 — 후속 PR 권장

다중 에이전트 분석에서 발견된 SSE 인프라 강화 항목(2KB padding, 25s heartbeat, `\r?\n` 분리자, decoder flush, tarot session unmount cleanup)은 본 PR에 포함하지 않음. 본 PR의 토큰·타임아웃 수정만으로 10장+ 결과 실패가 해소되는지 먼저 관측한 뒤, 잔여 iOS 이슈가 있다면 별도 PR로 진행하는 것이 회귀 추적에 유리.

https://claude.ai/code/session_01Fncq8ujQQ5Ps5ovwqDiNNV

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fncq8ujQQ5Ps5ovwqDiNNV)_