### PR TITLE
fix: make character effects previewable

### DIFF
--- a/docs/superpowers/specs/2026-05-09-arcana-character-effect-review.md
+++ b/docs/superpowers/specs/2026-05-09-arcana-character-effect-review.md
@@ -1,0 +1,40 @@
+# Arcana Character Effect Browser Review
+
+Date: 2026-05-09
+
+## Scope
+
+- Reviewed `CharacterDisplay`, `CharacterAnimationLayer`, and `SpriteAnimator`.
+- Added a local-only preview route at `/dev/arcana-effects`.
+- The preview uses the production Arcana character data and the same rendering stack as tarot/saju/shinjeom screens.
+
+## Findings
+
+- `SpriteAnimator` already applies visible expression swaps and idle motion.
+- `GlowOverlay`, `EyeBlinkLayer`, `CharacterAuraLayer`, and `GlowBurstRing` are visible overlays around the sprite.
+- The old mood animation layer rendered an empty animated overlay. It did not wrap the sprite, so smile/surprised/wink/serious motion was not visibly moving Arcana.
+- Character profile pages still use a static image. The preview route exists to verify the animated stack directly without changing the public profile page layout.
+- The global CSP blocked the existing Google Fonts stylesheet. The CSP now allows the configured Google font CSS and font files, and permits React development eval only in local development.
+
+## Preview Effects
+
+- `default`: idle float, soft radial glow, periodic blink overlay.
+- `smile`: expression swap plus a light scale pulse on the full character.
+- `serious`: expression swap plus a small upward settle motion.
+- `surprised`: expression swap plus a quick pop and settle bounce.
+- `wink`: expression swap plus a short playful scale pulse.
+- `mystical`: mystical expression, faster aura glow, idle float, and blink overlay.
+
+## Local URL
+
+Run `pnpm dev` and open:
+
+```text
+http://localhost:3000/dev/arcana-effects
+```
+
+Browser check result:
+
+- Preview route rendered with Arcana.
+- Mood buttons switched the visible expression sample.
+- Console had 0 errors after the CSP update. One existing Next image aspect-ratio warning remains from the theme icon.

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,14 +1,16 @@
 import type { NextConfig } from "next";
 
+const isDevelopment = process.env.NODE_ENV === "development";
+
 const securityHeaders = [
   {
     key: "Content-Security-Policy",
     value: [
       "default-src 'self'",
-      "script-src 'self' 'unsafe-inline'",
-      "style-src 'self' 'unsafe-inline'",
+      `script-src 'self' 'unsafe-inline'${isDevelopment ? " 'unsafe-eval'" : ""}`,
+      "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
       "img-src 'self' data: blob: https:",
-      "font-src 'self' data:",
+      "font-src 'self' data: https://fonts.gstatic.com",
       "connect-src 'self' https://api.x.ai https://api.anthropic.com https://*.supabase.co wss://*.supabase.co",
       "frame-ancestors 'none'",
     ].join("; "),

--- a/src/app/dev/arcana-effects/page.tsx
+++ b/src/app/dev/arcana-effects/page.tsx
@@ -1,0 +1,10 @@
+import { notFound } from "next/navigation";
+import { ArcanaEffectsPreview } from "./preview-client";
+
+export default function ArcanaEffectsPreviewPage() {
+  if (process.env.NODE_ENV === "production") {
+    notFound();
+  }
+
+  return <ArcanaEffectsPreview />;
+}

--- a/src/app/dev/arcana-effects/preview-client.tsx
+++ b/src/app/dev/arcana-effects/preview-client.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { useState } from "react";
+import { CharacterDisplay } from "@/components/character/CharacterDisplay";
+import { getCharacterById } from "@/data/characters";
+import type { Mood } from "@/types/character";
+
+const MOOD_PREVIEWS: Array<{
+  mood: Mood;
+  label: string;
+  effect: string;
+}> = [
+  { mood: "default", label: "Default", effect: "Idle float, soft radial glow, periodic blink overlay." },
+  { mood: "smile", label: "Smile", effect: "Expression swap with a light scale pulse on the full character." },
+  { mood: "serious", label: "Serious", effect: "Expression swap with a small upward settle motion." },
+  { mood: "surprised", label: "Surprised", effect: "Expression swap with a quick pop and settle bounce." },
+  { mood: "wink", label: "Wink", effect: "Expression swap with a short playful scale pulse." },
+  { mood: "mystical", label: "Mystical", effect: "Mystical expression, faster aura glow, idle float, and blink overlay." },
+];
+
+export function ArcanaEffectsPreview() {
+  const [mood, setMood] = useState<Mood>("default");
+  const character = getCharacterById("arcana");
+
+  if (!character) return null;
+
+  const selectedPreview = MOOD_PREVIEWS.find((preview) => preview.mood === mood) ?? MOOD_PREVIEWS[0];
+
+  return (
+    <main className="min-h-[100dvh] overflow-hidden bg-[#100d18] text-arcana-text">
+      <div
+        className="fixed inset-0 bg-cover bg-center opacity-35"
+        style={{ backgroundImage: "url('/images/backgrounds/tarot-topic-bg.jpg')" }}
+      />
+      <div className="fixed inset-0 bg-[#100d18]/75" />
+      <div className="relative mx-auto grid min-h-[100dvh] max-w-6xl grid-cols-1 gap-8 px-5 py-6 md:grid-cols-[minmax(320px,48%)_1fr] md:px-8">
+        <section className="relative min-h-[56dvh] overflow-hidden md:min-h-[calc(100dvh-3rem)]">
+          <div className="absolute inset-x-4 bottom-0 top-4">
+            <CharacterDisplay character={character} mood={mood} className="h-full w-full" />
+          </div>
+        </section>
+
+        <section className="flex flex-col justify-center pb-8 md:pb-0">
+          <p className="text-sm font-medium uppercase text-arcana-purple">Arcana effect preview</p>
+          <h1 className="mt-3 font-serif text-3xl font-bold text-white md:text-5xl">아르카나 캐릭터 이펙트 목업</h1>
+          <p className="mt-4 max-w-xl text-sm leading-6 text-arcana-muted md:text-base">
+            This local-only page uses the production CharacterDisplay stack so the sample shows the same aura, glow, blink,
+            sprite transition, and mood motion that users see in the app.
+          </p>
+
+          <div className="mt-7 grid grid-cols-2 gap-2 sm:grid-cols-3">
+            {MOOD_PREVIEWS.map((preview) => (
+              <button
+                key={preview.mood}
+                type="button"
+                onClick={() => setMood(preview.mood)}
+                className={`h-11 rounded-lg border px-3 text-sm font-semibold transition-colors ${
+                  mood === preview.mood
+                    ? "border-arcana-purple bg-arcana-purple text-white"
+                    : "border-arcana-border bg-arcana-card/70 text-arcana-text hover:border-arcana-purple"
+                }`}
+              >
+                {preview.label}
+              </button>
+            ))}
+          </div>
+
+          <div className="mt-7 border-l-2 border-arcana-purple pl-5">
+            <p className="text-xs font-semibold uppercase text-arcana-muted">Current sample</p>
+            <h2 className="mt-2 font-serif text-2xl font-bold text-white">{selectedPreview.label}</h2>
+            <p className="mt-2 max-w-lg text-sm leading-6 text-arcana-muted">{selectedPreview.effect}</p>
+          </div>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/src/components/character/CharacterAnimationLayer.tsx
+++ b/src/components/character/CharacterAnimationLayer.tsx
@@ -85,24 +85,29 @@ const MOOD_ANIM_MAP: Partial<Record<Mood, MoodAnimConfig>> = {
   },
 };
 
-function MoodAnimLayer({ mood }: { readonly mood: Mood }) {
-  if (mood === "default" || mood === "mystical") return null;
-
+function CharacterMotionLayer({
+  mood,
+  children,
+}: {
+  readonly mood: Mood;
+  readonly children: React.ReactNode;
+}) {
   const config = MOOD_ANIM_MAP[mood];
-  if (!config) return null;
 
   return (
     <motion.div
-      key={mood}
-      animate={config.animate}
-      transition={config.transition}
+      key={`character-motion-${mood}`}
+      animate={config?.animate}
+      transition={config?.transition}
       style={{
-        position: "absolute",
-        inset: 0,
-        pointerEvents: "none",
-        zIndex: 6,
+        position: "relative",
+        width: "100%",
+        height: "100%",
+        zIndex: 2,
       }}
-    />
+    >
+      {children}
+    </motion.div>
   );
 }
 
@@ -137,9 +142,8 @@ export function CharacterAnimationLayer({ mood, effectTheme, children }: Charact
   return (
     <div style={{ position: "relative", width: "100%", height: "100%" }}>
       <GlowOverlay mood={mood} effectTheme={effectTheme} />
-      {children}
+      <CharacterMotionLayer mood={mood}>{children}</CharacterMotionLayer>
       <EyeBlinkLayer mood={mood} />
-      <MoodAnimLayer mood={mood} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Fix CharacterAnimationLayer so mood motion wraps and moves the actual character sprite instead of an empty overlay.
- Add a local-only Arcana effect preview page at `/dev/arcana-effects` for browser review.
- Align CSP with existing Google Fonts usage and allow React dev eval only in development.
- Document the effect review and local verification notes.

## Verification
- `pnpm lint`
- `pnpm type-check`
- `pnpm build`
- `pnpm check:doc-links` (exits 0; existing archive link warnings remain)
- Browser: `http://localhost:3000/dev/arcana-effects`, Arcana mood buttons render and switch visible samples; console errors 0 after CSP update, one existing theme icon aspect-ratio warning remains.