### PR TITLE
docs: reorganize markdown documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,241 +1,130 @@
 # ArcanaInsight
 
-일본 애니메이션 스타일 캐릭터와 대화하며 타로·사주 리딩을 받는 운세 종합 콘텐츠 플랫폼
+일본 애니메이션 스타일 캐릭터와 대화하며 타로, 사주, 신점 리딩을 받는 운세 종합 콘텐츠 플랫폼.
+
+이 파일은 세션 시작용 빠른 지도입니다. 세부 규칙과 긴 설명은 `docs/`의 주제별 문서를 정본으로 삼습니다.
 
 ## 세션 시작 순서
 
-1. **이 CLAUDE.md 전체** — 프로젝트 구조·규칙·아키텍처 파악
-2. **`git log --oneline -10`** — 최근 변경사항
-3. **메모리 확인** — `~/.claude/projects/.../MEMORY.md`
-4. **MCP 연동** — SonarCloud QG + Railway 배포 상태 확인 (작업 전 필수). → [`docs/operations/monitoring.md`](docs/operations/monitoring.md)
-   - SonarCloud: `curl -s -u "SONARQUBE_TOKEN:" "https://sonarcloud.io/api/qualitygates/project_status?projectKey=xzawed_ArcanaInsight"`
-   - Railway: `railway link --project 24bdc6b7-db99-4487-896e-d4bd68dbb6b3 --environment production --service ArcanaInsight` 선행 필수
-5. **요청 관련 파일만 Read** — 전체 코드베이스 탐색 금지
-6. **불확실하면 질문 전에 코드 확인** — 추측 금지
+1. `git status --short`로 사용자 변경 사항을 먼저 확인한다.
+2. 요청과 관련된 파일만 읽되, 불확실한 내용은 코드와 문서를 대조한다.
+3. 문서 정합성은 [`docs/README.md`](docs/README.md)에서 주제별 정본을 찾아 확인한다.
+4. 운영 상태 확인이 필요한 작업은 [`docs/operations/monitoring.md`](docs/operations/monitoring.md)를 따른다.
+5. 코드 변경 후 관련 문서도 함께 갱신한다.
 
 ## 기술 스택
 
-| | |
+| 영역 | 현재 기준 |
 |---|---|
-| **언어·프레임워크** | TypeScript strict, Next.js 16.2.3 (App Router), React 19.2.4 |
-| **스타일링·애니메이션** | Tailwind CSS v4 (`@theme`), Framer Motion v12.38 |
-| **AI** | Grok API (xAI) 우선 + Claude API 자동 fallback |
-| **인증·DB** | Supabase Auth / NextAuth.js v5 (DB_PROVIDER별 전환) |
-| **DB ORM** | Supabase PostgreSQL / Drizzle ORM (DB_PROVIDER별 전환) |
-| **상태·패키지** | Zustand v5.0, pnpm 10.33.0 |
-| **다국어·i18n** | 자체 translations 모듈 + middleware locale 쿠키 (ko/en/ja) — → [`docs/architecture/i18n.md`](docs/architecture/i18n.md) |
-| **테스트** | Vitest 2.0 (819개, statements 98%), Playwright (3 디바이스, `SKIP_WEBKIT=1`로 iOS 제외 가능) |
-| **CI/CD·호스팅** | GitHub Actions → Railway |
+| 언어/프레임워크 | TypeScript strict, Next.js 16.2.3 App Router, React 19.2.4 |
+| 스타일/애니메이션 | Tailwind CSS v4, Framer Motion v12.38 |
+| AI | Grok API 우선, Claude API 자동 fallback |
+| 인증/DB | Supabase Auth + Supabase PostgreSQL 기본, `DB_PROVIDER=postgres` 전환 시 NextAuth.js v5 + Drizzle |
+| 상태/패키지 | Zustand v5, pnpm 10.33.0 |
+| i18n | 자체 translations 모듈, ko/en/ja, `ai_locale` 쿠키 |
+| 테스트 | Vitest, Playwright. 실제 테스트 수는 coverage 실행 결과를 기준으로 확인 |
+| 배포 | GitHub Actions, Railway |
 
 ## 프로젝트 구조
 
-```
+```text
 src/
-├── app/             # Pages & API (tarot·saju·shinjeom·mypage·auth·character·settings·api/locale)
-├── components/      # card/character/chat/common/effects/home/layout/saju/skin/tarot/ (CharacterDisplay·CharacterAuraLayer·ShuffleCeremony·ThemeDropdown·ServiceBackground·LanguageSwitcher 등)
-├── i18n/            # config·detect·LocaleProvider·useT·server-locale + translations/{ko,en,ja,shared}
-├── data/            # cards/, characters/, skins/, spreads/, saju/, shinjeom/, home/, topics.ts, birth-hours.ts, error-messages.ts, ui-copy.ts
-├── hooks/           # Zustand stores (useSession·useSajuSession·useShinjeomSession·useLocaleStore 등) + useSSEStream, useTheme, useCharacter, useCardAnimation
-├── lib/             # env.ts (getter 16개), request-utils.ts (SSE_HEADERS·jsonError), rate-limit.ts, db/ (getDb()·reading-saver·character-context), auth/ (getCurrentUser·requireUser·assertSessionOwnership), validation/ (api-schemas·Zod), storage/ (getCardImageUrl), color-utils.ts
-├── services/        # core/ (FallbackProvider·PromptBuilder·CircuitBreaker·http-utils), tarot/, saju/, shinjeom/
-├── types/           # card.ts, character.ts, session.ts, service.ts, user-info.ts
-├── test-helpers/    # mock-db, mock-auth, mock-request, mock-ai, reset-modules, api-route-setup
-└── __tests__/api/   # API 라우트 단위 테스트 (vitest.config.ts exclude 우회) + locale-wiring
+├── app/             # App Router 페이지와 API
+├── components/      # card, character, chat, common, effects, home, layout, saju, shinjeom, skin, tarot
+├── data/            # cards, characters, home, saju, shinjeom, skins, spreads, topics
+├── hooks/           # Zustand store와 UI/streaming hooks
+├── i18n/            # locale 감지, Provider, useT, translations
+├── lib/             # env, auth, db, storage, validation, request/rate-limit 유틸
+├── services/        # core AI provider/fallback + tarot/saju/shinjeom 서비스
+├── test-helpers/    # Vitest 공통 mock/setup
+└── types/           # 공유 타입
 
-docs/                # architecture/ conventions/ workflow/ operations/ archive/ → [`docs/README.md`](docs/README.md)
-supabase/migrations/ # 001+003~016 SQL (002 결번, PostgreSQL 모드: src/lib/db/schema/index.ts)
-e2e/                 # 22개 spec, 3 디바이스
-scripts/e2e-full/    # E2E 전수 검증 252 조합 (orchestrator/worker/reporter + matrix/flows/validators)
+docs/                # architecture, conventions, workflow, operations, archive
+e2e/                 # Playwright specs
+scripts/e2e-full/    # E2E 전수 검증 오케스트레이터
+supabase/migrations/ # Supabase SQL migrations
 ```
-
-## 캐릭터 시스템
-
-12명(arcana·miko·seonhwa·hoshi·luna·rei·cairn·zero·haru·ren·lix·ethan), 각자 다른 말투. → [`docs/architecture/data-model.md`](docs/architecture/data-model.md)
-
-**표정 규칙 (6-mood)**: `default` → 세션 진입/대기 | `mystical` → 카드 선택/리딩 대기 | `smile` → 결과 도착 | `serious` / `surprised` / `wink` → 대기 대사 mood 연동. 에러 시 `default` 복귀. 대기 대사 중 표정은 `line.mood` 따름.
-
-**이미지 경로**: 12캐릭터 모두 `nukki/[mood].png` (1408×768)
 
 ## 핵심 아키텍처
 
-**AI 신뢰성**: `services/core/` = Grok 우선 + Claude 자동 fallback. → [`docs/architecture/ai-infrastructure.md`](docs/architecture/ai-infrastructure.md)
+- AI 신뢰성: `src/services/core/`의 `FallbackProvider`가 Grok 우선 호출 후 Claude로 fallback. 상세는 [`docs/architecture/ai-infrastructure.md`](docs/architecture/ai-infrastructure.md).
+- DB/Auth 추상화: `DB_PROVIDER=supabase|postgres`에 따라 DB, Auth, Storage 구현을 런타임 분기. 상세는 [`docs/architecture/db-abstraction.md`](docs/architecture/db-abstraction.md), [`docs/architecture/auth-abstraction.md`](docs/architecture/auth-abstraction.md).
+- API 보안: Rate Limit -> Zod `safeParse` -> Auth -> 소유권 검증 순서. 새 API는 [`docs/conventions/zod-schemas.md`](docs/conventions/zod-schemas.md)를 먼저 확인.
+- SSE 스트리밍: 타로/사주/신점 리딩은 `SSE_HEADERS`, `fetchSSEStream()`, `AbortController` 패턴을 사용. 상세는 [`docs/architecture/ai-infrastructure.md`](docs/architecture/ai-infrastructure.md).
+- i18n: `middleware`가 locale을 결정하고 `x-locale` 헤더와 쿠키를 유지. 상세는 [`docs/architecture/i18n.md`](docs/architecture/i18n.md), [`docs/conventions/i18n-style.md`](docs/conventions/i18n-style.md).
 
-**DB_PROVIDER**: `supabase`(기본) ↔ `postgres` 즉시 전환. `getDb()` / `getCurrentUser()` / `getCardImageUrl()` 자동 분기. → [`docs/architecture/db-abstraction.md`](docs/architecture/db-abstraction.md)
+## 캐릭터/데이터 기준
 
-**API 보안**: Rate Limit → Zod safeParse → requireUser → assertSessionOwnership. → [`docs/architecture/auth-abstraction.md`](docs/architecture/auth-abstraction.md)
-- Rate Limit 범위: **세션 API**(tarot/saju/shinjeom session, 분당 20회) + **reading/message API** 모두 적용. `locale` 선언은 rate limit 호출 전 최상단에 위치.
+- 캐릭터 12명: `arcana`, `miko`, `seonhwa`, `hoshi`, `luna`, `rei`, `cairn`, `zero`, `haru`, `ren`, `lix`, `ethan`.
+- 캐릭터 표정 타입: `default`, `smile`, `serious`, `surprised`, `wink`, `mystical`.
+- 캐릭터 이미지는 `public/images/characters/[id]/nukki/[mood].png` 경로를 사용한다.
+- 카드, 스프레드, 스킨, 토픽 정본은 `src/data/`에 있다. 문서 설명은 [`docs/architecture/data-model.md`](docs/architecture/data-model.md).
 
-**SSE 스트리밍**: tarot/saju/shinjeom reading API. 서버: `SSE_HEADERS`+`jsonError()`(`request-utils.ts`), `readSseLines`+`withAbortTimeout`(`http-utils.ts`). 클라이언트: `fetchSSEStream()`(`useSSEStream.ts`, `AbortSignal` 지원). 클라이언트 hard timeout 240s — `AI_TIMEOUT_MS`와 동조 (10장+ 타로·full-fortune 사주 reasoning+truncation 대응). `AbortController`+`finished` 가드 (타로·사주·신점 세션 페이지 모두 적용), 초과 시 `readingErrorReason="timeout"` + 재시도 UI(`data-testid="reading-retry"`) 표시. 신점 세션은 `handleSend`·`handleEndConsultation` 각각 AbortController 적용. `/api/daily-card`는 JSON.
-
-**share_token**: `/*/result/[id]` 공개 공유. 소유자 전용 = `assertReadingAccess("owner")`.
-
-**비주얼 FX 시스템**: `CharacterAuraLayer`(오라·reduced-motion), `GlowBurstRing`(표정 전환 버스트), `ServiceBackground`(서비스별 배경 -z-10), `SpriteAnimator`(mood별 drop-shadow). OG 팩토리: `src/app/_og/ResultOgBase.tsx` → `makeResultOgResponse(config)` (SonarCloud 중복 방지).
-
-**ShuffleCeremony**: `src/components/tarot/ShuffleCeremony.tsx` — 카드 선택 진입 시 2.2s Canvas rAF 의식 4단계(덱컷→글로우→타이프라이터→부채꼴). 클릭/Enter/Space·`prefers-reduced-motion` 스킵. `getWaitingLinesData(locale)` 경유 ko/en/ja 분기. N=9 고정.
-
-**리딩 max_tokens**: Grok-3 reasoning 토큰 흡수 + 한국어 1.3배 비효율 고려해 +30~40% 상향. `reasoning_effort:"low"` 주입(`buildReasoningOption(model)` — grok-3 계열만), `AI_TIMEOUT_MS=240000`(10장+ 응답 시간 200~400s 대응), 빈 응답 throw→Claude fallback 자동 전환. `GROK_REASONING_EFFORT`·`GROK_MODEL` 환경변수로 제어. **Grok/Claude provider는 streaming 종료 시 `finish_reason`/`stop_reason`+`usage`를 콘솔에 로깅** — `length`/`max_tokens`이면 truncated 경고로 운영 진단 가능.
-- **타로**: `computeReadingMaxTokens(cardCount)` (`src/app/api/tarot/reading/route.ts`) — 1장→2600, 3장→4500, 5장→6500, 7장→8500, 9장→10500, **10장+은 `Math.min(2500 + cardCount*1700 + 5000, 60000)` 동적 산정** (10장→24500, 12장→27900/zodiac, 15장→33000, 20장→41500). 미래 spread 자동 대응.
-- **사주**: `computeSajuReadingMaxTokens(timeRange, includeMonthly)` (`src/app/api/saju/reading/route.ts`) — includeMonthly→20000, full-fortune→17000, five-year→15000, three/next-year→13000, 기본 10000.
-- **신점**: `SHINJEOM_TOKENS_FINAL=8500` / `SHINJEOM_TOKENS_CHAT=1500` (`src/app/api/shinjeom/message/route.ts`).
-
-**parseError**: `ReadingResult.parseError` = `"truncated"|"invalid_json"|"fallback_text"|"missing_fields"` (`src/types/service.ts`). parseError 있으면 SSE done 송신 + **DB INSERT 차단** (빈 결과 화면 방지). 클라이언트는 캐릭터 에러 메시지·재시도 표시 (타로 `truncated`만 부분 결과 유지).
-
-**reading-saver locale 가드**: `src/lib/db/reading-saver.ts` `safeLocale()` — 잘못된 locale 입력 시 'ko' 자동 치환 → 016 마이그레이션 CHECK 제약(`locale IN ('ko','en','ja')`) 위반 차단.
-
-**SpreadPosition rotation**: `SpreadPosition.rotation?: number` — celtic-cross position 1에 `rotation: 90` (전통 레이아웃). `CardSpread.tsx` 카드 컨테이너 `transform: rotate(Ndeg)` (라벨 회전 제외).
-
-**캐릭터 경험 시스템**: `CharacterId` union (`CHARACTER_IDS as const`). `CHAR_ENTRANCE`(입장 설정), `CHARACTER_RESULT_MOODS`(결과 mood). 6-mood 연동: 카드선택→`surprised`, 대기→`line.mood`, 결과→캐릭터별. 자유질문(`freeQuestion`→`buildFreeQuestionPrompt()`), 캐릭터 메모리(`getRecentCharacterMemory()`→system prompt 주입, 인증 사용자 전용). `fetchMemoryPrompt(characterId, locale)` 공통 함수 → `src/lib/db/character-context.ts`. → [`docs/architecture/data-model.md`](docs/architecture/data-model.md)
-
-**i18n 다국어 시스템**: ko/en/ja. middleware가 쿠키→Accept-Language→DEFAULT로 locale 결정 → `x-locale` 헤더. `useT()` (클라이언트) / `t(key, locale)` (서버). 사전: `src/i18n/translations/{ko,en,ja}/index.ts` + `shared/keys.ts`. DB 5테이블에 `locale CHECK('ko','en','ja')` (016 마이그레이션). INSERT 시 `getRequestLocale()` 동봉 필수. AI 응답 locale: `buildCharacterHeader(locale)` `LANGUAGE_INSTRUCTIONS` — en/ja는 응답 언어 + JSON 키 영어 고정 강제(`parseJsonSafe` 실패 방지). 캐릭터 locale 헬퍼: `src/data/characters/locale-helpers.ts`. drift 검사: `pnpm i18n:check`. → [`docs/architecture/i18n.md`](docs/architecture/i18n.md)
-
-## 명령어
+## 주요 명령어
 
 ```bash
-pnpm dev           # 개발 서버
-pnpm build         # 프로덕션 빌드
-pnpm lint          # ESLint
-pnpm type-check    # tsc --noEmit
-pnpm test:coverage # Vitest + 커버리지 (statements 98%)
-pnpm test:e2e      # Playwright (3 디바이스, smart-ci 제외)
-pnpm test:e2e:full          # 전수 E2E: 252 조합, 6 워커 (실서버 + 실 API 키 필요)
-pnpm test:e2e:full:ci       # CI 모드 오케스트레이터 (12 대표 케이스)
-pnpm sync:test-count        # CLAUDE.md 테스트 수 동기화
-pnpm check:env-docs         # env.ts ↔ env-variables.md 정합성
-pnpm check:doc-links        # docs 링크 검증
-pnpm i18n:check             # ko/en/ja 번역 키 drift 검출 (orphan 발견 시 exit 1)
+pnpm dev                  # 개발 서버
+pnpm build                # 프로덕션 빌드
+pnpm lint                 # ESLint
+pnpm type-check           # tsc --noEmit
+pnpm test:coverage        # Vitest + coverage
+pnpm test:e2e             # Playwright
+pnpm test:e2e:full        # 전수 E2E
+pnpm test:e2e:full:ci     # 대표 케이스 E2E
+pnpm sync:test-count      # 고정 테스트 수가 있는 문서 동기화
+pnpm check:env-docs       # env.ts와 env 문서 정합성
+pnpm check:doc-links      # 문서 링크 검증
+pnpm i18n:check           # 번역 키 drift 검출
 ```
 
-> scripts 정책 → [`docs/workflow/scripts.md`](docs/workflow/scripts.md) | Windows E2E Docker 필수 → [`docs/workflow/e2e-testing.md`](docs/workflow/e2e-testing.md) | `smart-ci.spec.ts` CI 자동 제외(`testIgnore: process.env.CI`)
+명령어 정책은 [`docs/workflow/scripts.md`](docs/workflow/scripts.md), 테스트 정책은 [`docs/workflow/unit-testing.md`](docs/workflow/unit-testing.md), [`docs/workflow/e2e-testing.md`](docs/workflow/e2e-testing.md)를 따른다.
 
 ## 환경변수
 
-→ 전체 목록·전환 방법: [`docs/operations/env-variables.md`](docs/operations/env-variables.md)
+전체 목록과 전환 절차는 [`docs/operations/env-variables.md`](docs/operations/env-variables.md)가 정본이다.
 
-**Supabase 모드 필수**: `GROK_API_KEY`, `NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_ANON_KEY`, `SUPABASE_SERVICE_ROLE_KEY`, `NEXT_PUBLIC_SITE_URL`
+- Supabase 기본 필수: `GROK_API_KEY`, `NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_ANON_KEY`, `SUPABASE_SERVICE_ROLE_KEY`, `NEXT_PUBLIC_SITE_URL`
+- PostgreSQL 모드 추가: `DB_PROVIDER=postgres`, `POSTGRES_URL`, `NEXTAUTH_SECRET`, `NEXTAUTH_URL`, `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`
 
-**PostgreSQL 모드 추가**: `DB_PROVIDER=postgres`, `POSTGRES_URL`, `NEXTAUTH_SECRET`, `NEXTAUTH_URL`, `GOOGLE_CLIENT_ID/SECRET`
+## 변경 프로세스
 
-## 코드 변경 프로세스
+상세 절차는 [`docs/workflow/code-change-process.md`](docs/workflow/code-change-process.md)를 따른다.
 
-→ 상세: [`docs/workflow/code-change-process.md`](docs/workflow/code-change-process.md)
+1. 코드/문서 변경 범위를 확인한다.
+2. 관련 테스트와 정적 검사를 실행한다.
+3. 사용자 변경 사항을 보존한다.
+4. 변경한 동작과 문서를 함께 보고한다.
 
-**7단계**: 코드변경 → 로컬검증(`type-check + lint + test + build`) → 리뷰 → 커밋+PR → CI → 머지+배포 → **CLAUDE.md 최신화(필수, 예외 없음)**
-
-**커밋 prefix**: `feat:` 새기능 | `fix:` 버그 | `docs:` 문서 | `chore:` 설정 | `refactor:` 구조개선 | `style:` UI | `test:` 테스트 | `merge:` 머지
-
-**CI/CD**: PR→main: lint→build→E2E. 주간QA 토요일. Railway 자동배포. → [`docs/workflow/ci-cd.md`](docs/workflow/ci-cd.md)
-
-**구현 계획서 필수 섹션** (`docs/superpowers/plans/*.md` 상단):
-```markdown
-## 적용 가능 위험 항목 (CLAUDE.md 필수 주의사항)
-- [ ] SSR/Hydration: useState 초기값·useEffect setState 패턴 해당 여부
-- [ ] 비슷한 파일 N개 생성 여부 → 공통 베이스 추출 검토
-- [ ] UI 텍스트 변경 여부 → E2E 셀렉터 동시 검토 필요
-```
-각 Task 검증 단계에 `pnpm type-check && pnpm lint` 포함 필수 (type-check만으로는 lint 규칙 미검출).
-
-## 레이아웃 규칙 (필수 준수)
-
-캐릭터 등장 모든 페이지. 상세: [`docs/conventions/layout-rules.md`](docs/conventions/layout-rules.md)
-
-- **데스크탑**: 캐릭터 `md:w-1/2` + 콘텐츠 `md:w-1/2` (5:5 flex)
-- **모바일**: `flex-col`. 캐릭터 `h-[25%]`, 콘텐츠 `overflow-y-auto`
-- **CSS mask 표준값** (수치 임의 변경 금지):
-  ```
-  top: transparent 0% → black 14%    bottom: transparent 0% → black 18%
-  left/right: transparent 0% → black 10%
-  ```
-- `CharacterDisplay` 컴포넌트 사용 시 자동 적용. 직접 `<Image>` 사용 시 래퍼 div에 적용.
-
-## 크로스 플랫폼 규칙 (필수 준수)
-
-상세: [`docs/conventions/cross-platform.md`](docs/conventions/cross-platform.md)
-
-- **`100vh` 금지** → `100dvh` 사용 (iOS Safari 호환). 패턴: `h-[calc(100dvh-7rem)]`
-- **하단 고정 요소**: `pb-[env(safe-area-inset-bottom)]` 필수
-- **`overflow-x: clip`** (`hidden` 대신 — iOS 스크롤 바운스 호환)
-- **포커스**: `:focus { outline: none }` + `:focus-visible { outline: ... }` 유지
+커밋 prefix와 브랜치 규칙은 [`docs/conventions/coding-style.md`](docs/conventions/coding-style.md)에 있다.
 
 ## 필수 주의사항
 
-> 카테고리별로 그룹화. 해당 작업 시 관련 그룹만 우선 확인.
+- 레이아웃: 캐릭터 등장 페이지의 5:5 규칙과 모바일 배치는 [`docs/conventions/layout-rules.md`](docs/conventions/layout-rules.md)를 따른다.
+- 크로스 플랫폼: `100vh` 대신 `100dvh`, safe-area, focus-visible 규칙은 [`docs/conventions/cross-platform.md`](docs/conventions/cross-platform.md)를 따른다.
+- SSR/Hydration: 비결정 값(`Date`, `Math.random`, `window`)은 클라이언트 effect 안에서만 다룬다.
+- API 입력: 타입 단언보다 Zod schema와 `safeParse`를 사용한다.
+- i18n: UI 텍스트는 번역 키를 우선 추가하고 `t()`/`useT()`로 노출한다.
+- 테스트 파일: API 라우트 테스트는 `src/__tests__/api/`에 둔다.
+- 패키지 추가: `pnpm-lock.yaml` 변동과 peer dependency 변화를 확인한다.
 
-### SSR · Hydration (컴포넌트 작성 시)
-- **SSR 비결정 값 금지**: `new Date()`, `Math.random()`, `window` → `useEffect` 안에서만. `useState` 초기값은 `""`/`0`/`null` (React error #418 방지). `useEffect` 내 setState 직접 호출 금지 → `setTimeout(() => setState(...), 0)` + `return () => clearTimeout(t)` 필수 (`react-hooks/set-state-in-effect`).
-- **`<Image fill>` sizes 필수**: 미설정 시 Mobile Android CI 타임아웃. `sizes="(max-width: 640px) 50vw, ..."` 필수.
-- **`next/dynamic ssr:false`는 Canvas/WebGL 전용**: `ShuffleCeremony`(Canvas rAF) 같은 컴포넌트에만 사용. 일반 UI 컴포넌트는 SSR 기본값 유지.
-<<<<<<< HEAD
-- **`React.memo` + `displayName`**: 무거운 렌더 컴포넌트(`SpriteAnimator`, `CardDeck`, `CardSpread`)는 `React.memo(function Name() {...})` + `Name.displayName = "Name"` 패턴. 배열 prop은 `areEqual` 커스텀 비교 함수 필수 (`revealedPositions` 등 — 참조 동일성 비교 실패 방지).
-=======
-- **`React.memo` + `displayName`**: 무거운 렌더 컴포넌트(`SpriteAnimator`, `CardDeck`, `CardSpread`, `CharacterDisplay`, `DialogueBox`)는 `React.memo(function Name() {...})` + `Name.displayName = "Name"` 패턴. 배열 prop은 `areEqual` 커스텀 비교 함수 필수 (`revealedPositions` 등 — 참조 동일성 비교 실패 방지). Zustand 스토어 구독은 prop이 아니므로 `areEqual` 우회 — re-render 정상 발생.
->>>>>>> 93ac8ac723a73c12245ace4582a1462035f19cf0
+## 업무별 진입점
 
-### API · 보안 (새 라우트 추가 시)
-- **API 스키마**: 새 라우트 → `api-schemas.ts` Zod 먼저 정의, `safeParse` 사용. 타입 단언 `as {...}` 금지.
-- **Zod `null` vs `undefined`**: Zustand `null` 초기값 필드 → `.nullish()` 필수. 위반 시 프로덕션 400 (로컬 통과). → [`docs/conventions/zod-schemas.md`](docs/conventions/zod-schemas.md)
-- **API 라우트 outer catch 커버리지**: `POST` 핸들러 최외부 `} catch {` 블록은 `checkRateLimit: vi.fn().mockRejectedValue(new Error(...))` 패턴으로 커버. 미커버 시 Codecov patch 실패.
-- **SSE 라우트 fire-and-forget 패턴**: 스트림 전송 완료 후 DB 저장은 `void saveFn(args).catch(e => console.error("[tag]", e))` 패턴 필수. `await` 금지 (스트림 블로킹).
-- **DB 어댑터 동적 require**: `getDb()`는 런타임 `require()` 로드. 새 어댑터 추가 시 정적 `import` 금지.
-- **JSON 파싱 — 문자열 내 `{}` 주의**: AI 응답 파싱 시 반드시 `parseJsonSafe()` (`src/services/core/text-cleaner.ts`) 사용. → [`docs/architecture/ai-infrastructure.md`](docs/architecture/ai-infrastructure.md#3-json-파싱-파이프라인)
-
-### 테스트 · CI (테스트 작성·PR 전)
-- **API 라우트 테스트 경로**: `src/app/api/` 내 `*.test.ts`는 vitest 수집 불가 → `src/__tests__/api/` 배치. → [`docs/workflow/unit-testing.md`](docs/workflow/unit-testing.md)
-- **E2E 스펙 추가 시 인증 의존성 명시**: 실 Supabase 세션 요구 spec은 파일 상단에 `// ⚠️ 실 Supabase 인증 세션 필요 — CI testIgnore 대상` 주석 필수.
-- **UI 텍스트 변경 시 E2E 셀렉터 동시 검토**: `e2e/` 내 `hasText`, `getByText`, `locator("text=")` 패턴 grep 후 같은 커밋에 수정.
-- **E2E 드롭다운**: `button:has(img)+text=` 조합 오탐 발생 → `data-testid` 필수. 데스크탑·모바일 드롭다운 반드시 별도 `ref`+별도 `testid` — 동일 `ref` 공유 시 React last-wins로 outside-click 오탐(드롭다운 선택 즉시 닫힘). **ThemeDropdown testid**: `theme-option-${id}` (데스크탑) / `mobile-theme-option-${id}` (모바일) — `text=` 셀렉터는 i18n 변경 시 파손.
-- **Mobile Android 스크롤 테스트**: `domcontentloaded` 직후 scrollTo/scrollHeight flaky → `load`+`networkidle` 두 단계 대기 + scrollHeight polling(최대 10s) + `window.scrollTo`&`mouse.wheel` 병행 필수.
-
-- **Enum 화이트리스트 하드코딩 금지**: API 라우트에서 Zod `z.enum([...])` 검증 통과 후 일부 값만 하드코딩으로 재검증하면 나머지 값이 누락됨. `spreadResolver.getSpreadByType(val)` 처럼 유틸 메서드로 전체 enum 검증 필수. session/route.ts·reading/route.ts 모두 적용.
-- **DB CHECK 제약과 앱 코드 동기화 필수**: DB schema에 CHECK 제약이 있는 enum 컬럼(spread_type, topic 등)에 새 값 추가 시 마이그레이션(ALTER TABLE ... DROP CONSTRAINT + ADD CONSTRAINT) 필수. 앱 코드만 수정하면 DB INSERT 500.
-
-### 패키지 · 빌드 (의존성 추가·수정 시)
-- **패키지 추가 후 lockfile 변동 확인 필수**: `pnpm add` 후 `git diff pnpm-lock.yaml | grep "^[-+].*version"` 으로 피어 의존성 버전 변동 검토.
-- **npm 미등록 패키지 side-effect import 즉시 차단**: `import "미등록패키지/path"` 형태는 모듈 로딩 시점에 vitest·Next.js 전체 차단. 새 PR에서 발견 시 병합 전 제거.
-- **비슷한 파일 N개 생성 시 공통 베이스 추출 검토**: 동일 의도 파일 2개 이상 → 팩토리/베이스 우선 설계. SonarCloud `new_duplicated_lines_density` 임계치 3%.
-
-### i18n 다국어 (UI 텍스트·번역·locale 작업 시)
-- **LocaleProvider SSR 패턴 필수**: `useEffect` 내 `setLocale()` 동기 호출 금지. `setTimeout(() => setLocale(initial), 0); return () => clearTimeout(t)` 패턴 사용. 미준수 시 hydration error #418 발생.
-- **번역 키 정의 우선**: 새 UI 텍스트 추가 → ① `src/i18n/translations/shared/keys.ts`에 타입 추가 → ② `ko/index.ts` (SSOT) 채움 → ③ `en/index.ts` 임시 영문 (외부 번역 대기) → ④ `ja/index.ts`는 일괄 마이그레이션 시 추가. ko 사전이 SSOT, en/ja는 부분 번역 허용 (Partial<SharedKeys>).
-- **`t()` namespace 정확성 필수**: `flatten()`이 `${namespace}.${innerKey}`로 키 생성. namespace 불일치 시 `t()` fallback이 **키 문자열 자체를 반환** → 화면 노출 UX 최악. 새 키 전 `grep "innerKey" shared/keys.ts`로 위치 확인.
-- **LanguageSwitcher 별도 ref+testid 필수**: 데스크탑·모바일 각각. 동일 ref 공유 시 React last-wins 오탐.
-- **INSERT에 locale 동봉 필수**: `getRequestLocale()` 경유. 미동봉 시 DEFAULT 'ko' → en/ja 사용자 데이터 오염.
-- **E2E 셀렉터 data-testid 우선**: 한글 `hasText` regex는 i18n 텍스트 변경에 깨짐.
-
-## 업무 유형별 가이드
-
-→ 상세: [`docs/workflow/task-playbooks.md`](docs/workflow/task-playbooks.md)
-
-| 업무 | 진입 파일 | 에이전트 |
-|------|----------|---------|
-| 새 캐릭터 | `src/data/characters/index.ts`, `waiting-lines.ts` | `character-add` |
-| 새 운세 서비스 | `src/services/core/ai-provider.ts` | `divination-scaffold` |
-| 새 페이지 | `src/app/layout.tsx`, `Header.tsx`, `MobileNav.tsx` | `page-builder` |
-| 테마·스타일 | `src/app/globals.css`, `useTheme.ts` | `theme-creator` |
-| 카드 스킨 | `src/data/skins/index.ts`, `src/lib/storage/index.ts` | `skin-manager` |
-| DB 스키마 | `supabase/migrations/`, `src/lib/db/schema/index.ts` | — |
-| AI 프롬프트 | `src/services/core/prompt-builder.ts`, `[service]-service.ts` | — |
-| 다국어·번역 | `src/i18n/translations/shared/keys.ts`, `{ko,en,ja}/index.ts` | — |
-| 코드 품질 검증 | `pnpm type-check && pnpm lint && pnpm build` | `quality-gate` |
-
-## 미구현 기능·기술 부채
-
-→ **정본**: [`docs/operations/known-issues.md`](docs/operations/known-issues.md)
-
-- rate-limit: UPSTASH_REDIS_REST_URL 미설정 시 in-memory fallback (분산 처리 미활성화)
+| 업무 | 먼저 볼 문서 |
+|---|---|
+| 시스템 구조 | [`docs/architecture/system-overview.md`](docs/architecture/system-overview.md) |
+| AI/프롬프트 | [`docs/architecture/ai-infrastructure.md`](docs/architecture/ai-infrastructure.md) |
+| DB/Auth | [`docs/architecture/db-abstraction.md`](docs/architecture/db-abstraction.md), [`docs/architecture/auth-abstraction.md`](docs/architecture/auth-abstraction.md) |
+| 캐릭터/카드/스킨 | [`docs/architecture/data-model.md`](docs/architecture/data-model.md) |
+| 새 기능/페이지/API | [`docs/workflow/task-playbooks.md`](docs/workflow/task-playbooks.md) |
+| 배포/운영 | [`docs/operations/deployment.md`](docs/operations/deployment.md), [`docs/operations/operation-guide.md`](docs/operations/operation-guide.md) |
+| 미구현/기술부채 | [`docs/operations/known-issues.md`](docs/operations/known-issues.md) |
 
 ## Claude 자율 관리 규칙
 
-**에이전트** (`.claude/agents/`): `character-add`, `divination-scaffold`, `page-builder`, `quality-gate`, `skin-manager`, `theme-creator`
+- `.claude/agents/`에는 반복 작업용 에이전트 정의가 있다.
+- 훅, deny 규칙, 배포 관련 파괴적 변경은 사용자 확인 후 진행한다.
+- 문서 변경 보고 형식:
 
-**훅**: PreToolUse `git push*` → `scripts/pre-push-checks.sh` (tsc+lint+build)
-
-**자율 관리 원칙**: 필요하면 즉시 생성, 불필요하면 즉시 삭제, 변경 후 보고. 파괴적 변경(deny 규칙·훅 삭제)만 사전 확인.
-
-**문서 관리**: 코드 변경 시 관련 문서 동시 업데이트. 중복은 링크로 대체. **High 등급(CLAUDE.md, README*, docs/architecture/*, known-issues.md, LICENSE) 변경 시 multi-agent ≥2 분리 검증 필수** (정합성·누락·구조). 변경 보고:
+```text
+문서 변경: [파일명] - 변경 이유: [이유] - 변경 내용: [1줄 요약]
 ```
-📄 문서 변경: [파일명] — 변경 이유: [이유] — 변경 내용: [1줄 요약]
-```
-
-## 운영 체계
-
-**Claude CLI**: 기획·구현·검토·배포 (7단계). **Grok API**: 리딩+이미지 전용. **n8n Cloud**: Spec Tracker/Quality Monitor/Weekly Report. **단일 진실 소스**: CLAUDE.md + `docs/` → [`docs/README.md`](docs/README.md). **MCP 자율 진단**: PR CI/QG Fail/Railway 이상/push 전 — 요청 없이 수집, MCP 미로드 시 REST/CLI 대체. → [`docs/operations/monitoring.md`](docs/operations/monitoring.md)

--- a/README.en.md
+++ b/README.en.md
@@ -170,14 +170,14 @@ pnpm dev
 | Category | Technology |
 |----------|-----------|
 | 🗣️ Language | TypeScript (strict) |
-| ⚛️ Framework | Next.js 16.2.1 (App Router) · React 19.2.4 |
+| ⚛️ Framework | Next.js 16.2.3 (App Router) · React 19.2.4 |
 | 🎨 Styling | Tailwind CSS v4 (`@theme` CSS-based config) |
 | 🎬 Animation | Framer Motion v12.38 |
 | 🤖 AI | Grok API (xAI) — SSE streaming · Claude API (Anthropic) auto-fallback |
 | 🔐 Auth | Supabase Auth Helpers (Google) |
 | 🗄️ Database | Supabase (PostgreSQL) · Drizzle ORM (on-premises switchover support) |
 | 📦 State | Zustand v5 |
-| 📦 Package manager | pnpm 10.33 |
+| 📦 Package manager | pnpm 10.33.0 |
 | 🚀 Hosting | Railway (auto-deploy via GitHub Actions) |
 | 🧪 E2E Tests | Playwright — 19 files, 141 tests (Desktop · Android · iOS) · [Guide](./e2e/README.md) |
 

--- a/README.md
+++ b/README.md
@@ -171,14 +171,14 @@ pnpm dev
 | 분류 | 기술 |
 |------|------|
 | 🗣️ 언어 | TypeScript (strict) |
-| ⚛️ 프레임워크 | Next.js 16.2.1 (App Router) · React 19.2.4 |
+| ⚛️ 프레임워크 | Next.js 16.2.3 (App Router) · React 19.2.4 |
 | 🎨 스타일링 | Tailwind CSS v4 (`@theme` CSS-based config) |
 | 🎬 애니메이션 | Framer Motion v12.38 |
 | 🤖 AI | Grok API (xAI) — SSE 스트리밍 · Claude API (Anthropic) 자동 fallback |
 | 🔐 인증 | Supabase Auth Helpers (구글) |
 | 🗄️ 데이터베이스 | Supabase (PostgreSQL) · Drizzle ORM (온프레미스 전환 지원) |
 | 📦 상태관리 | Zustand v5 |
-| 📦 패키지 매니저 | pnpm 10.33 |
+| 📦 패키지 매니저 | pnpm 10.33.0 |
 | 🚀 호스팅 | Railway (GitHub Actions 자동 배포) |
 | 🧪 E2E 테스트 | Playwright — 19개 파일, 141개 테스트 (Desktop · Android · iOS) · [가이드](./e2e/README.md) |
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,68 +1,79 @@
 # ArcanaInsight 문서 인덱스
 
-이 폴더는 CLAUDE.md의 세부 내용을 업무 유형별로 분류한 하위 문서 모음입니다.
-CLAUDE.md는 포인터(≤250줄)만 유지하며, 각 주제의 정본은 이 폴더 안에 위치합니다.
+이 폴더는 프로젝트의 장기 정본 문서를 주제별로 보관합니다. 루트 `CLAUDE.md`는 빠른 진입점이고, 세부 규칙과 배경 설명은 이 문서들이 기준입니다.
 
 ## 업무 유형별 진입점
 
 | 업무 | 진입 문서 |
-|------|----------|
+|---|---|
 | 시스템 구조 이해 | [architecture/system-overview.md](architecture/system-overview.md) |
-| AI 인프라 이해 | [architecture/ai-infrastructure.md](architecture/ai-infrastructure.md) |
-| DB 추상화 이해 | [architecture/db-abstraction.md](architecture/db-abstraction.md) |
-| Auth 추상화·API 보안 | [architecture/auth-abstraction.md](architecture/auth-abstraction.md) |
-| 캐릭터·카드·스킨 데이터 모델 | [architecture/data-model.md](architecture/data-model.md) |
+| AI/LLM fallback, SSE, JSON 파싱 | [architecture/ai-infrastructure.md](architecture/ai-infrastructure.md) |
+| DB 공급자 전환 | [architecture/db-abstraction.md](architecture/db-abstraction.md) |
+| Auth 추상화와 API 보안 | [architecture/auth-abstraction.md](architecture/auth-abstraction.md) |
+| 캐릭터, 카드, 스킨 데이터 | [architecture/data-model.md](architecture/data-model.md) |
+| 다국어 인프라 | [architecture/i18n.md](architecture/i18n.md) |
 | 코드 변경 절차 | [workflow/code-change-process.md](workflow/code-change-process.md) |
-| E2E 테스트 실행 | [workflow/e2e-testing.md](workflow/e2e-testing.md) |
-| 단위 테스트 패턴 | [workflow/unit-testing.md](workflow/unit-testing.md) |
-| 캐릭터/스킨/페이지 추가 | [workflow/task-playbooks.md](workflow/task-playbooks.md) |
+| 단위 테스트 | [workflow/unit-testing.md](workflow/unit-testing.md) |
+| E2E 테스트 | [workflow/e2e-testing.md](workflow/e2e-testing.md) |
+| 반복 작업별 파일 가이드 | [workflow/task-playbooks.md](workflow/task-playbooks.md) |
+| 스크립트 정책 | [workflow/scripts.md](workflow/scripts.md) |
 | CI/CD 파이프라인 | [workflow/ci-cd.md](workflow/ci-cd.md) |
-| 코딩 스타일·컨벤션 | [conventions/coding-style.md](conventions/coding-style.md) |
-| 레이아웃 5:5 규칙 | [conventions/layout-rules.md](conventions/layout-rules.md) |
-| 크로스플랫폼 품질 | [conventions/cross-platform.md](conventions/cross-platform.md) |
-| Zod 스키마·API 입력 검증 | [conventions/zod-schemas.md](conventions/zod-schemas.md) |
-| 이미지 에셋 규칙 | [conventions/image-assets.md](conventions/image-assets.md) |
-| 환경변수 목록 | [operations/env-variables.md](operations/env-variables.md) |
+| 코딩 스타일 | [conventions/coding-style.md](conventions/coding-style.md) |
+| 레이아웃 규칙 | [conventions/layout-rules.md](conventions/layout-rules.md) |
+| 크로스 플랫폼 품질 | [conventions/cross-platform.md](conventions/cross-platform.md) |
+| Zod/API 입력 검증 | [conventions/zod-schemas.md](conventions/zod-schemas.md) |
+| 이미지 에셋 | [conventions/image-assets.md](conventions/image-assets.md) |
+| i18n 작성 규칙 | [conventions/i18n-style.md](conventions/i18n-style.md) |
+| 환경변수 | [operations/env-variables.md](operations/env-variables.md) |
 | 운영자 가이드 | [operations/operation-guide.md](operations/operation-guide.md) |
 | 미구현/기술부채 | [operations/known-issues.md](operations/known-issues.md) |
-| 배포/롤백 절차 | [operations/deployment.md](operations/deployment.md) |
-| 모니터링·QA·n8n | [operations/monitoring.md](operations/monitoring.md) |
-| 내부 흐름도 아카이브 | [archive/process-diagrams.md](archive/process-diagrams.md) |
+| 배포/롤백 | [operations/deployment.md](operations/deployment.md) |
+| 모니터링/QA | [operations/monitoring.md](operations/monitoring.md) |
 
 ## 폴더 구조
 
-```
+```text
 docs/
-├── README.md                   # 이 파일 — 인덱스
-├── architecture/               # "시스템을 이해한다" ✅ PR-3 완성
+├── README.md
+├── architecture/
 │   ├── system-overview.md
 │   ├── ai-infrastructure.md
 │   ├── db-abstraction.md
 │   ├── auth-abstraction.md
-│   └── data-model.md
-├── workflow/                   # "어떻게 변경하는가" ✅ PR-4 완성
-│   ├── e2e-testing.md          # PR-2
-│   ├── unit-testing.md         # PR-3
-│   ├── task-playbooks.md       # PR-3
-│   ├── code-change-process.md  # PR-4
-│   └── ci-cd.md                # PR-4
-├── conventions/                # "어떻게 작성하는가" ✅ PR-3 완성
+│   ├── data-model.md
+│   └── i18n.md
+├── conventions/
 │   ├── coding-style.md
-│   ├── layout-rules.md
 │   ├── cross-platform.md
-│   ├── zod-schemas.md
-│   └── image-assets.md
-├── operations/                 # "운영하는 법" ✅ PR-4 완성
-│   ├── known-issues.md         # PR-1
-│   ├── operation-guide.md      # PR-2 (이동)
-│   ├── env-variables.md        # PR-4
-│   ├── deployment.md           # PR-4
-│   └── monitoring.md           # PR-4
-└── archive/                    # "역사적 자료" ✅ PR-4 완성
-    ├── skills-original.md      # PR-2 (이동)
-    ├── ai-quality-roadmap.md   # PR-2 (이동)
-    └── process-diagrams.md     # PR-4 (process.md 분해)
+│   ├── i18n-style.md
+│   ├── image-assets.md
+│   ├── layout-rules.md
+│   └── zod-schemas.md
+├── workflow/
+│   ├── ci-cd.md
+│   ├── code-change-process.md
+│   ├── e2e-testing.md
+│   ├── scripts.md
+│   ├── task-playbooks.md
+│   └── unit-testing.md
+├── operations/
+│   ├── deployment.md
+│   ├── env-variables.md
+│   ├── known-issues.md
+│   ├── monitoring.md
+│   └── operation-guide.md
+├── archive/
+│   ├── ai-quality-roadmap.md
+│   ├── process-diagrams.md
+│   └── skills-original.md
+└── superpowers/
+    ├── plans/
+    └── specs/
 ```
 
-> **완성 현황**: PR-1(known-issues) → PR-2(archive 이동) → PR-3(architecture/conventions 분할)
-> → PR-4(workflow/operations 완성 + process.md 분해) → PR-5(CLAUDE.md 250줄 축약)
+## 관리 원칙
+
+- 루트 `CLAUDE.md`에는 빠른 판단에 필요한 요약과 링크만 둡니다.
+- 중복 설명이 필요하면 한 곳을 정본으로 두고 다른 문서에서는 링크로 참조합니다.
+- 코드와 달라지기 쉬운 숫자(테스트 수, 커버리지 상세, 버전)는 가능하면 검증 스크립트나 `package.json`을 기준으로 안내합니다.
+- 변경 후에는 `pnpm check:doc-links`로 문서 링크를 확인합니다.

--- a/docs/architecture/auth-abstraction.md
+++ b/docs/architecture/auth-abstraction.md
@@ -113,4 +113,4 @@ API 라우트: `src/app/api/auth/[...nextauth]/` — PostgreSQL 모드 전용
 
 ## i18n locale 필드
 
-`AuthUser` 타입은 `{ id, email }`만 포함. locale 필드는 PR-4에서 추가 예정. 현재는 쿠키(`ai_locale`)가 SSOT이고 `profiles.locale`은 보조 동기화 (`/api/locale` POST가 양쪽 갱신). 상세: [`i18n.md`](i18n.md)
+`AuthUser` 타입은 `{ id, email }`만 포함한다. locale은 인증 객체에 싣지 않고 쿠키(`ai_locale`)를 요청 기준 SSOT로 사용하며, 인증 사용자의 `profiles.locale`은 `/api/locale` POST로 보조 동기화한다. 상세: [`i18n.md`](i18n.md)

--- a/docs/architecture/data-model.md
+++ b/docs/architecture/data-model.md
@@ -121,11 +121,11 @@ ArcanaInsight의 정적 데이터(캐릭터, 카드, 스프레드, 스킨) 모�
 | 홈 페이지 정적 데이터 | `src/data/home/` (faq.ts) |
 | 에러 메시지 상수 | `src/data/error-messages.ts` |
 
-## 다국어 데이터 (PR-3·PR-4·PR-5 예정)
+## 다국어 데이터
 
-- 카드 80장 `name`·`meanings` 객체화 (`{ ko, en, ja? }`) — PR-3에서 외부 번역가 의뢰
-- 12 캐릭터 페르소나 5필드(`greeting`·`personality`·`description`·`speciality`·`speechStyle`)에 영문·일문 추가 — PR-4 외부 번역
-- `waiting-lines.ts` 186줄 영문·일문 — PR-4
-- 일본어 전체 사전 채움 — PR-5
+- 카드 데이터는 `name`, `nameKo`, `nameJa`를 함께 가진다. 리딩 의미문은 현재 한국어 중심이며 AI 응답 언어는 프롬프트 locale 지시로 제어한다.
+- 캐릭터 데이터는 `greetingEn`, `greetingJa`, `descriptionEn`, `descriptionJa`, `specialityEn`, `specialityJa` 필드를 가진다.
+- 대기 대사는 `waiting-lines.ts`, `waiting-lines-en.ts`, `waiting-lines-ja.ts`, `waiting-lines-i18n.ts`로 분리되어 locale별로 조회한다.
+- UI 사전은 `src/i18n/translations/{ko,en,ja}/index.ts`에 있으며, 미번역 키는 ko fallback을 사용한다.
 
 상세: [`i18n.md`](i18n.md)

--- a/docs/architecture/i18n.md
+++ b/docs/architecture/i18n.md
@@ -39,9 +39,9 @@ src/i18n/
 └── translations/
     ├── index.ts              # buildDict + t(key, locale) + fallback chain
     ├── shared/keys.ts        # SharedKeys 타입 (5 namespace) + flatten 헬퍼
-    ├── ko/index.ts           # SSOT (전체 키)
-    ├── en/index.ts           # 1차 임시 영문 (외부 번역 발주 대기)
-    └── ja/index.ts           # common·locale namespace만 1차 (PR-5 일괄)
+    ├── ko/index.ts           # SSOT
+    ├── en/index.ts           # 영문 사전
+    └── ja/index.ts           # 일본어 사전
 ```
 
 ### namespace
@@ -68,14 +68,14 @@ CREATE INDEX idx_sessions_user_locale ON public.sessions (user_id, locale);
 
 ### 컬럼 의미
 - `profiles.locale`: 사용자 선호 locale (인증 사용자 전용 SSOT, 비인증은 쿠키만)
-- `sessions.locale`: 세션 작성 시점 locale (PR-4 character-context cross-locale 필터)
+- `sessions.locale`: 세션 작성 시점 locale. 캐릭터 메모리 조회 시 locale 필터로 사용
 - `readings.locale` / `saju_readings.locale` / `shinjeom_readings.locale`: 결과 텍스트 작성 언어 추적
 
 ### `daily_cards` 미포함 (의도적)
 - 키: `(date, character_id)` UNIQUE — 단일 사전 정책
-- locale 분리 시 4×용량 폭증 → character_id 종속 해석으로 PR-3·PR-5에서 표시 시점 처리
+- locale 분리 시 저장 용량이 늘어나므로 일일 카드는 단일 사전 정책을 유지
 
-## 라우트 INSERT 정책 (PR-A 핫픽스 이후)
+## 라우트 INSERT 정책
 
 신규 세션·리딩 INSERT 시 `getRequestLocale()`로 결정한 locale을 명시 동봉한다. 누락 시 DEFAULT 'ko'가 입력되어 영어·일본어 사용자 데이터가 'ko'로 고정되는 결함이 발생한다.
 
@@ -102,27 +102,17 @@ saveShinjeomFinalReading(db, sessionId, result, locale);
 - `src/__tests__/api/locale-wiring.test.ts` — 6개 INSERT locale 동봉 검증
 - `vitest.setup.ts` — `next/headers` 전역 mock (개별 테스트 override 가능)
 
-## 진행 상황
+## 현재 범위와 남은 주의점
 
-| 단계 | 영역 | 상태 |
-|---|---|---|
-| PR-1 | 인프라 (middleware·DB·layout·Provider·api/locale) | 머지 완료 (#223) |
-| PR-2 | UI 사전·LanguageSwitcher·LocaleConfirmModal·Toast·Header/Footer/MobileNav | 머지 완료 (#225) |
-| PR-A | locale wiring 핫픽스·sonar 정리·E2E testid | 머지 완료 (#226) |
-| PR-B | CLAUDE.md·docs/architecture·conventions·known-issues 갱신 | 진행 중 |
-| PR-3 | 카드 299·스프레드 87·사주 51 영문 (외부 번역 발주) | 대기 |
-| PR-4 | 12 캐릭터 페르소나 + AI 프롬프트 locale 분기 | 대기 |
-| PR-5 | 일본어 전체 채움 | 대기 |
-| PR-6 | E2E locale 매트릭스 + hreflang SEO + 신점 하이브리드 | 대기 |
-
-## 외부 번역 정책
-
-영어·일본어 사전은 외부 전문 번역가 의뢰 결정. 코드에서는 임시 직역으로 placeholder 채우고, 외부 번역 도착 시 `src/i18n/translations/{en,ja}/index.ts` 교체. 캐릭터 페르소나(PR-4)·도메인 용어(PR-3)는 별도 보이스 가이드·glossary와 함께 발주 (`docs/i18n/glossary.md`·`character-voice-guide.md` PR-3·PR-4 시 작성).
+- locale 인프라, UI 사전, 캐릭터 주요 표시 필드, AI 프롬프트 locale 분기는 코드에 반영되어 있다.
+- `AuthUser` 타입은 `{ id, email }`만 포함한다. 사용자 선호 locale은 쿠키(`ai_locale`)와 `profiles.locale` 동기화로 관리한다.
+- `daily_cards` 테이블은 의도적으로 locale 컬럼을 두지 않는다.
+- 미번역 키와 도메인 번역 품질은 ko fallback과 외부 검수 정책으로 관리한다.
 
 ## 참조
 
-- 마스터 플랜: [`docs/superpowers/plans/i18n-master-plan.md`](../superpowers/plans/i18n-master-plan.md) (PR-B.6 이관)
-- 정합성 핫픽스 계획: [`docs/superpowers/plans/i18n-consistency-fix.md`](../superpowers/plans/i18n-consistency-fix.md) (PR-B.6 이관)
+- 마스터 플랜: [`docs/superpowers/plans/i18n-master-plan.md`](../superpowers/plans/i18n-master-plan.md)
+- 정합성 핫픽스 계획: [`docs/superpowers/plans/i18n-consistency-fix.md`](../superpowers/plans/i18n-consistency-fix.md)
 - 코딩 컨벤션: [`docs/conventions/i18n-style.md`](../conventions/i18n-style.md)
 - 데이터 모델: [`docs/architecture/data-model.md`](data-model.md)
 - DB 추상화: [`docs/architecture/db-abstraction.md`](db-abstraction.md)

--- a/docs/conventions/i18n-style.md
+++ b/docs/conventions/i18n-style.md
@@ -50,7 +50,7 @@ export async function POST(req: NextRequest) {
 1. **타입 먼저**: `src/i18n/translations/shared/keys.ts`의 `SharedKeys` 인터페이스에 키 추가
 2. **ko 사전 채움**: `src/i18n/translations/ko/index.ts` (SSOT, 모든 키 필수)
 3. **en 사전 임시 영문**: `src/i18n/translations/en/index.ts` (외부 번역가 의뢰 대기 중에는 1차 직역)
-4. **ja 사전 PR-5 일괄**: 현재는 `common`·`locale` namespace만 1차 채움 (나머지는 ko fallback)
+4. **ja 사전 관리**: 미번역 키는 ko fallback을 허용하되, 사용자에게 직접 보이는 주요 UI는 우선 번역한다.
 
 ## SSR 규칙 (필수 준수)
 
@@ -61,10 +61,10 @@ export async function POST(req: NextRequest) {
 
 ## 우선 외부 번역 영역 (직접 영문화 금지)
 
-- 캐릭터 12명 페르소나 5필드 (PR-4): 화법 시그니처 보존 필수
-- 카드 80장 `name`·`meanings` (PR-3): 도메인 표준 영문명
-- 사주 천간·지지·오행·십성·신살 (PR-3): 학술 vs 대중 톤 결정
-- 신점 한국 무속 용어 (PR-6): 한국어+로마자+영문 해설 하이브리드
+- 캐릭터 12명 페르소나 필드: 화법 시그니처 보존 필수
+- 카드 이름과 리딩 의미: 도메인 표준 영문명과 사용자가 이해하기 쉬운 표현 균형
+- 사주 천간·지지·오행·십성·신살: 학술 번역과 대중적 설명 톤 결정
+- 신점 한국 무속 용어: 한국어 원문, 로마자, 영문/일문 해설의 혼합 사용 검토
 
 ## E2E 셀렉터
 
@@ -85,9 +85,9 @@ export async function POST(req: NextRequest) {
 
 ## 외부 번역 의뢰 자료
 
-- `docs/i18n/glossary.md` (PR-3 작성): 사주 십성·오방색·타로 표준 영문 용어집
-- `docs/i18n/character-voice-guide.md` (PR-4 작성): 12 캐릭터 영문·일문 화법 시그니처
-- `docs/i18n/character-qa-checklist.md` (PR-4 작성): 페르소나 톤 일관성 QA
+- `docs/i18n/glossary.md`: 사주 십성·오방색·타로 표준 영문 용어집
+- `docs/i18n/character-voice-guide.md`: 12 캐릭터 영문·일문 화법 시그니처
+- `docs/i18n/character-qa-checklist.md`: 페르소나 톤 일관성 QA
 
 ## 참조
 

--- a/docs/workflow/code-change-process.md
+++ b/docs/workflow/code-change-process.md
@@ -144,7 +144,7 @@ git branch | grep -v '^\* main' | xargs git branch -D
 - [ ] `shared/keys.ts` 타입 추가 (ko/en/ja 모두 강제)
 - [ ] ko 사전 100% 채움 (SSOT)
 - [ ] en 사전 임시 영문 (외부 번역 발주 대기 중)
-- [ ] ja 사전은 PR-5 일괄 (현재는 ko fallback)
+- [ ] ja 사전 미번역 키는 ko fallback 의도인지 확인
 - [ ] 클라이언트 호출 = `useT()`, 서버 호출 = `t(key, locale)` + `getRequestLocale()`
 - [ ] LocaleProvider SSR 패턴 (`setTimeout` 래핑) 준수
 - [ ] E2E 셀렉터를 `data-testid`로 (한글 regex 금지)

--- a/docs/workflow/unit-testing.md
+++ b/docs/workflow/unit-testing.md
@@ -6,8 +6,8 @@ Vitest 기반 단위 테스트 작성 패턴과 주의사항입니다.
 
 ## 1. 테스트 현황
 
-- **804개 테스트** / statements 98%+ 커버리지
 - **Vitest 2.0** (node env, v8 coverage)
+- 실제 테스트 수는 변경이 잦으므로 `pnpm test:coverage` 출력과 coverage 리포트를 기준으로 확인한다.
 - 임계값: `branches 92 / functions 98 / lines 98 / statements 98`
 
 ```bash
@@ -161,11 +161,11 @@ coverage: {
 
 ---
 
-## 8. CLAUDE.md 테스트 수 동기화
+## 8. 테스트 수 확인
 
-테스트가 추가/삭제될 때마다 CLAUDE.md의 테스트 수를 동기화합니다:
+테스트가 추가/삭제될 때마다 coverage 출력과 문서의 고정 숫자가 어긋나지 않는지 확인합니다. 고정 숫자를 유지하는 문서가 있다면 아래 스크립트로 동기화합니다:
 
 ```bash
-pnpm exec tsx scripts/sync-test-count.ts          # CLAUDE.md 자동 갱신
+pnpm exec tsx scripts/sync-test-count.ts          # 문서 자동 갱신
 pnpm exec tsx scripts/sync-test-count.ts --check  # CI 모드: 불일치 시 exit 1
 ```


### PR DESCRIPTION
## Summary
- 축약된 CLAUDE.md를 세션 시작용 빠른 지도 형태로 정리하고 충돌 마커를 제거했습니다.
- docs/README.md 인덱스를 현재 문서 구조 기준으로 재작성했습니다.
- README와 i18n/데이터 모델/테스트 문서의 오래된 버전, 예정 표현, 고정 테스트 수 문구를 실제 코드 기준으로 갱신했습니다.

## Validation
- pnpm check:doc-links
  - 기존 archive 문서 docs/superpowers/plans/archive/2026-05-01-visual-fx-revitalization.md의 상대 링크 5개가 경고로 남아 있습니다. 이번 변경 파일에서는 신규 깨진 링크가 확인되지 않았습니다.

## Notes
- .claude/scheduled_tasks.lock 는 기존 untracked 파일이라 PR에 포함하지 않았습니다.