### PR TITLE
Fix tarot card selection race

### DIFF
--- a/e2e/tarot-flow.spec.ts
+++ b/e2e/tarot-flow.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from "@playwright/test";
+import { createSSEBody, mockSessionCreate, TAROT_READING_CHUNKS, TAROT_READING_RESULT } from "./helpers/sse-mock";
 
 test.describe("타로 서비스 플로우", () => {
   test("Step 1→2: 캐릭터 선택 → 주제 선택 전환", async ({ page }) => {
@@ -79,5 +80,48 @@ test.describe("타로 서비스 플로우", () => {
       await backBtn.click();
       await expect(characterCards.first()).toBeVisible({ timeout: 5_000 });
     }
+  });
+
+  test("카드 선택 중 중복/초과 클릭을 반복해도 리딩은 한 번만 시작된다", async ({ page }) => {
+    await page.emulateMedia({ reducedMotion: "reduce" });
+    await mockSessionCreate(page, "**/api/tarot/session");
+
+    let readingRequests = 0;
+    await page.route("**/api/tarot/reading", async (route) => {
+      readingRequests += 1;
+      await route.fulfill({
+        status: 200,
+        contentType: "text/event-stream",
+        headers: { "Cache-Control": "no-cache", "Connection": "keep-alive" },
+        body: createSSEBody(TAROT_READING_CHUNKS, { result: TAROT_READING_RESULT }),
+      });
+    });
+
+    await page.goto("/tarot");
+    const characterCards = page.locator("button").filter({ hasText: /아르카나|미코|선화/ });
+    await expect(characterCards.first()).toBeVisible({ timeout: 10_000 });
+    await characterCards.first().click();
+
+    await page.locator("[data-testid='topic-btn-general']").click();
+    await page.locator("[data-testid='spread-btn-one-card']").evaluate((el) => (el as HTMLElement).click());
+    await page.waitForURL("**/tarot/session**", { timeout: 10_000 });
+
+    const firstCard = page.locator("[data-testid='card-back-0']");
+    await expect(firstCard).toBeVisible({ timeout: 10_000 });
+    await page.waitForTimeout(700);
+
+    for (let i = 0; i < 8; i += 1) {
+      await firstCard.click({ force: true });
+    }
+
+    const proceedButton = page.getByRole("button", { name: /진행|Proceed|進む|확인|Confirm|確認/ });
+    if (await proceedButton.isVisible().catch(() => false)) {
+      await proceedButton.click({ force: true });
+      await proceedButton.click({ force: true }).catch(() => undefined);
+    }
+
+    await expect(page.locator("[data-testid='reading-content']")).toBeVisible({ timeout: 10_000 });
+    await expect(page.locator("[data-testid='reading-error']")).toHaveCount(0);
+    expect(readingRequests).toBe(1);
   });
 });

--- a/src/app/tarot/session/page.tsx
+++ b/src/app/tarot/session/page.tsx
@@ -181,6 +181,8 @@ export default function TarotSessionPage() {
   const selectionLockRef = useRef(false);
   // 마지막 카드 자동 시작 setTimeout 이중 큐잉 차단
   const autoStartTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // 자동 시작 타이머와 확인 버튼이 동시에 startReading을 호출하는 race 차단
+  const readingInFlightRef = useRef(false);
 
   const toggleConfirmMode = () => {
     setConfirmEachCard((prev) => {
@@ -270,10 +272,11 @@ export default function TarotSessionPage() {
     if (currentCards.some((c) => c.card.id === shuffledDeck[index]?.id)) return;
 
     const card = shuffledDeck[index];
+    if (!card) return;
     const isReversed = Math.random() > 0.5;
     const position = currentCards.length;
     const selected: SelectedCard = { card, position, isReversed, selectedAt: new Date() };
-    selectCard(selected);
+    if (!selectCard(selected)) return;
     setSelectedIndices((prev) => prev.includes(index) ? prev : [...prev, index]);
     setRevealedPositions((prev) => prev.includes(position) ? prev : [...prev, position]);
     setMood("surprised");
@@ -319,6 +322,10 @@ export default function TarotSessionPage() {
   const handleConfirmCard = useCallback(() => {
     // 빠른 더블클릭으로 startReading 이중 호출 차단
     if (!pendingConfirmRef.current) return;
+    if (autoStartTimerRef.current) {
+      clearTimeout(autoStartTimerRef.current);
+      autoStartTimerRef.current = null;
+    }
     setPendingConfirm(false);
     const { selectedCards: currentCards } = useSessionStore.getState();
     if (currentCards.length >= requiredCards) {
@@ -388,14 +395,16 @@ export default function TarotSessionPage() {
   }, [locale, spreadType, addChatMessage]);
 
   const startReading = async (cards: SelectedCard[]) => {
-    // 진입 가드 — race로 cards가 비어있으면 abort. 부족·초과는 서버 superRefine이 400으로 차단하므로
-    // 클라이언트는 빈 배열만 strict하게 막음 (E2E mock·기타 우회 흐름과 호환).
-    if (!cards || cards.length === 0) {
-      console.warn("[tarot-session] startReading aborted: empty cards");
+    if (readingInFlightRef.current) return;
+    const { requiredCards: required } = useSessionStore.getState();
+    if (!cards || cards.length !== required) {
+      console.warn("[tarot-session] startReading aborted: card count mismatch", cards?.length ?? 0, "/", required);
       setPendingConfirm(false);
       setLoading(false);
       return;
     }
+    readingInFlightRef.current = true;
+    setPendingConfirm(false);
     setPhase("reading"); setLoading(true); setMood("mystical"); setReadingError(false);
     setReadingErrorReason("generic");
     setIsConnecting(true);
@@ -430,6 +439,7 @@ export default function TarotSessionPage() {
       setLoading(false);
       setReadingStartedAt(null);
       setIsConnecting(false);
+      readingInFlightRef.current = false;
       return;
     }
 
@@ -451,6 +461,7 @@ export default function TarotSessionPage() {
       setReadingError(true);
       setLoading(false);
       setReadingStartedAt(null);
+      readingInFlightRef.current = false;
     }, 240_000);
 
     await fetchSSEStream({
@@ -472,6 +483,7 @@ export default function TarotSessionPage() {
         if (!result) {
           addChatMessage({ id: crypto.randomUUID(), role: "character", content: translate("tarot.session.msg.no-result", locale), mood: "default", timestamp: new Date() });
           setMood("default"); setReadingError(true);
+          readingInFlightRef.current = false;
           return;
         }
 
@@ -484,6 +496,7 @@ export default function TarotSessionPage() {
           console.warn("[tarot-session] 결과 표시 불가:", { parseError: result.parseError, expected: result.expectedCardCount });
           addChatMessage({ id: crypto.randomUUID(), role: "character", content: translate("tarot.session.msg.no-result", locale), mood: "default", timestamp: new Date() });
           setMood("default"); setReadingError(true);
+          readingInFlightRef.current = false;
           return;
         }
 
@@ -499,6 +512,7 @@ export default function TarotSessionPage() {
         const currentSpread = spreadType ? spreads[spreadType] : null;
         addReadingResultMessages(result, cards, currentSpread, addChatMessage, locale);
         setPhase("result"); setMood(CHARACTER_RESULT_MOODS[characterId ?? ""] ?? "smile");
+        readingInFlightRef.current = false;
       },
       onError: (msg) => {
         if (finished) return;
@@ -512,11 +526,13 @@ export default function TarotSessionPage() {
           mood: "default", timestamp: new Date(),
         });
         setMood("default"); setReadingError(true);
+        readingInFlightRef.current = false;
       },
     });
     if (!finished) clearTimeout(timeoutId);
     setLoading(false);
     setReadingStartedAt(null);
+    readingInFlightRef.current = false;
   };
 
   // elapsed 카운터 — phase=reading + isLoading 동안 1초 단위로 갱신.

--- a/src/hooks/__tests__/useSession.test.ts
+++ b/src/hooks/__tests__/useSession.test.ts
@@ -32,42 +32,42 @@ describe("useSessionStore — selectCard atomic dedup", () => {
   });
 
   it("정상 카드 선택 시 selectedCards에 push", () => {
-    useSessionStore.getState().selectCard(makeSelected("a", 0));
+    expect(useSessionStore.getState().selectCard(makeSelected("a", 0))).toBe(true);
     expect(useSessionStore.getState().selectedCards).toHaveLength(1);
     expect(useSessionStore.getState().selectedCards[0].card.id).toBe("a");
   });
 
   it("같은 card.id 두 번 호출 시 두 번째는 무시 (빠른 더블탭 race 방어)", () => {
     const card = makeSelected("dup", 0);
-    useSessionStore.getState().selectCard(card);
-    useSessionStore.getState().selectCard(card);
+    expect(useSessionStore.getState().selectCard(card)).toBe(true);
+    expect(useSessionStore.getState().selectCard(card)).toBe(false);
     expect(useSessionStore.getState().selectedCards).toHaveLength(1);
   });
 
   it("requiredCards 도달 후 추가 selectCard 호출은 무시 (length cap)", () => {
     useSessionStore.setState({ requiredCards: 2 });
-    useSessionStore.getState().selectCard(makeSelected("a", 0));
-    useSessionStore.getState().selectCard(makeSelected("b", 1));
-    useSessionStore.getState().selectCard(makeSelected("c", 2)); // 초과
+    expect(useSessionStore.getState().selectCard(makeSelected("a", 0))).toBe(true);
+    expect(useSessionStore.getState().selectCard(makeSelected("b", 1))).toBe(true);
+    expect(useSessionStore.getState().selectCard(makeSelected("c", 2))).toBe(false); // 초과
     expect(useSessionStore.getState().selectedCards).toHaveLength(2);
     expect(useSessionStore.getState().selectedCards.map((c) => c.card.id)).toEqual(["a", "b"]);
   });
 
   it("cancel 후 같은 card.id 재선택은 허용 (cancel-then-reselect 호환)", () => {
     const cardA = makeSelected("a", 0);
-    useSessionStore.getState().selectCard(cardA);
+    expect(useSessionStore.getState().selectCard(cardA)).toBe(true);
     // cancel: 직접 setState로 selectedCards 비우기 (handleCancelLastCard와 동일 패턴)
     useSessionStore.setState({ selectedCards: [] });
     // 같은 card.id로 다시 선택 — store에 없으니 통과
-    useSessionStore.getState().selectCard(cardA);
+    expect(useSessionStore.getState().selectCard(cardA)).toBe(true);
     expect(useSessionStore.getState().selectedCards).toHaveLength(1);
     expect(useSessionStore.getState().selectedCards[0].card.id).toBe("a");
   });
 
   it("서로 다른 card.id는 정상 누적", () => {
-    useSessionStore.getState().selectCard(makeSelected("a", 0));
-    useSessionStore.getState().selectCard(makeSelected("b", 1));
-    useSessionStore.getState().selectCard(makeSelected("c", 2));
+    expect(useSessionStore.getState().selectCard(makeSelected("a", 0))).toBe(true);
+    expect(useSessionStore.getState().selectCard(makeSelected("b", 1))).toBe(true);
+    expect(useSessionStore.getState().selectCard(makeSelected("c", 2))).toBe(true);
     expect(useSessionStore.getState().selectedCards).toHaveLength(3);
   });
 });

--- a/src/hooks/useSession.ts
+++ b/src/hooks/useSession.ts
@@ -29,7 +29,7 @@ interface SessionState {
   setSessionId: (id: string) => void;
   setCharacterId: (id: string) => void;
   setAvailableCards: (cards: TarotCard[]) => void;
-  selectCard: (card: SelectedCard) => void;
+  selectCard: (card: SelectedCard) => boolean;
   addChatMessage: (message: ChatMessage) => void;
   appendToLastMessage: (content: string) => void;
   setReadingResult: (result: ReadingResult) => void;
@@ -56,7 +56,7 @@ const initialState = {
   freeQuestion: null,
 };
 
-export const useSessionStore = create<SessionState>((set) => ({
+export const useSessionStore = create<SessionState>((set, get) => ({
   ...initialState,
   setPhase: (phase) => set({ phase }),
   setTopic: (topic) => set({ topic }),
@@ -64,15 +64,17 @@ export const useSessionStore = create<SessionState>((set) => ({
   setSessionId: (id) => set({ sessionId: id }),
   setCharacterId: (id) => set({ characterId: id }),
   setAvailableCards: (cards) => set({ availableCards: cards }),
-  selectCard: (card) => set((state) => {
+  selectCard: (card) => {
     // atomic check-and-push: 빠른 연속 클릭 race 차단.
     // - length cap 초과 무시 (handleCardSelect 가드와 이중 방어)
     // - 같은 card.id 중복 차단 (deck 내 같은 카드 두 번 push 방지)
     // cancel 후 재선택은 store에서 카드가 빠진 뒤이므로 통과 — 정상.
-    if (state.selectedCards.length >= state.requiredCards) return state;
-    if (state.selectedCards.some((c) => c.card.id === card.card.id)) return state;
-    return { selectedCards: [...state.selectedCards, card] };
-  }),
+    const state = get();
+    if (state.selectedCards.length >= state.requiredCards) return false;
+    if (state.selectedCards.some((c) => c.card.id === card.card.id)) return false;
+    set({ selectedCards: [...state.selectedCards, card] });
+    return true;
+  },
   addChatMessage: (message) => set((state) => ({ chatMessages: [...state.chatMessages, message] })),
   appendToLastMessage: (content) => set((state) => {
     const messages = [...state.chatMessages];

--- a/src/lib/validation/api-schemas.test.ts
+++ b/src/lib/validation/api-schemas.test.ts
@@ -109,6 +109,28 @@ describe("TarotReadingSchema", () => {
     });
     expect(result.success).toBe(false);
   });
+
+  it("같은 cardId 중복 실패", () => {
+    const result = TarotReadingSchema.safeParse({
+      topic: "love",
+      cards: [
+        { cardId: "major-00", position: 0, isReversed: false },
+        { cardId: "major-00", position: 1, isReversed: true },
+      ],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("같은 position 중복 실패", () => {
+    const result = TarotReadingSchema.safeParse({
+      topic: "love",
+      cards: [
+        { cardId: "major-00", position: 0, isReversed: false },
+        { cardId: "major-01", position: 0, isReversed: true },
+      ],
+    });
+    expect(result.success).toBe(false);
+  });
 });
 
 // ──────────────────────────────────────────────

--- a/src/lib/validation/api-schemas.ts
+++ b/src/lib/validation/api-schemas.ts
@@ -73,6 +73,28 @@ export const TarotReadingSchema = z.object({
     isReversed: z.boolean(),
   })).min(1).max(22),
 }).superRefine((data, ctx) => {
+  const cardIds = new Set<string>();
+  const positions = new Set<number>();
+  data.cards.forEach((card, index) => {
+    if (cardIds.has(card.cardId)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `duplicate cardId '${card.cardId}'`,
+        path: ["cards", index, "cardId"],
+      });
+    }
+    cardIds.add(card.cardId);
+
+    if (positions.has(card.position)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `duplicate position '${card.position}'`,
+        path: ["cards", index, "position"],
+      });
+    }
+    positions.add(card.position);
+  });
+
   // spread별 정확한 카드 수와 일치 강제 — 빠른 클릭 race로 부족·초과 카드로 startReading 호출 차단
   if (!data.spreadType) return;
   const expected = SPREAD_REQUIRED_CARDS[data.spreadType];


### PR DESCRIPTION
## Summary
- Re-apply the tarot card selection race fix that was pushed after PR #289 had already been merged.
- Ensure tarot reading starts only once even when users repeatedly click selected cards, click beyond the required count, or mash the proceed button.
- Make `selectCard` return whether the store actually accepted the card, so UI state only updates after a real selection.
- Add server-side guards for duplicate tarot `cardId` and duplicate `position` payloads.
- Add a Playwright regression test for repeated card clicks plus proceed-button double clicks.

## Validation
- pnpm type-check
- pnpm lint
- pnpm exec vitest run src/hooks/__tests__/useSession.test.ts src/lib/validation/api-schemas.test.ts src/__tests__/api/tarot-reading.test.ts
- pnpm exec playwright test e2e/tarot-flow.spec.ts -g "카드 선택 중 중복/초과 클릭" --project="Desktop Chrome"