### PR TITLE
Fix server session creation RLS failures

### DIFF
--- a/src/__tests__/api/locale-wiring.test.ts
+++ b/src/__tests__/api/locale-wiring.test.ts
@@ -45,7 +45,7 @@ describe("locale wiring — sessions INSERT", () => {
   it("tarot/session: locale='en' 헤더 → sessions INSERT에 locale='en' 동봉", async () => {
     setupServerLocale("en");
     const mockDb = makeMockDb();
-    vi.doMock("@/lib/db", () => ({ getDb: () => mockDb }));
+    vi.doMock("@/lib/db", () => ({ getDb: () => mockDb, getAdminDb: () => mockDb }));
     vi.doMock("@/lib/auth", () => ({ getCurrentUser: vi.fn().mockResolvedValue(null) }));
 
     const { POST } = await import("@/app/api/tarot/session/route");
@@ -59,7 +59,7 @@ describe("locale wiring — sessions INSERT", () => {
   it("saju/session: locale='ja' → sessions INSERT에 locale='ja' 동봉", async () => {
     setupServerLocale("ja");
     const mockDb = makeMockDb();
-    vi.doMock("@/lib/db", () => ({ getDb: () => mockDb }));
+    vi.doMock("@/lib/db", () => ({ getDb: () => mockDb, getAdminDb: () => mockDb }));
     vi.doMock("@/lib/auth", () => ({ getCurrentUser: vi.fn().mockResolvedValue(null) }));
 
     const { POST } = await import("@/app/api/saju/session/route");
@@ -73,7 +73,7 @@ describe("locale wiring — sessions INSERT", () => {
   it("shinjeom/session: locale='ko' → sessions INSERT에 locale='ko' 동봉", async () => {
     setupServerLocale("ko");
     const mockDb = makeMockDb();
-    vi.doMock("@/lib/db", () => ({ getDb: () => mockDb }));
+    vi.doMock("@/lib/db", () => ({ getDb: () => mockDb, getAdminDb: () => mockDb }));
     vi.doMock("@/lib/auth", () => ({ getCurrentUser: vi.fn().mockResolvedValue(null) }));
 
     const { POST } = await import("@/app/api/shinjeom/session/route");

--- a/src/app/api/saju/session/route.ts
+++ b/src/app/api/saju/session/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server"
-import { getDb } from "@/lib/db"
+import { getAdminDb } from "@/lib/db"
 import { getCurrentUser } from "@/lib/auth"
 import { getCharacterById } from "@/data/characters"
 import { Topic } from "@/types/session"
@@ -27,7 +27,7 @@ export async function POST(request: NextRequest) {
     const topic = rawTopic as Topic
     const validCharId = characterId && getCharacterById(characterId) ? characterId : null
     const user = await getCurrentUser()
-    const db = getDb()
+    const db = getAdminDb()
     const session = await db.insert("sessions", {
       user_id: user?.id ?? null,
       service_type: "saju",

--- a/src/app/api/shinjeom/session/route.ts
+++ b/src/app/api/shinjeom/session/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server"
-import { getDb } from "@/lib/db"
+import { getAdminDb } from "@/lib/db"
 import { getCurrentUser } from "@/lib/auth"
 import { ShinjeomSessionSchema } from "@/lib/validation/api-schemas"
 import { checkRateLimit, rateLimitResponse } from "@/lib/rate-limit"
@@ -26,7 +26,7 @@ export async function POST(request: NextRequest) {
     let session = null
     try {
       const user = await getCurrentUser()
-      const db = getDb()
+      const db = getAdminDb()
       session = await db.insert("sessions", {
         service_type: "shinjeom",
         topic,

--- a/src/app/api/tarot/session/route.ts
+++ b/src/app/api/tarot/session/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server"
-import { getDb } from "@/lib/db"
+import { getAdminDb } from "@/lib/db"
 import { getCurrentUser } from "@/lib/auth"
 import { TarotService } from "@/services/tarot/tarot-service"
 import { SpreadResolver } from "@/services/tarot/spread-resolver"
@@ -37,7 +37,7 @@ export async function POST(request: NextRequest) {
       ? spreadType
       : sessionData.spreadType
 
-    const db = getDb()
+    const db = getAdminDb()
     const session = await db.insert("sessions", {
       user_id: user?.id ?? null,
       service_type: sessionData.serviceType,

--- a/src/test-helpers/api-route-setup.ts
+++ b/src/test-helpers/api-route-setup.ts
@@ -19,7 +19,10 @@ export async function makeSessionRouteSetup<TSession>(
   mockDb.insert.mockResolvedValue(mockSession)
 
   const user = "user" in options ? options.user : MOCK_USER
-  vi.doMock("@/lib/db", () => ({ getDb: vi.fn().mockReturnValue(mockDb) }))
+  vi.doMock("@/lib/db", () => ({
+    getDb: vi.fn().mockReturnValue(mockDb),
+    getAdminDb: vi.fn().mockReturnValue(mockDb),
+  }))
   vi.doMock("@/lib/auth", () => makeAuthMock(user))
 
   const route = await routeImport()
@@ -79,7 +82,10 @@ export async function makeStreamingRouteSetup(
     checkRateLimit: vi.fn().mockReturnValue(true),
     rateLimitResponse: vi.fn(),
   }))
-  vi.doMock("@/lib/db", () => ({ getDb: vi.fn().mockReturnValue(mockDb) }))
+  vi.doMock("@/lib/db", () => ({
+    getDb: vi.fn().mockReturnValue(mockDb),
+    getAdminDb: vi.fn().mockReturnValue(mockDb),
+  }))
   vi.doMock("@/lib/auth", () => makeAuthMock())
   vi.doMock("@/services/core/fallback-provider", () => makeMockAiModule())
 


### PR DESCRIPTION
## Summary
- Confirmed Railway production logs show `POST /api/tarot/session` returning 500 because Supabase rejected `sessions` INSERT with RLS: `new row violates row-level security policy for table "sessions"`.
- Switched server-side session creation endpoints for tarot, saju, and shinjeom to `getAdminDb()` so controlled server inserts use the service-role adapter instead of the anonymous RLS client.
- Updated API route test helpers and locale wiring tests to mock `getAdminDb()` for session routes.

## Railway evidence
- Deployment: `b5386c38-cfd6-4c17-91d4-42a1133bc694`
- Request: `POST /api/tarot/session`, status `500`, requestId `v802-ss_QCyy4LjiipRofQ`
- App log: `세션 생성 오류: Error: new row violates row-level security policy for table "sessions"`

## Validation
- `pnpm exec vitest run src/__tests__/api/locale-wiring.test.ts src/__tests__/api/tarot-session.test.ts src/__tests__/api/saju-session.test.ts src/__tests__/api/shinjeom-session.test.ts`
- `pnpm type-check`
- `pnpm lint`
- `git diff --check HEAD~1..HEAD`