### PR TITLE
Fix tarot fallback reading display

### DIFF
--- a/e2e/tarot-flow.spec.ts
+++ b/e2e/tarot-flow.spec.ts
@@ -124,4 +124,42 @@ test.describe("타로 서비스 플로우", () => {
     await expect(page.locator("[data-testid='reading-error']")).toHaveCount(0);
     expect(readingRequests).toBe(1);
   });
+
+  test("JSON 파싱 fallback 텍스트가 있으면 오류 대신 결과를 표시한다", async ({ page }) => {
+    await page.emulateMedia({ reducedMotion: "reduce" });
+    await mockSessionCreate(page, "**/api/tarot/session");
+    await page.route("**/api/tarot/reading", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "text/event-stream",
+        headers: { "Cache-Control": "no-cache", "Connection": "keep-alive" },
+        body: createSSEBody([], {
+          result: {
+            cardInterpretations: [],
+            overallReading: "카드들이 말하는 핵심은 지금의 불안을 정리하고 다음 선택을 차분히 보라는 것입니다.",
+            advice: "",
+            parseError: "fallback_text",
+            expectedCardCount: 1,
+          },
+        }),
+      });
+    });
+
+    await page.goto("/tarot");
+    const characterCards = page.locator("button").filter({ hasText: /아르카나|미코|선화/ });
+    await expect(characterCards.first()).toBeVisible({ timeout: 10_000 });
+    await characterCards.first().click();
+
+    await page.locator("[data-testid='topic-btn-general']").click();
+    await page.locator("[data-testid='spread-btn-one-card']").evaluate((el) => (el as HTMLElement).click());
+    await page.waitForURL("**/tarot/session**", { timeout: 10_000 });
+
+    const firstCard = page.locator("[data-testid='card-back-0']");
+    await expect(firstCard).toBeVisible({ timeout: 10_000 });
+    await page.waitForTimeout(700);
+    await firstCard.click({ force: true });
+
+    await expect(page.locator("[data-testid='reading-content']")).toContainText("카드들이 말하는 핵심", { timeout: 10_000 });
+    await expect(page.locator("[data-testid='reading-error']")).toHaveCount(0);
+  });
 });

--- a/src/__tests__/api/tarot-reading.test.ts
+++ b/src/__tests__/api/tarot-reading.test.ts
@@ -320,6 +320,30 @@ describe("POST /api/tarot/reading", () => {
     expect(payload.result.parseError).toBe("truncated");
   });
 
+  it("AI 응답이 JSON이 아니어도 텍스트가 있으면 fallback_text 결과를 내려준다", async () => {
+    vi.doMock("@/lib/rate-limit", () => ({
+      checkRateLimit: vi.fn().mockReturnValue(true),
+      rateLimitResponse: vi.fn(),
+    }));
+    vi.doMock("@/lib/db", () => ({ getDb: vi.fn().mockReturnValue(makeMockDb()) }));
+    vi.doMock("@/lib/auth", () => makeAuthMock());
+    vi.doMock("@/services/core/fallback-provider", () => ({
+      FallbackProvider: vi.fn().mockImplementation(() => ({
+        streamReading: vi.fn().mockImplementation(async function* () {
+          yield "카드들이 말하는 핵심은 지금의 불안을 정리하고 다음 선택을 차분히 보라는 것입니다.";
+        }),
+      })),
+    }));
+
+    const { POST } = await import("@/app/api/tarot/reading/route");
+    const res = await POST(makePostRequest(VALID_BODY));
+    const text = await readSSEStream(res);
+    const doneLine = text.split("\n").find((l) => l.startsWith("data:") && l.includes("\"done\":true"));
+    const payload = JSON.parse(doneLine!.slice(5).trim());
+    expect(payload.result.parseError).toBe("fallback_text");
+    expect(payload.result.overallReading).toContain("카드들이 말하는 핵심");
+  });
+
   it("freeQuestion 포함 요청 → SSE 스트림 응답", async () => {
     const { POST } = await setup();
     const res = await POST(makePostRequest({

--- a/src/app/tarot/session/page.tsx
+++ b/src/app/tarot/session/page.tsx
@@ -487,11 +487,10 @@ export default function TarotSessionPage() {
           return;
         }
 
-        // 결과 표시 불가 — 빈 핵심 필드/JSON 실패/fallback (DB 저장 차단됨)
+        // 결과 표시 불가 — fallback_text는 정제된 본문이 있으므로 세션 화면에서는 표시한다.
         if (
           result.parseError === "invalid_json" ||
-          result.parseError === "missing_fields" ||
-          result.parseError === "fallback_text"
+          result.parseError === "missing_fields"
         ) {
           console.warn("[tarot-session] 결과 표시 불가:", { parseError: result.parseError, expected: result.expectedCardCount });
           addChatMessage({ id: crypto.randomUUID(), role: "character", content: translate("tarot.session.msg.no-result", locale), mood: "default", timestamp: new Date() });
@@ -500,8 +499,8 @@ export default function TarotSessionPage() {
           return;
         }
 
-        // 부분 파싱(잘림) — 받은 해석은 그대로 표시하고 안내 메시지 추가
-        if (result.parseError === "truncated") {
+        // 부분/대체 파싱 — 받은 해석은 그대로 표시하고 안내 메시지 추가
+        if (result.parseError === "truncated" || result.parseError === "fallback_text") {
           console.warn("[tarot-session] 부분 파싱 응답:", { expected: result.expectedCardCount, got: result.cardInterpretations?.length ?? 0 });
           addChatMessage({ id: crypto.randomUUID(), role: "character", content: translate("tarot.session.msg.partial-result", locale), mood: "default", timestamp: new Date() });
         }

--- a/src/services/tarot/tarot-service.test.ts
+++ b/src/services/tarot/tarot-service.test.ts
@@ -376,8 +376,16 @@ describe("TarotService", () => {
         expect(result.cardInterpretations).toHaveLength(3);
       });
 
-      it("JSON 파싱 완전 실패 시 parseError='invalid_json'을 반환한다", () => {
+      it("JSON 파싱 실패 후 fallback 텍스트가 있으면 parseError='fallback_text'를 반환한다", () => {
         const result = service.parseResult("완전히 망가진 응답", 3);
+        expect(result.parseError).toBe("fallback_text");
+        expect(result.expectedCardCount).toBe(3);
+        expect(result.cardInterpretations).toEqual([]);
+        expect(result.overallReading).toContain("완전히 망가진 응답");
+      });
+
+      it("JSON 파싱 실패 후 fallback 텍스트도 없으면 parseError='invalid_json'을 반환한다", () => {
+        const result = service.parseResult("", 3);
         expect(result.parseError).toBe("invalid_json");
         expect(result.expectedCardCount).toBe(3);
         expect(result.cardInterpretations).toEqual([]);

--- a/src/services/tarot/tarot-service.ts
+++ b/src/services/tarot/tarot-service.ts
@@ -66,7 +66,7 @@ export class TarotService implements DivinationService {
       cardInterpretations: [],
       overallReading: cleanText || "해석 결과를 처리하는 중 문제가 발생했습니다. 다시 시도해주세요.",
       advice: "",
-      parseError: "invalid_json",
+      parseError: cleanText ? "fallback_text" : "invalid_json",
       ...(typeof expectedCardCount === "number" ? { expectedCardCount } : {}),
     };
   }


### PR DESCRIPTION
## Summary
- Re-apply the tarot fallback reading display fix as a new PR from the current `main` branch because PR #290 was already merged before this change was included.
- Classify non-JSON tarot AI responses with usable text as `fallback_text` instead of `invalid_json`.
- Allow tarot session UI to display `fallback_text` results instead of showing the reading error modal.
- Keep true non-displayable cases (`invalid_json`, `missing_fields`) as errors.
- Add API/service tests and a Playwright regression test for fallback text rendering.

## Validation
- pnpm type-check
- pnpm lint
- pnpm exec vitest run src/services/tarot/tarot-service.test.ts src/__tests__/api/tarot-reading.test.ts
- pnpm exec playwright test e2e/tarot-flow.spec.ts -g "JSON 파싱 fallback" --project="Desktop Chrome"