### PR TITLE
Fix reading session RLS lookup failures

### DIFF
--- a/src/__tests__/api/saju-reading.test.ts
+++ b/src/__tests__/api/saju-reading.test.ts
@@ -75,7 +75,7 @@ describe("POST /api/saju/reading", () => {
       checkRateLimit: vi.fn().mockReturnValue(false),
       rateLimitResponse: vi.fn().mockReturnValue(new Response(JSON.stringify({ error: "Too many requests" }), { status: 429 })),
     }));
-    vi.doMock("@/lib/db", () => ({ getDb: vi.fn().mockReturnValue(makeMockDb()) }));
+    vi.doMock("@/lib/db", () => ({ getDb: vi.fn().mockReturnValue(makeMockDb()), getAdminDb: vi.fn().mockReturnValue(makeMockDb()) }));
     vi.doMock("@/lib/auth", () => makeAuthMock());
     vi.doMock("@/services/core/fallback-provider", () => makeMockAiModule());
     const { POST } = await import("@/app/api/saju/reading/route");
@@ -88,7 +88,7 @@ describe("POST /api/saju/reading", () => {
       checkRateLimit: vi.fn().mockRejectedValue(new Error("unexpected")),
       rateLimitResponse: vi.fn(),
     }));
-    vi.doMock("@/lib/db", () => ({ getDb: vi.fn().mockReturnValue(makeMockDb()) }));
+    vi.doMock("@/lib/db", () => ({ getDb: vi.fn().mockReturnValue(makeMockDb()), getAdminDb: vi.fn().mockReturnValue(makeMockDb()) }));
     vi.doMock("@/lib/auth", () => makeAuthMock());
     vi.doMock("@/services/core/fallback-provider", () => makeMockAiModule());
     const { POST } = await import("@/app/api/saju/reading/route");
@@ -112,7 +112,7 @@ describe("POST /api/saju/reading", () => {
       checkRateLimit: vi.fn().mockReturnValue(true),
       rateLimitResponse: vi.fn(),
     }));
-    vi.doMock("@/lib/db", () => ({ getDb: vi.fn().mockReturnValue(makeMockDb()) }));
+    vi.doMock("@/lib/db", () => ({ getDb: vi.fn().mockReturnValue(makeMockDb()), getAdminDb: vi.fn().mockReturnValue(makeMockDb()) }));
     vi.doMock("@/lib/auth", () => makeAuthMock());
     vi.doMock("@/services/core/fallback-provider", () => mockAiModule);
     const { POST } = await import("@/app/api/saju/reading/route");
@@ -127,7 +127,7 @@ describe("POST /api/saju/reading", () => {
       checkRateLimit: vi.fn().mockReturnValue(true),
       rateLimitResponse: vi.fn(),
     }));
-    vi.doMock("@/lib/db", () => ({ getDb: vi.fn().mockReturnValue(makeMockDb()) }));
+    vi.doMock("@/lib/db", () => ({ getDb: vi.fn().mockReturnValue(makeMockDb()), getAdminDb: vi.fn().mockReturnValue(makeMockDb()) }));
     vi.doMock("@/lib/auth", () => ({
       ...makeAuthMock(),
       assertSessionOwnership: vi.fn().mockResolvedValue(
@@ -151,7 +151,7 @@ describe("POST /api/saju/reading", () => {
       rateLimitResponse: vi.fn(),
     }));
     const mockDb = makeMockDb();
-    vi.doMock("@/lib/db", () => ({ getDb: vi.fn().mockReturnValue(mockDb) }));
+    vi.doMock("@/lib/db", () => ({ getDb: vi.fn().mockReturnValue(mockDb), getAdminDb: vi.fn().mockReturnValue(mockDb) }));
     vi.doMock("@/lib/auth", () => makeAuthMock());
     vi.doMock("@/services/core/fallback-provider", () => makeMockAiModule());
     const { POST } = await import("@/app/api/saju/reading/route");
@@ -174,7 +174,7 @@ describe("POST /api/saju/reading", () => {
       rateLimitResponse: vi.fn(),
     }));
     const mockDb = makeMockDb();
-    vi.doMock("@/lib/db", () => ({ getDb: vi.fn().mockReturnValue(mockDb) }));
+    vi.doMock("@/lib/db", () => ({ getDb: vi.fn().mockReturnValue(mockDb), getAdminDb: vi.fn().mockReturnValue(mockDb) }));
     vi.doMock("@/lib/auth", () => makeAuthMock());
     vi.doMock("@/services/core/fallback-provider", () => mockAiModule);
     const { POST } = await import("@/app/api/saju/reading/route");
@@ -193,7 +193,7 @@ describe("POST /api/saju/reading", () => {
       checkRateLimit: vi.fn().mockReturnValue(true),
       rateLimitResponse: vi.fn(),
     }));
-    vi.doMock("@/lib/db", () => ({ getDb: vi.fn().mockReturnValue(makeMockDb()) }));
+    vi.doMock("@/lib/db", () => ({ getDb: vi.fn().mockReturnValue(makeMockDb()), getAdminDb: vi.fn().mockReturnValue(makeMockDb()) }));
     vi.doMock("@/lib/auth", () => makeAuthMock());
     vi.doMock("@/services/core/fallback-provider", () => mockAiModule);
     const { POST } = await import("@/app/api/saju/reading/route");
@@ -208,7 +208,7 @@ describe("POST /api/saju/reading", () => {
       checkRateLimit: vi.fn().mockRejectedValue("string-throw"),
       rateLimitResponse: vi.fn(),
     }));
-    vi.doMock("@/lib/db", () => ({ getDb: vi.fn().mockReturnValue(makeMockDb()) }));
+    vi.doMock("@/lib/db", () => ({ getDb: vi.fn().mockReturnValue(makeMockDb()), getAdminDb: vi.fn().mockReturnValue(makeMockDb()) }));
     vi.doMock("@/lib/auth", () => makeAuthMock());
     vi.doMock("@/services/core/fallback-provider", () => makeMockAiModule());
     const { POST } = await import("@/app/api/saju/reading/route");
@@ -230,7 +230,7 @@ describe("POST /api/saju/reading", () => {
         checkRateLimit: vi.fn().mockReturnValue(true),
         rateLimitResponse: vi.fn(),
       }));
-      vi.doMock("@/lib/db", () => ({ getDb: vi.fn().mockReturnValue(makeMockDb()) }));
+      vi.doMock("@/lib/db", () => ({ getDb: vi.fn().mockReturnValue(makeMockDb()), getAdminDb: vi.fn().mockReturnValue(makeMockDb()) }));
       vi.doMock("@/lib/auth", () => makeAuthMock());
       vi.doMock("@/services/core/fallback-provider", () => mockAiModule);
       const { POST } = await import("@/app/api/saju/reading/route");
@@ -275,7 +275,7 @@ describe("POST /api/saju/reading", () => {
       rateLimitResponse: vi.fn(),
     }));
     const mockDb = makeMockDb();
-    vi.doMock("@/lib/db", () => ({ getDb: vi.fn().mockReturnValue(mockDb) }));
+    vi.doMock("@/lib/db", () => ({ getDb: vi.fn().mockReturnValue(mockDb), getAdminDb: vi.fn().mockReturnValue(mockDb) }));
     vi.doMock("@/lib/auth", () => makeAuthMock());
     vi.doMock("@/services/core/fallback-provider", () => mockAiModule);
     const { POST } = await import("@/app/api/saju/reading/route");

--- a/src/__tests__/api/shinjeom-message.test.ts
+++ b/src/__tests__/api/shinjeom-message.test.ts
@@ -84,7 +84,7 @@ describe("POST /api/shinjeom/message", () => {
       checkRateLimit: vi.fn().mockReturnValue(false),
       rateLimitResponse: vi.fn().mockReturnValue(new Response(JSON.stringify({ error: "Too many requests" }), { status: 429 })),
     }));
-    vi.doMock("@/lib/db", () => ({ getDb: vi.fn().mockReturnValue(makeMockDb()) }));
+    vi.doMock("@/lib/db", () => ({ getDb: vi.fn().mockReturnValue(makeMockDb()), getAdminDb: vi.fn().mockReturnValue(makeMockDb()) }));
     vi.doMock("@/lib/auth", () => makeAuthMock());
     vi.doMock("@/services/core/fallback-provider", () => makeMockAiModule());
     const { POST } = await import("@/app/api/shinjeom/message/route");
@@ -97,7 +97,7 @@ describe("POST /api/shinjeom/message", () => {
       checkRateLimit: vi.fn().mockRejectedValue(new Error("unexpected")),
       rateLimitResponse: vi.fn(),
     }));
-    vi.doMock("@/lib/db", () => ({ getDb: vi.fn().mockReturnValue(makeMockDb()) }));
+    vi.doMock("@/lib/db", () => ({ getDb: vi.fn().mockReturnValue(makeMockDb()), getAdminDb: vi.fn().mockReturnValue(makeMockDb()) }));
     vi.doMock("@/lib/auth", () => makeAuthMock());
     vi.doMock("@/services/core/fallback-provider", () => makeMockAiModule());
     const { POST } = await import("@/app/api/shinjeom/message/route");
@@ -110,7 +110,7 @@ describe("POST /api/shinjeom/message", () => {
       checkRateLimit: vi.fn().mockReturnValue(true),
       rateLimitResponse: vi.fn(),
     }));
-    vi.doMock("@/lib/db", () => ({ getDb: vi.fn().mockReturnValue(makeMockDb()) }));
+    vi.doMock("@/lib/db", () => ({ getDb: vi.fn().mockReturnValue(makeMockDb()), getAdminDb: vi.fn().mockReturnValue(makeMockDb()) }));
     vi.doMock("@/lib/auth", () => ({
       ...makeAuthMock(),
       assertSessionOwnership: vi.fn().mockResolvedValue(
@@ -149,7 +149,7 @@ describe("POST /api/shinjeom/message", () => {
       rateLimitResponse: vi.fn(),
     }));
     const mockDb = makeMockDb();
-    vi.doMock("@/lib/db", () => ({ getDb: vi.fn().mockReturnValue(mockDb) }));
+    vi.doMock("@/lib/db", () => ({ getDb: vi.fn().mockReturnValue(mockDb), getAdminDb: vi.fn().mockReturnValue(mockDb) }));
     vi.doMock("@/lib/auth", () => makeAuthMock());
     vi.doMock("@/services/core/fallback-provider", () => makeMockAiModule());
     const { POST } = await import("@/app/api/shinjeom/message/route");
@@ -167,7 +167,7 @@ describe("POST /api/shinjeom/message", () => {
       checkRateLimit: vi.fn().mockReturnValue(true),
       rateLimitResponse: vi.fn(),
     }));
-    vi.doMock("@/lib/db", () => ({ getDb: vi.fn().mockReturnValue(makeMockDb()) }));
+    vi.doMock("@/lib/db", () => ({ getDb: vi.fn().mockReturnValue(makeMockDb()), getAdminDb: vi.fn().mockReturnValue(makeMockDb()) }));
     vi.doMock("@/lib/auth", () => makeAuthMock());
     vi.doMock("@/services/core/fallback-provider", () => mockAiModule);
     const { POST } = await import("@/app/api/shinjeom/message/route");
@@ -188,7 +188,7 @@ describe("POST /api/shinjeom/message", () => {
       checkRateLimit: vi.fn().mockReturnValue(true),
       rateLimitResponse: vi.fn(),
     }));
-    vi.doMock("@/lib/db", () => ({ getDb: vi.fn().mockReturnValue(makeMockDb()) }));
+    vi.doMock("@/lib/db", () => ({ getDb: vi.fn().mockReturnValue(makeMockDb()), getAdminDb: vi.fn().mockReturnValue(makeMockDb()) }));
     vi.doMock("@/lib/auth", () => makeAuthMock());
     vi.doMock("@/services/core/fallback-provider", () => makeMockAiModule());
     const { POST } = await import("@/app/api/shinjeom/message/route");
@@ -211,7 +211,7 @@ describe("POST /api/shinjeom/message", () => {
       rateLimitResponse: vi.fn(),
     }));
     const mockDb = makeMockDb();
-    vi.doMock("@/lib/db", () => ({ getDb: vi.fn().mockReturnValue(mockDb) }));
+    vi.doMock("@/lib/db", () => ({ getDb: vi.fn().mockReturnValue(mockDb), getAdminDb: vi.fn().mockReturnValue(mockDb) }));
     vi.doMock("@/lib/auth", () => makeAuthMock());
     vi.doMock("@/services/core/fallback-provider", () => makeMockAiModule());
     const { POST } = await import("@/app/api/shinjeom/message/route");
@@ -229,7 +229,7 @@ describe("POST /api/shinjeom/message", () => {
       checkRateLimit: vi.fn().mockReturnValue(true),
       rateLimitResponse: vi.fn(),
     }));
-    vi.doMock("@/lib/db", () => ({ getDb: vi.fn().mockReturnValue(makeMockDb()) }));
+    vi.doMock("@/lib/db", () => ({ getDb: vi.fn().mockReturnValue(makeMockDb()), getAdminDb: vi.fn().mockReturnValue(makeMockDb()) }));
     vi.doMock("@/lib/auth", () => makeAuthMock());
     vi.doMock("@/services/core/fallback-provider", () => mockAiModule);
     const { POST } = await import("@/app/api/shinjeom/message/route");
@@ -244,7 +244,7 @@ describe("POST /api/shinjeom/message", () => {
       checkRateLimit: vi.fn().mockRejectedValue("string-throw"),
       rateLimitResponse: vi.fn(),
     }));
-    vi.doMock("@/lib/db", () => ({ getDb: vi.fn().mockReturnValue(makeMockDb()) }));
+    vi.doMock("@/lib/db", () => ({ getDb: vi.fn().mockReturnValue(makeMockDb()), getAdminDb: vi.fn().mockReturnValue(makeMockDb()) }));
     vi.doMock("@/lib/auth", () => makeAuthMock());
     vi.doMock("@/services/core/fallback-provider", () => makeMockAiModule());
     const { POST } = await import("@/app/api/shinjeom/message/route");
@@ -274,7 +274,7 @@ describe("POST /api/shinjeom/message", () => {
         checkRateLimit: vi.fn().mockReturnValue(true),
         rateLimitResponse: vi.fn(),
       }));
-      vi.doMock("@/lib/db", () => ({ getDb: vi.fn().mockReturnValue(makeMockDb()) }));
+      vi.doMock("@/lib/db", () => ({ getDb: vi.fn().mockReturnValue(makeMockDb()), getAdminDb: vi.fn().mockReturnValue(makeMockDb()) }));
       vi.doMock("@/lib/auth", () => makeAuthMock());
       vi.doMock("@/services/core/fallback-provider", () => mockAiModule);
       const { POST } = await import("@/app/api/shinjeom/message/route");
@@ -311,7 +311,7 @@ describe("POST /api/shinjeom/message", () => {
       rateLimitResponse: vi.fn(),
     }));
     const mockDb = makeMockDb();
-    vi.doMock("@/lib/db", () => ({ getDb: vi.fn().mockReturnValue(mockDb) }));
+    vi.doMock("@/lib/db", () => ({ getDb: vi.fn().mockReturnValue(mockDb), getAdminDb: vi.fn().mockReturnValue(mockDb) }));
     vi.doMock("@/lib/auth", () => makeAuthMock());
     vi.doMock("@/services/core/fallback-provider", () => mockAiModule);
     const { POST } = await import("@/app/api/shinjeom/message/route");

--- a/src/__tests__/api/tarot-reading.test.ts
+++ b/src/__tests__/api/tarot-reading.test.ts
@@ -42,7 +42,7 @@ async function setup(options: { aiError?: boolean } = {}) {
     checkRateLimit: vi.fn().mockReturnValue(true),
     rateLimitResponse: vi.fn(),
   }));
-  vi.doMock("@/lib/db", () => ({ getDb: vi.fn().mockReturnValue(mockDb) }));
+  vi.doMock("@/lib/db", () => ({ getDb: vi.fn().mockReturnValue(mockDb), getAdminDb: vi.fn().mockReturnValue(mockDb) }));
   vi.doMock("@/lib/auth", () => makeAuthMock());
   vi.doMock("@/services/core/fallback-provider", () => mockAiModule);
 
@@ -85,7 +85,7 @@ describe("POST /api/tarot/reading", () => {
       checkRateLimit: vi.fn().mockReturnValue(false),
       rateLimitResponse: vi.fn().mockReturnValue(new Response(JSON.stringify({ error: "Too many requests" }), { status: 429 })),
     }));
-    vi.doMock("@/lib/db", () => ({ getDb: vi.fn().mockReturnValue(makeMockDb()) }));
+    vi.doMock("@/lib/db", () => ({ getDb: vi.fn().mockReturnValue(makeMockDb()), getAdminDb: vi.fn().mockReturnValue(makeMockDb()) }));
     vi.doMock("@/lib/auth", () => makeAuthMock());
     vi.doMock("@/services/core/fallback-provider", () => makeMockAiModule());
     const { POST } = await import("@/app/api/tarot/reading/route");
@@ -107,7 +107,7 @@ describe("POST /api/tarot/reading", () => {
       checkRateLimit: vi.fn().mockReturnValue(true),
       rateLimitResponse: vi.fn(),
     }));
-    vi.doMock("@/lib/db", () => ({ getDb: vi.fn().mockReturnValue(makeMockDb()) }));
+    vi.doMock("@/lib/db", () => ({ getDb: vi.fn().mockReturnValue(makeMockDb()), getAdminDb: vi.fn().mockReturnValue(makeMockDb()) }));
     vi.doMock("@/lib/auth", () => ({
       ...makeAuthMock(),
       assertSessionOwnership: vi.fn().mockResolvedValue(
@@ -128,7 +128,7 @@ describe("POST /api/tarot/reading", () => {
       checkRateLimit: vi.fn().mockRejectedValue(new Error("unexpected")),
       rateLimitResponse: vi.fn(),
     }));
-    vi.doMock("@/lib/db", () => ({ getDb: vi.fn().mockReturnValue(makeMockDb()) }));
+    vi.doMock("@/lib/db", () => ({ getDb: vi.fn().mockReturnValue(makeMockDb()), getAdminDb: vi.fn().mockReturnValue(makeMockDb()) }));
     vi.doMock("@/lib/auth", () => makeAuthMock());
     vi.doMock("@/services/core/fallback-provider", () => makeMockAiModule());
     const { POST } = await import("@/app/api/tarot/reading/route");
@@ -196,7 +196,7 @@ describe("POST /api/tarot/reading", () => {
       rateLimitResponse: vi.fn(),
     }));
     const mockDb = makeMockDb();
-    vi.doMock("@/lib/db", () => ({ getDb: vi.fn().mockReturnValue(mockDb) }));
+    vi.doMock("@/lib/db", () => ({ getDb: vi.fn().mockReturnValue(mockDb), getAdminDb: vi.fn().mockReturnValue(mockDb) }));
     vi.doMock("@/lib/auth", () => makeAuthMock());
     vi.doMock("@/services/core/fallback-provider", () => makeMockAiModule());
     const { POST } = await import("@/app/api/tarot/reading/route");
@@ -238,7 +238,7 @@ describe("POST /api/tarot/reading", () => {
       checkRateLimit: vi.fn().mockReturnValue(true),
       rateLimitResponse: vi.fn(),
     }));
-    vi.doMock("@/lib/db", () => ({ getDb: vi.fn().mockReturnValue(makeMockDb()) }));
+    vi.doMock("@/lib/db", () => ({ getDb: vi.fn().mockReturnValue(makeMockDb()), getAdminDb: vi.fn().mockReturnValue(makeMockDb()) }));
     vi.doMock("@/lib/auth", () => makeAuthMock());
     vi.doMock("@/services/core/fallback-provider", () => mockAiModule);
     const { POST } = await import("@/app/api/tarot/reading/route");
@@ -278,7 +278,7 @@ describe("POST /api/tarot/reading", () => {
         checkRateLimit: vi.fn().mockReturnValue(true),
         rateLimitResponse: vi.fn(),
       }));
-      vi.doMock("@/lib/db", () => ({ getDb: vi.fn().mockReturnValue(makeMockDb()) }));
+      vi.doMock("@/lib/db", () => ({ getDb: vi.fn().mockReturnValue(makeMockDb()), getAdminDb: vi.fn().mockReturnValue(makeMockDb()) }));
       vi.doMock("@/lib/auth", () => makeAuthMock());
       const { POST } = await import("@/app/api/tarot/reading/route");
       const cardsArr = Array.from({ length: count }, (_, i) => ({
@@ -325,7 +325,7 @@ describe("POST /api/tarot/reading", () => {
       checkRateLimit: vi.fn().mockReturnValue(true),
       rateLimitResponse: vi.fn(),
     }));
-    vi.doMock("@/lib/db", () => ({ getDb: vi.fn().mockReturnValue(makeMockDb()) }));
+    vi.doMock("@/lib/db", () => ({ getDb: vi.fn().mockReturnValue(makeMockDb()), getAdminDb: vi.fn().mockReturnValue(makeMockDb()) }));
     vi.doMock("@/lib/auth", () => makeAuthMock());
     vi.doMock("@/services/core/fallback-provider", () => ({
       FallbackProvider: vi.fn().mockImplementation(() => ({
@@ -369,7 +369,7 @@ describe("POST /api/tarot/reading", () => {
       checkRateLimit: vi.fn().mockRejectedValue("string-throw"),
       rateLimitResponse: vi.fn(),
     }));
-    vi.doMock("@/lib/db", () => ({ getDb: vi.fn().mockReturnValue(makeMockDb()) }));
+    vi.doMock("@/lib/db", () => ({ getDb: vi.fn().mockReturnValue(makeMockDb()), getAdminDb: vi.fn().mockReturnValue(makeMockDb()) }));
     vi.doMock("@/lib/auth", () => makeAuthMock());
     vi.doMock("@/services/core/fallback-provider", () => makeMockAiModule());
     const { POST } = await import("@/app/api/tarot/reading/route");

--- a/src/__tests__/lib/auth-session-ownership.test.ts
+++ b/src/__tests__/lib/auth-session-ownership.test.ts
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { MOCK_USER } from "@/test-helpers/mock-auth";
+import { makeMockDb } from "@/test-helpers/mock-db";
+
+describe("assertSessionOwnership", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    vi.doMock("@/lib/env", () => ({ getDbProvider: vi.fn().mockReturnValue("supabase") }));
+  });
+
+  async function setup(session: { user_id: string | null } | null, user: typeof MOCK_USER | null = MOCK_USER) {
+    const adminDb = makeMockDb();
+    adminDb.findOne.mockResolvedValue(session);
+    const getDb = vi.fn().mockReturnValue(makeMockDb());
+    const getAdminDb = vi.fn().mockReturnValue(adminDb);
+
+    vi.doMock("@/lib/db", () => ({ getDb, getAdminDb }));
+    vi.doMock("@/lib/auth/supabase-auth", () => ({
+      getSupabaseUser: vi.fn().mockResolvedValue(user),
+    }));
+
+    const { assertSessionOwnership } = await import("@/lib/auth");
+    return { assertSessionOwnership, getDb, getAdminDb, adminDb };
+  }
+
+  it("service-role admin DB로 세션을 조회한다", async () => {
+    const { assertSessionOwnership, getDb, getAdminDb, adminDb } = await setup({ user_id: null });
+
+    const result = await assertSessionOwnership("session-id");
+
+    expect(result).toBeNull();
+    expect(getAdminDb).toHaveBeenCalledTimes(1);
+    expect(getDb).not.toHaveBeenCalled();
+    expect(adminDb.findOne).toHaveBeenCalledWith("sessions", { id: "session-id" });
+  });
+
+  it("익명 세션은 통과시킨다", async () => {
+    const { assertSessionOwnership } = await setup({ user_id: null }, null);
+
+    await expect(assertSessionOwnership("anonymous-session")).resolves.toBeNull();
+  });
+
+  it("세션이 없으면 404를 반환한다", async () => {
+    const { assertSessionOwnership } = await setup(null);
+
+    const result = await assertSessionOwnership("missing-session");
+
+    expect(result?.status).toBe(404);
+  });
+
+  it("소유 세션에 비인증 사용자가 접근하면 403을 반환한다", async () => {
+    const { assertSessionOwnership } = await setup({ user_id: "owner-id" }, null);
+
+    const result = await assertSessionOwnership("owned-session");
+
+    expect(result?.status).toBe(403);
+  });
+
+  it("현재 사용자가 세션 소유자면 통과시킨다", async () => {
+    const { assertSessionOwnership } = await setup({ user_id: MOCK_USER.id }, MOCK_USER);
+
+    await expect(assertSessionOwnership("owned-session")).resolves.toBeNull();
+  });
+});

--- a/src/app/api/saju/reading/route.ts
+++ b/src/app/api/saju/reading/route.ts
@@ -4,7 +4,7 @@ import { FallbackProvider } from "@/services/core/fallback-provider";
 import { calculateSaju } from "@/services/saju/saju-calculator";
 import { Topic, SajuTimeRange } from "@/types/session";
 import { sajuTimeOptions } from "@/data/saju/categories";
-import { getDb } from "@/lib/db";
+import { getAdminDb } from "@/lib/db";
 import { assertSessionOwnership } from "@/lib/auth";
 import { fetchMemoryPrompt } from "@/lib/db/character-context";
 import { buildFreeQuestionPrompt } from "@/services/core/prompt-builder";
@@ -88,7 +88,7 @@ export async function POST(request: NextRequest) {
     const readingPrompt = sajuService.buildSajuPrompt(topic, timeRange, sajuResult, userInfo)
       + buildFreeQuestionPrompt(freeQuestion);
 
-    const db = sessionId ? getDb() : null
+    const db = sessionId ? getAdminDb() : null
 
     // 캐릭터 메모리 조회 (인증된 사용자 + sessionId 있을 때만)
     const memoryPrompt = (sessionId && characterId)

--- a/src/app/api/shinjeom/message/route.ts
+++ b/src/app/api/shinjeom/message/route.ts
@@ -2,7 +2,7 @@ import { NextRequest } from "next/server";
 import { ShinjeomService } from "@/services/shinjeom/shinjeom-service";
 import { FallbackProvider } from "@/services/core/fallback-provider";
 import { Topic, ChatMessage } from "@/types/session";
-import { getDb } from "@/lib/db";
+import { getAdminDb } from "@/lib/db";
 import { assertSessionOwnership } from "@/lib/auth";
 import { fetchMemoryPrompt } from "@/lib/db/character-context";
 import { ShinjeomMessageSchema } from "@/lib/validation/api-schemas";
@@ -52,7 +52,7 @@ export async function POST(request: NextRequest) {
     const systemPrompt = shinjeomService.getSystemPrompt(characterId ?? undefined, locale);
     const userPrompt = shinjeomService.buildConversationPrompt(topic, currentMessage, chatHistory, isFinalTurn);
 
-    const db = sessionId ? getDb() : null;
+    const db = sessionId ? getAdminDb() : null;
 
     // 최종 턴에만 캐릭터 메모리 주입 (중간 대화는 토큰 절약)
     const memoryPrompt = (sessionId && characterId && isFinalTurn)

--- a/src/app/api/tarot/reading/route.ts
+++ b/src/app/api/tarot/reading/route.ts
@@ -8,7 +8,7 @@ import { SelectedCard } from "@/types/card";
 import { buildUserInfoPrompt, buildFreeQuestionPrompt } from "@/services/core/prompt-builder";
 import { assertSessionOwnership } from "@/lib/auth";
 import { fetchMemoryPrompt } from "@/lib/db/character-context";
-import { getDb } from "@/lib/db";
+import { getAdminDb } from "@/lib/db";
 import { TAROT_TOPICS } from "@/data/topics";
 import { TarotReadingSchema } from "@/lib/validation/api-schemas";
 import { checkRateLimit, rateLimitResponse } from "@/lib/rate-limit"
@@ -89,7 +89,7 @@ export async function POST(request: NextRequest) {
       selectedCards, chatHistory: [], topic,
     });
 
-    const db = sessionId ? getDb() : null
+    const db = sessionId ? getAdminDb() : null
 
     // 캐릭터 메모리 조회 (인증된 사용자 + sessionId 있을 때만)
     const memoryPrompt = (sessionId && characterId)

--- a/src/lib/auth/index.ts
+++ b/src/lib/auth/index.ts
@@ -48,8 +48,8 @@ export async function assertReadingAccess(
  * 반환값: 에러 Response(403/404) 또는 null(통과)
  */
 export async function assertSessionOwnership(sessionId: string): Promise<Response | null> {
-  const { getDb } = await import("@/lib/db")
-  const db = getDb()
+  const { getAdminDb } = await import("@/lib/db")
+  const db = getAdminDb()
   const [user, session] = await Promise.all([
     getCurrentUser(),
     db.findOne<{ user_id: string | null }>("sessions", { id: sessionId }),


### PR DESCRIPTION
## Summary
- Confirmed the latest Railway deployment includes #292 and `/api/tarot/session` now returns 200.
- Found the remaining production failure in Railway HTTP logs: `POST /api/tarot/reading` returns 404 after session creation.
- Root cause: `assertSessionOwnership()` still queried `sessions` through the normal Supabase RLS client, so server-created anonymous sessions could be invisible during reading start.
- Switched session ownership verification and reading result persistence for tarot/saju/shinjeom to `getAdminDb()` while keeping the existing user_id ownership checks in application code.
- Added regression tests to ensure ownership verification uses admin DB and still returns 403/404 correctly.

## Railway evidence
- Latest deployment: `febd536e-681d-4774-ba20-9d30347b0cd1`, commit `aab26431bbce3b2a7782a2835c555e21beaed98d` (#292)
- `POST /api/tarot/session` -> 200, requestId `VkCqzKesSYS1adD0DcO5xA`
- `POST /api/tarot/reading` -> 404, requestId `BLpYowcwTIauHVW4DcO5xA`

## Validation
- `pnpm exec vitest run src/__tests__/lib/auth-session-ownership.test.ts src/__tests__/api/tarot-reading.test.ts src/__tests__/api/saju-reading.test.ts src/__tests__/api/shinjeom-message.test.ts`
- `pnpm exec vitest run src/__tests__/api src/__tests__/lib src/__tests__/structural`
- `pnpm type-check`
- `pnpm lint`
- `pnpm build`
- `git diff --cached --check`