### PR TITLE
Fix audited code issues

### DIFF
--- a/src/__tests__/api/locale-wiring.test.ts
+++ b/src/__tests__/api/locale-wiring.test.ts
@@ -77,7 +77,7 @@ describe("locale wiring — sessions INSERT", () => {
     vi.doMock("@/lib/auth", () => ({ getCurrentUser: vi.fn().mockResolvedValue(null) }));
 
     const { POST } = await import("@/app/api/shinjeom/session/route");
-    await POST(makePostRequest({ topic: "love", characterId: "arcana" }));
+    await POST(makePostRequest({ topic: "shinjeom-love", characterId: "arcana" }));
 
     const sessionInsert = mockDb.insertCalls.find((c) => c.table === "sessions");
     expect(sessionInsert).toBeDefined();

--- a/src/__tests__/api/shinjeom-message.test.ts
+++ b/src/__tests__/api/shinjeom-message.test.ts
@@ -64,6 +64,13 @@ describe("POST /api/shinjeom/message", () => {
     expect((await res.json()).error).toContain("Message required");
   });
 
+  it("신점 topic 목록 밖의 값 → 400", async () => {
+    const { POST } = await setup();
+    const res = await POST(makePostRequest({ ...VALID_BODY, topic: "love" }));
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toBe("Invalid topic");
+  });
+
   it("isFinalTurn=true → 최종 결과 SSE 포함", async () => {
     const { POST } = await setup();
     const res = await POST(makePostRequest({ ...VALID_BODY, isFinalTurn: true }));

--- a/src/__tests__/api/shinjeom-session.test.ts
+++ b/src/__tests__/api/shinjeom-session.test.ts
@@ -36,6 +36,13 @@ describe("POST /api/shinjeom/session", () => {
     expect((await res.json()).error).toBe("Invalid request");
   });
 
+  it("신점 topic 목록 밖의 값 → 400", async () => {
+    const { POST } = await setup();
+    const res = await POST(makePostRequest({ topic: "love", characterId: "arcana" }));
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toBe("Invalid topic");
+  });
+
   it("DB insert 실패해도 200 반환 (신점은 세션 없이 계속 진행)", async () => {
     const { POST, mockDb } = await setup();
     mockDb.insert.mockRejectedValue(new Error("DB unavailable"));

--- a/src/app/api/shinjeom/message/route.ts
+++ b/src/app/api/shinjeom/message/route.ts
@@ -11,6 +11,7 @@ import { getClientIp, jsonError, SSE_HEADERS } from "@/lib/request-utils"
 import { saveShinjeomFinalReading, saveShinjeomMessages } from "@/lib/db/reading-saver";
 import { getRequestLocale } from "@/i18n/server-locale";
 import { t as translate } from "@/i18n/translations";
+import { SHINJEOM_TOPICS } from "@/data/topics";
 
 const shinjeomService = new ShinjeomService();
 const aiProvider = new FallbackProvider();
@@ -31,8 +32,9 @@ export async function POST(request: NextRequest) {
     // Zod 입력 검증 (chatHistory 100개 상한으로 토큰 과소비 방어)
     const parsed = ShinjeomMessageSchema.safeParse(rawBody);
     if (!parsed.success) return jsonError("Invalid request");
-    const { sessionId, characterId, currentMessage, isFinalTurn, messageIndex } = parsed.data;
-    const topic = parsed.data.topic as Topic;
+    const { sessionId, characterId, currentMessage, isFinalTurn, messageIndex, topic: rawTopic } = parsed.data;
+    if (!SHINJEOM_TOPICS.includes(rawTopic)) return jsonError("Invalid topic");
+    const topic = rawTopic as Topic;
     // timestamp는 네트워크 전송 시 문자열/숫자로 직렬화되므로 Date로 복원
     const chatHistory: ChatMessage[] = parsed.data.chatHistory.map((m) => ({
       ...m,

--- a/src/app/api/shinjeom/session/route.ts
+++ b/src/app/api/shinjeom/session/route.ts
@@ -5,6 +5,7 @@ import { ShinjeomSessionSchema } from "@/lib/validation/api-schemas"
 import { checkRateLimit, rateLimitResponse } from "@/lib/rate-limit"
 import { getClientIp } from "@/lib/request-utils"
 import { getRequestLocale } from "@/i18n/server-locale"
+import { SHINJEOM_TOPICS } from "@/data/topics"
 
 export async function POST(request: NextRequest) {
   try {
@@ -18,6 +19,9 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "Invalid request" }, { status: 400 })
     }
     const { topic, characterId } = parsed.data
+    if (!SHINJEOM_TOPICS.includes(topic)) {
+      return NextResponse.json({ error: "Invalid topic" }, { status: 400 })
+    }
 
     let session = null
     try {

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -12,6 +12,45 @@ import { GenderFilter } from "@/types/character";
 import { useT } from "@/i18n/useT";
 import { useLocaleStore } from "@/hooks/useLocaleStore";
 
+const USER_INFO_KEY = "arcana_user_info";
+const USER_INFO_CONSENT_KEY = "arcana_privacy_agreed";
+
+function hasSavedUserInfo(): boolean {
+  try {
+    return !!sessionStorage.getItem(USER_INFO_KEY);
+  } catch {
+    return false;
+  }
+}
+
+function clearSavedUserInfo(): void {
+  try {
+    sessionStorage.removeItem(USER_INFO_KEY);
+    sessionStorage.removeItem(USER_INFO_CONSENT_KEY);
+    // 이전 localStorage 저장 방식에서 남은 데이터를 함께 정리한다.
+    localStorage.removeItem(USER_INFO_KEY);
+    localStorage.removeItem(USER_INFO_CONSENT_KEY);
+  } catch {
+    // storage 차단 환경에서는 표시 상태만 갱신한다.
+  }
+}
+
+function isConfirmEachCardEnabled(): boolean {
+  try {
+    return localStorage.getItem("arcana-confirm-each-card") === "true";
+  } catch {
+    return false;
+  }
+}
+
+function saveConfirmEachCard(enabled: boolean): void {
+  try {
+    localStorage.setItem("arcana-confirm-each-card", String(enabled));
+  } catch {
+    // storage 차단 환경에서는 현재 화면 상태만 유지한다.
+  }
+}
+
 function SaveToast({ visible, text }: { visible: boolean; text: string }) {
   return (
     <div
@@ -40,8 +79,8 @@ export default function SettingsPage() {
 
   useEffect(() => {
     const t = setTimeout(() => {
-      setConfirmEachCard(localStorage.getItem("arcana-confirm-each-card") === "true");
-      setHasSavedInfo(!!localStorage.getItem("arcana_user_info"));
+      setConfirmEachCard(isConfirmEachCardEnabled());
+      setHasSavedInfo(hasSavedUserInfo());
     }, 0);
     return () => clearTimeout(t);
   }, []);
@@ -70,7 +109,7 @@ export default function SettingsPage() {
   const toggleConfirmMode = () => {
     const next = !confirmEachCard;
     setConfirmEachCard(next);
-    localStorage.setItem("arcana-confirm-each-card", String(next));
+    saveConfirmEachCard(next);
     showToast();
   };
 
@@ -80,8 +119,7 @@ export default function SettingsPage() {
   };
 
   const clearSavedInfo = () => {
-    localStorage.removeItem("arcana_user_info");
-    localStorage.removeItem("arcana_privacy_agreed");
+    clearSavedUserInfo();
     setHasSavedInfo(false);
     showToast();
   };

--- a/src/components/common/ResultShareButton.tsx
+++ b/src/components/common/ResultShareButton.tsx
@@ -11,9 +11,9 @@ type Service = "tarot" | "saju" | "shinjeom";
 const SITE = "ArcanaInsight";
 
 const SERVICE_PATH: Record<Service, string> = {
-  tarot: "/tarot/result",
-  saju: "/saju/result",
-  shinjeom: "/shinjeom/result",
+  tarot: "/tarot/result/",
+  saju: "/saju/result/",
+  shinjeom: "/shinjeom/result/",
 };
 
 const SERVICE_EMOJI: Record<Service, string> = {
@@ -28,9 +28,12 @@ function getShareTitle(service: Service, locale: Locale): string {
     | "tarot.session.share.title"
     | "saju.session.share.title"
     | "shinjeom.session.share.title";
-  // shinjeom.session.share.title은 PR 6에서 추가 안 됨 → result.title 재사용
   if (service === "shinjeom") return `${translate("shinjeom.result.title", locale)} - ${SITE}`;
   return `${translate(key, locale)} - ${SITE}`;
+}
+
+function getShareUrl(service: Service, shareToken: string): string {
+  return `${window.location.origin}${SERVICE_PATH[service]}${shareToken}`;
 }
 
 interface ResultShareButtonProps {
@@ -45,7 +48,7 @@ export function ResultShareButton({ service, shareToken, spreadName }: ResultSha
   const [copied, setCopied] = useState(false);
 
   const handleShare = async () => {
-    const url = `${window.location.origin}${SERVICE_PATH[service]}/${shareToken}`;
+    const url = getShareUrl(service, shareToken);
     const title = getShareTitle(service, locale);
     const labelPrefix = service === "tarot" && spreadName ? `${spreadName} ` : "";
     const text = `${SERVICE_EMOJI[service]} ${labelPrefix}${title}`;

--- a/src/components/common/UserInfoForm.tsx
+++ b/src/components/common/UserInfoForm.tsx
@@ -119,7 +119,7 @@ export function UserInfoForm({ mode, onSubmit, onBack, characterName }: UserInfo
   const [loading, setLoading] = useState(true);
   const [saveWarning, setSaveWarning] = useState(false);
 
-  // 저장된 정보 자동 채우기 (로그인: Supabase / 비로그인: localStorage)
+  // 저장된 정보 자동 채우기 (로그인: Supabase / 비로그인: sessionStorage)
   useEffect(() => {
     const setters: ProfileSetters = { setName, setBirthDate, setGender: (v) => setGender(v), setBirthHour, setSaveInfo, setHasSavedInfo };
     const loadUserInfo = async () => {

--- a/src/components/home/DailyCard.tsx
+++ b/src/components/home/DailyCard.tsx
@@ -13,6 +13,11 @@ import { useT } from "@/i18n/useT";
 import { getCardName } from "@/data/cards/locale-helpers";
 
 const deckManager = new DeckManager();
+const DATE_LOCALE: Record<string, string> = {
+  ko: "ko-KR",
+  en: "en-US",
+  ja: "ja-JP",
+};
 
 interface DailyCardData {
   cardId: string;
@@ -67,7 +72,7 @@ function renderCardSlot({ isLoading, currentCard, currentData, isFlipped, select
   }
   return (
     <div className="w-32 h-48 rounded-lg bg-arcana-card/60 border border-dashed border-arcana-border flex items-center justify-center">
-      <span className="text-arcana-muted text-xs">카드 로딩 중...</span>
+      <span className="text-arcana-muted text-xs">{tr("common.loading")}</span>
     </div>
   );
 }
@@ -151,8 +156,13 @@ export function DailyCard() {
     const d = new Date();
     // eslint-disable-next-line react-hooks/set-state-in-effect
     setToday(d.toISOString().split("T")[0]);
-    setTodayLabel(d.toLocaleDateString("ko-KR", { year: "numeric", month: "long", day: "numeric", weekday: "long" }));
-  }, []);
+    setTodayLabel(d.toLocaleDateString(DATE_LOCALE[locale] ?? DATE_LOCALE.ko, {
+      year: "numeric",
+      month: "long",
+      day: "numeric",
+      weekday: "long",
+    }));
+  }, [locale]);
 
   const fetchDailyCard = useCallback(async (characterId: string) => {
     if (!today) return;
@@ -188,9 +198,10 @@ export function DailyCard() {
 
   const handleShare = async () => {
     if (!currentData || !currentCard) return;
-    const text = `🔮 오늘의 카드: ${getCardName(currentCard, locale)}\n\n${currentData.interpretation}\n\n- ${activeCharacter?.name}의 해석 | ArcanaInsight`;
+    const title = tr("home.daily-card.share-text");
+    const text = `🔮 ${title}: ${getCardName(currentCard, locale)}\n\n${currentData.interpretation}\n\nArcanaInsight`;
     if (navigator.share) {
-      await navigator.share({ title: tr("home.daily-card.share-text"), text });
+      await navigator.share({ title, text });
     } else {
       await navigator.clipboard.writeText(text);
     }


### PR DESCRIPTION
## Summary
- fix result share URL construction and remove stale share-title comment
- align settings cleanup with sessionStorage-backed anonymous user info and harden storage access
- validate shinjeom topics consistently in message/session APIs and add regression tests
- localize daily card date/loading/share text handling

## Validation
- pnpm type-check
- pnpm lint
- pnpm build
- pnpm test:coverage
- pnpm i18n:check
- pnpm check:env-docs