### PR TITLE
fix: 타로 카드 빠른 연속 터치 race condition 차단 (atomic + ref-lock)

### DIFF
--- a/src/app/tarot/session/page.tsx
+++ b/src/app/tarot/session/page.tsx
@@ -177,6 +177,10 @@ export default function TarotSessionPage() {
   const [confirmEachCard, setConfirmEachCard] = useState(false);
   const resultContainerRef = useRef<HTMLDivElement>(null);
   const redirectedRef = useRef(false);
+  // 빠른 연속 터치 race 차단: 동기 ref-lock (RAF로 다음 frame에 unlock)
+  const selectionLockRef = useRef(false);
+  // 마지막 카드 자동 시작 setTimeout 이중 큐잉 차단
+  const autoStartTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const toggleConfirmMode = () => {
     setConfirmEachCard((prev) => {
@@ -241,17 +245,25 @@ export default function TarotSessionPage() {
   }, [addChatMessage, setAnimationPhase, setPhase, t]);
 
   const handleCardSelect = useCallback((index: number) => {
+    // 빠른 연속 터치 race 차단:
+    // 1. selectionLockRef 동기 ref-lock (state 반영 전 두 번째 click 차단)
+    // 2. pendingConfirmRef (확인 대기 중 추가 선택 차단)
+    if (selectionLockRef.current || pendingConfirmRef.current) return;
     // 항상 fresh 상태를 읽어 stale closure 방지
     const { selectedCards: currentCards, requiredCards: required } = useSessionStore.getState();
-    if (currentCards.length >= required || pendingConfirmRef.current) return;
+    if (currentCards.length >= required) return;
+    // 같은 deck index 중복 클릭 방어 (CardDeck isSelected prop의 stale 보완)
+    if (currentCards.some((c) => c.card.id === shuffledDeck[index]?.id)) return;
+    selectionLockRef.current = true;
+    requestAnimationFrame(() => { selectionLockRef.current = false; });
 
     const card = shuffledDeck[index];
     const isReversed = Math.random() > 0.5;
     const position = currentCards.length;
     const selected: SelectedCard = { card, position, isReversed, selectedAt: new Date() };
     selectCard(selected);
-    setSelectedIndices((prev) => [...prev, index]);
-    setRevealedPositions((prev) => [...prev, position]);
+    setSelectedIndices((prev) => prev.includes(index) ? prev : [...prev, index]);
+    setRevealedPositions((prev) => prev.includes(position) ? prev : [...prev, position]);
     setMood("surprised");
 
     const currentCount = currentCards.length + 1;
@@ -260,7 +272,10 @@ export default function TarotSessionPage() {
     if (isLast && !confirmEachCard) {
       // 확인 모드 OFF + 마지막 카드 → 자동으로 리딩 시작 (즉시 잠금으로 중복 방지)
       setPendingConfirm(true);
-      setTimeout(() => {
+      // setTimeout 이중 큐잉 차단: 이미 예약된 타이머가 있으면 재예약 안 함
+      if (autoStartTimerRef.current) return;
+      autoStartTimerRef.current = setTimeout(() => {
+        autoStartTimerRef.current = null;
         const allCards = useSessionStore.getState().selectedCards;
         startReading(allCards);
       }, 800);
@@ -284,6 +299,8 @@ export default function TarotSessionPage() {
 
   /** 확인 → 마지막 카드면 리딩 시작, 아니면 다음 카드 선택 계속 */
   const handleConfirmCard = useCallback(() => {
+    // 빠른 더블클릭으로 startReading 이중 호출 차단
+    if (!pendingConfirmRef.current) return;
     setPendingConfirm(false);
     const { selectedCards: currentCards } = useSessionStore.getState();
     if (currentCards.length >= requiredCards) {

--- a/src/hooks/__tests__/useSession.test.ts
+++ b/src/hooks/__tests__/useSession.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { useSessionStore } from "../useSession";
+import { SelectedCard, TarotCard } from "@/types/card";
+
+function makeCard(id: string): TarotCard {
+  return {
+    id,
+    name: `카드-${id}`,
+    arcana: "minor",
+    suit: "cups",
+    number: 1,
+    keywords: [],
+    keywordsReversed: [],
+    upright: "",
+    reversed: "",
+  } as unknown as TarotCard;
+}
+
+function makeSelected(id: string, position: number): SelectedCard {
+  return {
+    card: makeCard(id),
+    position,
+    isReversed: false,
+    selectedAt: new Date(),
+  };
+}
+
+describe("useSessionStore — selectCard atomic dedup", () => {
+  beforeEach(() => {
+    useSessionStore.getState().reset();
+    useSessionStore.setState({ requiredCards: 3 });
+  });
+
+  it("정상 카드 선택 시 selectedCards에 push", () => {
+    useSessionStore.getState().selectCard(makeSelected("a", 0));
+    expect(useSessionStore.getState().selectedCards).toHaveLength(1);
+    expect(useSessionStore.getState().selectedCards[0].card.id).toBe("a");
+  });
+
+  it("같은 card.id 두 번 호출 시 두 번째는 무시 (빠른 더블탭 race 방어)", () => {
+    const card = makeSelected("dup", 0);
+    useSessionStore.getState().selectCard(card);
+    useSessionStore.getState().selectCard(card);
+    expect(useSessionStore.getState().selectedCards).toHaveLength(1);
+  });
+
+  it("requiredCards 도달 후 추가 selectCard 호출은 무시 (length cap)", () => {
+    useSessionStore.setState({ requiredCards: 2 });
+    useSessionStore.getState().selectCard(makeSelected("a", 0));
+    useSessionStore.getState().selectCard(makeSelected("b", 1));
+    useSessionStore.getState().selectCard(makeSelected("c", 2)); // 초과
+    expect(useSessionStore.getState().selectedCards).toHaveLength(2);
+    expect(useSessionStore.getState().selectedCards.map((c) => c.card.id)).toEqual(["a", "b"]);
+  });
+
+  it("cancel 후 같은 card.id 재선택은 허용 (cancel-then-reselect 호환)", () => {
+    const cardA = makeSelected("a", 0);
+    useSessionStore.getState().selectCard(cardA);
+    // cancel: 직접 setState로 selectedCards 비우기 (handleCancelLastCard와 동일 패턴)
+    useSessionStore.setState({ selectedCards: [] });
+    // 같은 card.id로 다시 선택 — store에 없으니 통과
+    useSessionStore.getState().selectCard(cardA);
+    expect(useSessionStore.getState().selectedCards).toHaveLength(1);
+    expect(useSessionStore.getState().selectedCards[0].card.id).toBe("a");
+  });
+
+  it("서로 다른 card.id는 정상 누적", () => {
+    useSessionStore.getState().selectCard(makeSelected("a", 0));
+    useSessionStore.getState().selectCard(makeSelected("b", 1));
+    useSessionStore.getState().selectCard(makeSelected("c", 2));
+    expect(useSessionStore.getState().selectedCards).toHaveLength(3);
+  });
+});

--- a/src/hooks/useSession.ts
+++ b/src/hooks/useSession.ts
@@ -64,7 +64,15 @@ export const useSessionStore = create<SessionState>((set) => ({
   setSessionId: (id) => set({ sessionId: id }),
   setCharacterId: (id) => set({ characterId: id }),
   setAvailableCards: (cards) => set({ availableCards: cards }),
-  selectCard: (card) => set((state) => ({ selectedCards: [...state.selectedCards, card] })),
+  selectCard: (card) => set((state) => {
+    // atomic check-and-push: 빠른 연속 클릭 race 차단.
+    // - length cap 초과 무시 (handleCardSelect 가드와 이중 방어)
+    // - 같은 card.id 중복 차단 (deck 내 같은 카드 두 번 push 방지)
+    // cancel 후 재선택은 store에서 카드가 빠진 뒤이므로 통과 — 정상.
+    if (state.selectedCards.length >= state.requiredCards) return state;
+    if (state.selectedCards.some((c) => c.card.id === card.card.id)) return state;
+    return { selectedCards: [...state.selectedCards, card] };
+  }),
   addChatMessage: (message) => set((state) => ({ chatMessages: [...state.chatMessages, message] })),
   appendToLastMessage: (content) => set((state) => {
     const messages = [...state.chatMessages];


### PR DESCRIPTION
## 배경

사용자 보고: **타로 카드를 빠르게 여러 번 터치하여 선택 시 이슈 발생**.

## 다중 에이전트 분석 — 5개 root cause 확정

4개 분석 에이전트(CardDeck 이벤트 / 부모 흐름 / React state batching / iOS 외부 리서치) + Plan 에이전트 비판적 검증으로 race condition 5개 식별:

| # | 위치 | 문제 |
|---|---|---|
| **RC1** | `CardDeck.tsx:117, 150` | `isSelected = selectedIndices.includes(index)` prop이 stale → 같은 카드 더블탭 시 두 onClick 모두 가드 통과 |
| **RC2** | `tarot/session/page.tsx:243` | `pendingConfirmRef` lock은 마지막 카드 분기에서만 활성. 비-마지막 카드는 length 가드뿐 |
| **RC3** | `page.tsx:263-266` | 마지막 카드 더블탭 시 `setTimeout(startReading, 800)` 이중 큐잉 → SSE 2회·AI 비용 2배·DB 중복 INSERT |
| **RC4** | `page.tsx:286` | `handleConfirmCard`에 ref 가드 부재 → 확인 버튼 더블클릭 시 `startReading` 이중 호출 |
| **RC5** | `useSession.ts:67` | `selectCard` action에 atomic check-and-push·중복 방지 부재 |

## 수정 내용

### `src/hooks/useSession.ts`
**selectCard atomic dedup** — length cap + `card.id` 중복 차단을 store에 내장. cancel-then-reselect 시나리오와 호환(cancel 후엔 store에서 카드가 빠져 통과).

### `src/app/tarot/session/page.tsx`
- **`selectionLockRef`**: 동기 ref-lock + `requestAnimationFrame` unlock. state 반영 전 두 번째 click 차단
- **`autoStartTimerRef`**: 마지막 카드 자동 시작 setTimeout 이중 큐잉 차단
- **`setSelectedIndices`/`setRevealedPositions` 중복 방지**: `.includes` 체크 추가
- **`handleConfirmCard` 진입 가드**: `pendingConfirmRef.current` 검사

### `src/hooks/__tests__/useSession.test.ts` (신규)
atomic dedup 5개 케이스:
- 정상 선택
- 같은 card.id 두 번 호출 시 두 번째 무시 (race 방어)
- requiredCards 도달 후 추가 호출 무시 (length cap)
- cancel 후 같은 card.id 재선택 허용 (호환성 검증)
- 서로 다른 card.id 정상 누적

## Plan agent 검증 결과 반영

- ✅ `card.id` 기반 dedup이 cancel-then-reselect와 호환
- ❌ `startingRef` 폐기 — `phase` 전이만으로 충분 (phase!=="card-select"면 CardDeck unmount)
- ❌ Framer Motion `whileTap` 별도 처리 불필요 — issue#1722이 motion v10+에서 해결, 현재 v12.38

## 검증
- ✅ `pnpm type-check`
- ✅ `pnpm lint`
- ✅ `pnpm vitest run` — **819 → 824 통과 (+5 신규)**

## Test plan
- [ ] 같은 카드 빠른 더블탭 → 카드 1장만 선택됨 (selectedCards.length === 1)
- [ ] 마지막 카드 빠른 더블탭 → SSE 1회만 호출 (`/api/tarot/reading` Network 탭)
- [ ] 확인 모드 ON에서 확인 버튼 더블클릭 → `startReading` 1회만 호출
- [ ] 카드 선택 → cancel → 같은 카드 재선택이 정상 동작 (호환성)
- [ ] iPhone Safari에서 빠른 연속 터치 시 결과 일관

https://claude.ai/code/session_01Fncq8ujQQ5Ps5ovwqDiNNV

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fncq8ujQQ5Ps5ovwqDiNNV)_