### PR TITLE
feat: add theme atmosphere and character polish

### DIFF
--- a/docs/superpowers/specs/2026-05-09-theme-atmosphere-character-polish-design.md
+++ b/docs/superpowers/specs/2026-05-09-theme-atmosphere-character-polish-design.md
@@ -1,0 +1,44 @@
+# Theme Atmosphere and Character Edge Polish Design
+
+Date: 2026-05-09
+
+## Goals
+
+- Make transparent character cutouts read sharper and more intentional after background removal.
+- Add richer theme-specific atmosphere so each selected theme changes the emotional texture of the page, not just colors.
+- Keep effects decorative, accessible, and mobile-conscious.
+
+## Character Edge Treatment
+
+- Keep source PNG assets unchanged.
+- Apply subtle CSS edge support in the shared character renderer instead of creating harsh outlines.
+- Stabilize moving image layers with compositor-friendly styles.
+- Reduce sprite-level blur where it makes transparent antialiasing look hazy, while keeping aura and glow in surrounding layers.
+- Treat the static character profile page separately because it bypasses `CharacterDisplay`.
+
+## Theme Atmosphere
+
+Seven existing themes map to distinct ambient effects:
+
+- `midnight`: small stars, constellation shimmer, deep lunar haze.
+- `dawn`: pale mist and soft aurora-like dawn light.
+- `sunset`: warm horizon rays and golden dust.
+- `spring`: drifting cherry petals.
+- `summer`: firefly glints and night-sky sparkle.
+- `autumn`: falling leaves and ember-like dust.
+- `winter`: slow snow and frost glow.
+
+The implementation should use deterministic decorative layers, avoid random SSR output, and respect reduced motion.
+
+## Integration
+
+- Add a central theme atmosphere config under `src/components/effects/`.
+- Reuse it from home/service/background effect components.
+- Preserve service identity for tarot/saju/shinjeom while letting active theme add a secondary atmosphere.
+- Keep all atmospheric layers `pointer-events-none` and `aria-hidden`.
+
+## Verification
+
+- Run `pnpm lint`, `pnpm type-check`, `pnpm build`, and doc link checks.
+- Use the local browser to inspect at least the home hero and Arcana preview/profile area across multiple themes.
+- Check console output for new errors.

--- a/src/app/character/[id]/page.tsx
+++ b/src/app/character/[id]/page.tsx
@@ -8,6 +8,7 @@ import { getCharacterDescription, getCharacterSpeciality } from "@/data/characte
 import { useLocaleStore } from "@/hooks/useLocaleStore";
 import { useT } from "@/i18n/useT";
 import { ParticleOverlay } from "@/components/effects/ParticleOverlay";
+import { getCharacterCutoutImageStyle } from "@/components/character/SpriteAnimator";
 
 const SERVICE_IDS = [
   { id: "tarot",    icon: "🃏" },
@@ -39,6 +40,7 @@ export default function CharacterPage() {
     desc: t(`character.service.${s.id}.desc`),
     disabled: "disabled" in s ? s.disabled : false,
   }));
+  const cutoutImageStyle = getCharacterCutoutImageStyle(character.effectTheme.primary);
 
   return (
     <div className="relative min-h-screen overflow-hidden">
@@ -75,6 +77,7 @@ export default function CharacterPage() {
             fill
             sizes="(max-width: 768px) 100vw, 50vw"
             className="object-cover object-top"
+            style={cutoutImageStyle}
           />
         </div>
 

--- a/src/components/character/SpriteAnimator.tsx
+++ b/src/components/character/SpriteAnimator.tsx
@@ -35,29 +35,42 @@ function buildLoopMotion(primary: string): Record<string, Record<string, number[
     float: {
       y: [0, -6, 0],
       scale: [1, 1.01, 1],
-      filter: [sh(6, 0.25), sh(16, 0.6), sh(6, 0.25)],
+      filter: [sh(4, 0.18), sh(10, 0.36), sh(4, 0.18)],
     },
     "float-strong": {
       y: [0, -8, 0],
       scale: [1, 1.015, 1],
-      filter: [sh(8, 0.3), sh(22, 0.7), sh(8, 0.3)],
+      filter: [sh(5, 0.22), sh(12, 0.42), sh(5, 0.22)],
     },
     bounce: {
       y: [0, -12, 0],
       scale: [1, 1.02, 1],
-      filter: [sh(6, 0.2), sh(18, 0.55), sh(6, 0.2)],
+      filter: [sh(4, 0.16), sh(10, 0.34), sh(4, 0.16)],
     },
     breathe: {
       y: [0, -2, 0, -1, 0],
       scale: [1, 1.005, 1, 1.003, 1],
       opacity: [1, 1, 1, 0.88, 1],
-      filter: [sh(4, 0.2), sh(12, 0.5), sh(4, 0.2), sh(8, 0.35), sh(4, 0.2)],
+      filter: [sh(3, 0.16), sh(8, 0.32), sh(3, 0.16), sh(6, 0.24), sh(3, 0.16)],
     },
     mystical: {
       y: [0, -10, 0],
       scale: [1, 1.02, 1],
-      filter: [sh(8, 0.3), sh(20, 0.6), sh(8, 0.3)],
+      filter: [sh(5, 0.22), sh(12, 0.4), sh(5, 0.22)],
     },
+  };
+}
+
+export function getCharacterCutoutImageStyle(primaryColor = "#a78bfa"): React.CSSProperties {
+  return {
+    filter: [
+      "drop-shadow(0 0 0.35px rgba(255, 255, 255, 0.22))",
+      "drop-shadow(0 1px 0.6px rgba(10, 8, 18, 0.28))",
+      `drop-shadow(0 0 2px ${hexToRgba(primaryColor, 0.16)})`,
+    ].join(" "),
+    backfaceVisibility: "hidden",
+    transform: "translateZ(0)",
+    WebkitFontSmoothing: "antialiased",
   };
 }
 
@@ -133,6 +146,7 @@ export const SpriteAnimator = React.memo(function SpriteAnimator({ characterId, 
   const isLooping = config.loop;
   const activeLoopKey = mood === "default" ? idleAnimation : mood;
   const loopMotion = useMemo(() => buildLoopMotion(primaryColor ?? "#a78bfa"), [primaryColor]);
+  const cutoutImageStyle = useMemo(() => getCharacterCutoutImageStyle(primaryColor), [primaryColor]);
   const loopAnim = loopMotion[activeLoopKey] ?? loopMotion.float;
   const loopTransition = LOOP_TRANSITIONS[activeLoopKey] ?? LOOP_TRANSITIONS.float;
   const enterAnim = ENTER_MOTION[mood];
@@ -152,7 +166,7 @@ export const SpriteAnimator = React.memo(function SpriteAnimator({ characterId, 
             <motion.div animate={enterAnim} transition={{ duration: 0.5, ease: "easeOut" }}
               className="relative w-full h-full">
               <Image src={imageSrc} alt="" fill sizes="50vw"
-                className="object-contain object-center" priority />
+                className="object-contain object-center" style={cutoutImageStyle} priority />
             </motion.div>
           ) : (
             <motion.div
@@ -161,7 +175,7 @@ export const SpriteAnimator = React.memo(function SpriteAnimator({ characterId, 
               className="relative w-full h-full"
             >
               <Image src={imageSrc} alt="" fill sizes="50vw"
-                className="object-contain object-center" priority />
+                className="object-contain object-center" style={cutoutImageStyle} priority />
             </motion.div>
           )}
         </motion.div>

--- a/src/components/effects/MysticBackground.tsx
+++ b/src/components/effects/MysticBackground.tsx
@@ -1,12 +1,21 @@
 "use client";
 
 import { useId } from "react";
+import type { CSSProperties } from "react";
 import { motion, useReducedMotion } from "framer-motion";
+import type { ThemeId } from "@/hooks/useTheme";
+import { THEME_ATMOSPHERES, type AtmosphereParticle } from "./themeAtmosphere";
 
 type Service = "home" | "tarot" | "saju" | "shinjeom";
 
 interface MysticBackgroundProps {
   readonly service: Service;
+}
+
+interface ThemeAtmosphereProps {
+  readonly theme: ThemeId;
+  readonly intensity?: "hero" | "service";
+  readonly className?: string;
 }
 
 const MIST_COLOR: Record<Service, string> = {
@@ -51,6 +60,248 @@ const RUNE_POSITIONS = [
   { top: "30%", left: "87%", fontSize: 14, opacity: 0.15 },
   { top: "70%", left: "89%", fontSize: 12, opacity: 0.12 },
 ];
+
+const INTENSITY_OPACITY: Record<NonNullable<ThemeAtmosphereProps["intensity"]>, number> = {
+  hero: 1,
+  service: 0.56,
+};
+
+function particleStyle(particle: AtmosphereParticle): CSSProperties {
+  const base: CSSProperties = {
+    left: `${particle.x}%`,
+    top: `${particle.y}%`,
+    width: particle.size,
+    height: particle.size,
+    opacity: particle.opacity,
+  };
+
+  if (particle.kind === "mist") {
+    return {
+      ...base,
+      background: particle.color ?? "rgba(255, 255, 255, 0.22)",
+      borderRadius: "999px",
+      filter: "blur(18px)",
+    };
+  }
+
+  if (particle.kind === "petal") {
+    return {
+      ...base,
+      height: particle.size * 0.62,
+      background: "linear-gradient(135deg, rgba(252,231,243,0.82), rgba(244,114,182,0.5))",
+      borderRadius: "78% 22% 76% 24%",
+      transform: `rotate(${particle.rotate ?? 0}deg)`,
+      boxShadow: "0 0 12px rgba(249,168,212,0.18)",
+    };
+  }
+
+  if (particle.kind === "leaf") {
+    return {
+      ...base,
+      height: particle.size * 0.55,
+      background: particle.color ?? "rgba(217, 119, 6, 0.62)",
+      borderRadius: "90% 8% 86% 12%",
+      transform: `rotate(${particle.rotate ?? 0}deg)`,
+      boxShadow: "0 0 14px rgba(245,158,11,0.12)",
+    };
+  }
+
+  if (particle.kind === "firefly") {
+    return {
+      ...base,
+      background: "rgba(253, 224, 71, 0.92)",
+      borderRadius: "999px",
+      boxShadow: "0 0 10px rgba(253,224,71,0.85), 0 0 24px rgba(56,189,248,0.26)",
+    };
+  }
+
+  if (particle.kind === "ember") {
+    return {
+      ...base,
+      background: "rgba(251, 146, 60, 0.9)",
+      borderRadius: "999px",
+      boxShadow: "0 0 12px rgba(251,146,60,0.75)",
+    };
+  }
+
+  if (particle.kind === "snow") {
+    return {
+      ...base,
+      background: "rgba(240, 249, 255, 0.88)",
+      borderRadius: "999px",
+      boxShadow: "0 0 8px rgba(191,219,254,0.42)",
+    };
+  }
+
+  if (particle.kind === "dust") {
+    return {
+      ...base,
+      background: "rgba(253, 224, 171, 0.78)",
+      borderRadius: "999px",
+      boxShadow: "0 0 10px rgba(251,146,60,0.32)",
+    };
+  }
+
+  return {
+    ...base,
+    background: "rgba(255, 255, 255, 0.88)",
+    borderRadius: "999px",
+    boxShadow: "0 0 10px rgba(245,158,11,0.48)",
+  };
+}
+
+function particleMotion(particle: AtmosphereParticle, shouldReduceMotion: boolean) {
+  if (shouldReduceMotion) return { opacity: particle.opacity };
+
+  if (particle.kind === "petal" || particle.kind === "leaf") {
+    return {
+      x: [0, particle.kind === "petal" ? 18 : 24, 4],
+      y: [0, 28, 56],
+      rotate: [particle.rotate ?? 0, (particle.rotate ?? 0) + 18, (particle.rotate ?? 0) - 8],
+      opacity: [particle.opacity * 0.25, particle.opacity, particle.opacity * 0.2],
+    };
+  }
+
+  if (particle.kind === "snow") {
+    return {
+      x: [0, 10, -6, 8],
+      y: [0, 34, 68],
+      opacity: [particle.opacity * 0.35, particle.opacity, particle.opacity * 0.35],
+    };
+  }
+
+  if (particle.kind === "mist") {
+    return {
+      x: [0, 18, -10, 0],
+      scale: [0.96, 1.08, 1],
+      opacity: [particle.opacity * 0.65, particle.opacity, particle.opacity * 0.75],
+    };
+  }
+
+  if (particle.kind === "firefly") {
+    return {
+      x: [0, 10, -8, 6, 0],
+      y: [0, -12, 5, -8, 0],
+      opacity: [particle.opacity * 0.22, particle.opacity, particle.opacity * 0.36],
+      scale: [0.8, 1.25, 0.9],
+    };
+  }
+
+  if (particle.kind === "ember") {
+    return {
+      y: [0, -24, -54],
+      x: [0, 6, -4],
+      opacity: [particle.opacity * 0.2, particle.opacity, 0],
+    };
+  }
+
+  return {
+    opacity: [particle.opacity * 0.35, particle.opacity, particle.opacity * 0.45],
+    scale: [0.82, 1.18, 0.9],
+  };
+}
+
+export function ThemeAtmosphere({ theme, intensity = "hero", className = "" }: ThemeAtmosphereProps) {
+  const shouldReduceMotion = useReducedMotion();
+  const config = THEME_ATMOSPHERES[theme];
+  const opacity = INTENSITY_OPACITY[intensity];
+
+  return (
+    <div
+      className={`absolute inset-0 overflow-hidden pointer-events-none ${className}`}
+      style={{ opacity }}
+      aria-hidden
+    >
+      <motion.div
+        className="absolute inset-0"
+        style={{ background: config.baseGlow }}
+        animate={shouldReduceMotion ? { opacity: 0.82 } : { opacity: [0.72, 1, 0.76] }}
+        transition={shouldReduceMotion ? { duration: 0 } : { duration: 9, repeat: Infinity, ease: "easeInOut" }}
+      />
+
+      {config.texture ? (
+        <div
+          className="absolute inset-0"
+          style={{
+            backgroundImage: config.texture,
+            backgroundSize: theme === "summer" ? "96px 96px" : "auto",
+            opacity: 0.62,
+          }}
+        />
+      ) : null}
+
+      {config.rays?.map((ray) => (
+        <motion.div
+          key={ray.id}
+          className="absolute -top-[12%] h-[86%] origin-top"
+          style={{
+            left: `${ray.left}%`,
+            width: `${ray.width}%`,
+            transform: `rotate(${ray.rotate}deg)`,
+            background: `linear-gradient(180deg, ${ray.color}, transparent 78%)`,
+            filter: "blur(10px)",
+            opacity: ray.opacity,
+          }}
+          animate={shouldReduceMotion ? { opacity: ray.opacity } : { opacity: [ray.opacity * 0.55, ray.opacity, ray.opacity * 0.62] }}
+          transition={shouldReduceMotion ? { duration: 0 } : { duration: 7, repeat: Infinity, ease: "easeInOut", delay: ray.delay }}
+        />
+      ))}
+
+      {config.ribbons ? (
+        <svg className="absolute inset-0 h-full w-full" viewBox="0 0 100 100" preserveAspectRatio="none">
+          {config.ribbons.map((ribbon) => (
+            <motion.path
+              key={ribbon.id}
+              d={ribbon.path}
+              fill="none"
+              stroke={ribbon.color}
+              strokeLinecap="round"
+              strokeWidth="9"
+              opacity={ribbon.opacity}
+              filter="blur(5px)"
+              animate={shouldReduceMotion ? { pathLength: 1 } : { pathLength: [0.82, 1, 0.86], opacity: [ribbon.opacity * 0.55, ribbon.opacity, ribbon.opacity * 0.6] }}
+              transition={shouldReduceMotion ? { duration: 0 } : { duration: ribbon.duration, repeat: Infinity, ease: "easeInOut", delay: ribbon.delay }}
+            />
+          ))}
+        </svg>
+      ) : null}
+
+      {config.lines ? (
+        <svg className="absolute inset-0 h-full w-full" viewBox="0 0 100 100" preserveAspectRatio="none">
+          {config.lines.map((line) => (
+            <motion.line
+              key={line.id}
+              x1={line.x1}
+              y1={line.y1}
+              x2={line.x2}
+              y2={line.y2}
+              stroke="rgba(226, 232, 240, 0.72)"
+              strokeWidth="0.18"
+              opacity={line.opacity}
+              initial={shouldReduceMotion ? false : { pathLength: 0 }}
+              animate={shouldReduceMotion ? { opacity: line.opacity } : { pathLength: 1, opacity: [line.opacity * 0.45, line.opacity, line.opacity * 0.52] }}
+              transition={shouldReduceMotion ? { duration: 0 } : { duration: 5.5, repeat: Infinity, ease: "easeInOut" }}
+            />
+          ))}
+        </svg>
+      ) : null}
+
+      {config.particles.map((particle) => (
+        <motion.span
+          key={particle.id}
+          className="absolute block"
+          style={particleStyle(particle)}
+          animate={particleMotion(particle, Boolean(shouldReduceMotion))}
+          transition={
+            shouldReduceMotion
+              ? { duration: 0 }
+              : { duration: particle.duration, repeat: Infinity, ease: "easeInOut", delay: particle.delay }
+          }
+        />
+      ))}
+    </div>
+  );
+}
 
 export function MysticBackground({ service }: MysticBackgroundProps) {
   const shouldReduceMotion = useReducedMotion();

--- a/src/components/effects/ServiceBackground.tsx
+++ b/src/components/effects/ServiceBackground.tsx
@@ -1,6 +1,8 @@
 "use client";
 
-import { motion } from "framer-motion";
+import { motion, useReducedMotion } from "framer-motion";
+import { useThemeStore } from "@/hooks/useTheme";
+import { ThemeAtmosphere } from "./MysticBackground";
 
 type ServiceType = "tarot" | "saju" | "shinjeom";
 
@@ -27,7 +29,7 @@ const OBANGSAEK_LAYERS = [
   { color: "#D1D5DB", angle: 180, delay: 4.8 },
 ];
 
-function TarotBackground() {
+function TarotBackground({ shouldReduceMotion }: { readonly shouldReduceMotion: boolean }) {
   return (
     <>
       <div className="absolute inset-0" style={{ backgroundColor: "#0F0A2E" }} />
@@ -46,35 +48,35 @@ function TarotBackground() {
             height: `${star.size}px`,
             willChange: "opacity",
           }}
-          animate={{ opacity: [0.2, 0.9, 0.2] }}
-          transition={{ duration: star.duration, repeat: Infinity, ease: "easeInOut", delay: star.delay }}
+          animate={shouldReduceMotion ? { opacity: 0.48 } : { opacity: [0.2, 0.9, 0.2] }}
+          transition={shouldReduceMotion ? { duration: 0 } : { duration: star.duration, repeat: Infinity, ease: "easeInOut", delay: star.delay }}
         />
       ))}
     </>
   );
 }
 
-function SajuBackground() {
+function SajuBackground({ shouldReduceMotion }: { readonly shouldReduceMotion: boolean }) {
   return (
     <>
       <div className="absolute inset-0" style={{ backgroundColor: "#1A1209" }} />
       <motion.div
         className="absolute inset-0"
         style={{ background: "radial-gradient(ellipse 70% 40% at 50% 90%, rgba(217,119,6,0.35) 0%, transparent 65%)" }}
-        animate={{ opacity: [0.6, 1, 0.6] }}
-        transition={{ duration: 4, repeat: Infinity, ease: "easeInOut" }}
+        animate={shouldReduceMotion ? { opacity: 0.74 } : { opacity: [0.6, 1, 0.6] }}
+        transition={shouldReduceMotion ? { duration: 0 } : { duration: 4, repeat: Infinity, ease: "easeInOut" }}
       />
       <motion.div
         className="absolute inset-0"
         style={{ background: "radial-gradient(ellipse 40% 30% at 50% 10%, rgba(6,95,70,0.2) 0%, transparent 60%)" }}
-        animate={{ opacity: [0.4, 0.8, 0.4] }}
-        transition={{ duration: 6, repeat: Infinity, ease: "easeInOut", delay: 2 }}
+        animate={shouldReduceMotion ? { opacity: 0.52 } : { opacity: [0.4, 0.8, 0.4] }}
+        transition={shouldReduceMotion ? { duration: 0 } : { duration: 6, repeat: Infinity, ease: "easeInOut", delay: 2 }}
       />
     </>
   );
 }
 
-function ShinjeomBackground() {
+function ShinjeomBackground({ shouldReduceMotion }: { readonly shouldReduceMotion: boolean }) {
   return (
     <>
       <div className="absolute inset-0" style={{ backgroundColor: "#120A18" }} />
@@ -85,26 +87,30 @@ function ShinjeomBackground() {
           style={{
             background: `linear-gradient(${layer.angle}deg, ${layer.color}28 0%, transparent 55%)`,
           }}
-          animate={{ opacity: [0.4, 0.85, 0.4] }}
-          transition={{ duration: 5, repeat: Infinity, ease: "easeInOut", delay: layer.delay }}
+          animate={shouldReduceMotion ? { opacity: 0.54 } : { opacity: [0.4, 0.85, 0.4] }}
+          transition={shouldReduceMotion ? { duration: 0 } : { duration: 5, repeat: Infinity, ease: "easeInOut", delay: layer.delay }}
         />
       ))}
       <motion.div
         className="absolute inset-0"
         style={{ background: "radial-gradient(ellipse 50% 40% at 50% 50%, rgba(139,92,246,0.15) 0%, transparent 60%)" }}
-        animate={{ opacity: [0.3, 0.7, 0.3] }}
-        transition={{ duration: 8, repeat: Infinity, ease: "easeInOut" }}
+        animate={shouldReduceMotion ? { opacity: 0.42 } : { opacity: [0.3, 0.7, 0.3] }}
+        transition={shouldReduceMotion ? { duration: 0 } : { duration: 8, repeat: Infinity, ease: "easeInOut" }}
       />
     </>
   );
 }
 
 export function ServiceBackground({ service }: ServiceBackgroundProps) {
+  const { activeTheme } = useThemeStore();
+  const shouldReduceMotion = Boolean(useReducedMotion());
+
   return (
-    <div className="fixed inset-0 -z-10 overflow-hidden">
-      {service === "tarot" && <TarotBackground />}
-      {service === "saju" && <SajuBackground />}
-      {service === "shinjeom" && <ShinjeomBackground />}
+    <div className="fixed inset-0 -z-10 overflow-hidden pointer-events-none" aria-hidden>
+      {service === "tarot" && <TarotBackground shouldReduceMotion={shouldReduceMotion} />}
+      {service === "saju" && <SajuBackground shouldReduceMotion={shouldReduceMotion} />}
+      {service === "shinjeom" && <ShinjeomBackground shouldReduceMotion={shouldReduceMotion} />}
+      <ThemeAtmosphere theme={activeTheme} intensity="service" className="mix-blend-screen" />
     </div>
   );
 }

--- a/src/components/effects/themeAtmosphere.ts
+++ b/src/components/effects/themeAtmosphere.ts
@@ -1,0 +1,182 @@
+import type { ThemeId } from "@/hooks/useTheme";
+
+type DriftParticleKind = "star" | "mist" | "dust" | "petal" | "firefly" | "leaf" | "snow" | "ember";
+
+export interface AtmosphereParticle {
+  readonly id: string;
+  readonly kind: DriftParticleKind;
+  readonly x: number;
+  readonly y: number;
+  readonly size: number;
+  readonly opacity: number;
+  readonly delay: number;
+  readonly duration: number;
+  readonly color?: string;
+  readonly rotate?: number;
+}
+
+export interface AtmosphereLine {
+  readonly id: string;
+  readonly x1: number;
+  readonly y1: number;
+  readonly x2: number;
+  readonly y2: number;
+  readonly opacity: number;
+}
+
+export interface AtmosphereRibbon {
+  readonly id: string;
+  readonly path: string;
+  readonly color: string;
+  readonly opacity: number;
+  readonly delay: number;
+  readonly duration: number;
+}
+
+export interface AtmosphereRay {
+  readonly id: string;
+  readonly left: number;
+  readonly width: number;
+  readonly rotate: number;
+  readonly opacity: number;
+  readonly color: string;
+  readonly delay: number;
+}
+
+export interface ThemeAtmosphereConfig {
+  readonly baseGlow: string;
+  readonly texture?: string;
+  readonly particles: readonly AtmosphereParticle[];
+  readonly lines?: readonly AtmosphereLine[];
+  readonly ribbons?: readonly AtmosphereRibbon[];
+  readonly rays?: readonly AtmosphereRay[];
+}
+
+const STAR_PARTICLES: readonly AtmosphereParticle[] = [
+  { id: "m-star-1", kind: "star", x: 9, y: 14, size: 2, opacity: 0.76, delay: 0.1, duration: 3.6 },
+  { id: "m-star-2", kind: "star", x: 19, y: 24, size: 1.4, opacity: 0.56, delay: 0.8, duration: 4.2 },
+  { id: "m-star-3", kind: "star", x: 31, y: 11, size: 2.8, opacity: 0.72, delay: 1.2, duration: 5 },
+  { id: "m-star-4", kind: "star", x: 49, y: 19, size: 1.8, opacity: 0.62, delay: 0.4, duration: 3.8 },
+  { id: "m-star-5", kind: "star", x: 66, y: 10, size: 2.2, opacity: 0.7, delay: 1.6, duration: 4.8 },
+  { id: "m-star-6", kind: "star", x: 84, y: 23, size: 1.6, opacity: 0.6, delay: 0.6, duration: 3.4 },
+  { id: "m-star-7", kind: "star", x: 91, y: 44, size: 2.4, opacity: 0.64, delay: 1.1, duration: 4.6 },
+  { id: "m-star-8", kind: "star", x: 14, y: 68, size: 1.5, opacity: 0.48, delay: 0.2, duration: 4.4 },
+  { id: "m-star-9", kind: "star", x: 72, y: 74, size: 1.7, opacity: 0.5, delay: 1.9, duration: 5.4 },
+];
+
+const MIST_PARTICLES: readonly AtmosphereParticle[] = [
+  { id: "d-mist-1", kind: "mist", x: 11, y: 62, size: 34, opacity: 0.2, delay: 0, duration: 8, color: "rgba(248, 187, 217, 0.34)" },
+  { id: "d-mist-2", kind: "mist", x: 33, y: 72, size: 42, opacity: 0.18, delay: 1.5, duration: 10, color: "rgba(147, 197, 253, 0.28)" },
+  { id: "d-mist-3", kind: "mist", x: 64, y: 58, size: 38, opacity: 0.2, delay: 0.8, duration: 9, color: "rgba(251, 191, 36, 0.18)" },
+  { id: "d-mist-4", kind: "mist", x: 84, y: 76, size: 46, opacity: 0.16, delay: 2.2, duration: 11, color: "rgba(192, 132, 252, 0.28)" },
+];
+
+const DUST_PARTICLES: readonly AtmosphereParticle[] = [
+  { id: "s-dust-1", kind: "dust", x: 12, y: 40, size: 2, opacity: 0.36, delay: 0.1, duration: 7 },
+  { id: "s-dust-2", kind: "dust", x: 24, y: 61, size: 1.4, opacity: 0.3, delay: 1.3, duration: 8 },
+  { id: "s-dust-3", kind: "dust", x: 38, y: 28, size: 2.2, opacity: 0.34, delay: 0.7, duration: 6.5 },
+  { id: "s-dust-4", kind: "dust", x: 52, y: 52, size: 1.6, opacity: 0.32, delay: 2.1, duration: 7.8 },
+  { id: "s-dust-5", kind: "dust", x: 70, y: 34, size: 2.4, opacity: 0.34, delay: 1.6, duration: 8.4 },
+  { id: "s-dust-6", kind: "dust", x: 83, y: 66, size: 1.8, opacity: 0.3, delay: 0.4, duration: 7.2 },
+  { id: "s-dust-7", kind: "dust", x: 91, y: 43, size: 2, opacity: 0.32, delay: 2.6, duration: 9 },
+];
+
+const PETALS: readonly AtmosphereParticle[] = [
+  { id: "sp-petal-1", kind: "petal", x: 8, y: 20, size: 12, opacity: 0.42, delay: 0, duration: 10, rotate: -18 },
+  { id: "sp-petal-2", kind: "petal", x: 22, y: 46, size: 9, opacity: 0.34, delay: 1.8, duration: 12, rotate: 26 },
+  { id: "sp-petal-3", kind: "petal", x: 39, y: 18, size: 11, opacity: 0.4, delay: 3.1, duration: 11, rotate: 12 },
+  { id: "sp-petal-4", kind: "petal", x: 56, y: 58, size: 8, opacity: 0.32, delay: 0.9, duration: 13, rotate: -30 },
+  { id: "sp-petal-5", kind: "petal", x: 74, y: 29, size: 12, opacity: 0.38, delay: 2.4, duration: 12, rotate: 18 },
+  { id: "sp-petal-6", kind: "petal", x: 89, y: 51, size: 10, opacity: 0.34, delay: 4, duration: 14, rotate: -10 },
+];
+
+const FIREFLIES: readonly AtmosphereParticle[] = [
+  { id: "su-firefly-1", kind: "firefly", x: 12, y: 72, size: 5, opacity: 0.58, delay: 0, duration: 5.4 },
+  { id: "su-firefly-2", kind: "firefly", x: 29, y: 38, size: 3, opacity: 0.48, delay: 1.3, duration: 6.2 },
+  { id: "su-firefly-3", kind: "firefly", x: 43, y: 66, size: 4, opacity: 0.52, delay: 2.1, duration: 5.8 },
+  { id: "su-firefly-4", kind: "firefly", x: 63, y: 32, size: 3, opacity: 0.48, delay: 0.7, duration: 6.5 },
+  { id: "su-firefly-5", kind: "firefly", x: 78, y: 70, size: 5, opacity: 0.56, delay: 1.8, duration: 5.6 },
+  { id: "su-glint-1", kind: "star", x: 87, y: 18, size: 2, opacity: 0.58, delay: 0.4, duration: 3.8 },
+  { id: "su-glint-2", kind: "star", x: 55, y: 15, size: 1.6, opacity: 0.48, delay: 1.5, duration: 4.4 },
+];
+
+const LEAVES_AND_EMBERS: readonly AtmosphereParticle[] = [
+  { id: "a-leaf-1", kind: "leaf", x: 10, y: 18, size: 14, opacity: 0.38, delay: 0, duration: 13, color: "rgba(245, 158, 11, 0.72)", rotate: -24 },
+  { id: "a-leaf-2", kind: "leaf", x: 26, y: 48, size: 11, opacity: 0.34, delay: 2, duration: 15, color: "rgba(220, 38, 38, 0.58)", rotate: 18 },
+  { id: "a-leaf-3", kind: "leaf", x: 48, y: 26, size: 13, opacity: 0.36, delay: 3.6, duration: 14, color: "rgba(180, 83, 9, 0.7)", rotate: 34 },
+  { id: "a-leaf-4", kind: "leaf", x: 76, y: 42, size: 12, opacity: 0.34, delay: 1.1, duration: 16, color: "rgba(251, 191, 36, 0.55)", rotate: -12 },
+  { id: "a-ember-1", kind: "ember", x: 18, y: 80, size: 2, opacity: 0.42, delay: 0.4, duration: 5.8 },
+  { id: "a-ember-2", kind: "ember", x: 61, y: 74, size: 2.4, opacity: 0.46, delay: 1.8, duration: 6.4 },
+  { id: "a-ember-3", kind: "ember", x: 88, y: 78, size: 1.8, opacity: 0.38, delay: 2.7, duration: 5.2 },
+];
+
+const SNOW: readonly AtmosphereParticle[] = [
+  { id: "w-snow-1", kind: "snow", x: 8, y: 12, size: 3, opacity: 0.54, delay: 0, duration: 10 },
+  { id: "w-snow-2", kind: "snow", x: 19, y: 36, size: 2, opacity: 0.42, delay: 2, duration: 12 },
+  { id: "w-snow-3", kind: "snow", x: 32, y: 18, size: 2.8, opacity: 0.48, delay: 1.1, duration: 11 },
+  { id: "w-snow-4", kind: "snow", x: 47, y: 54, size: 2, opacity: 0.4, delay: 3, duration: 13 },
+  { id: "w-snow-5", kind: "snow", x: 63, y: 24, size: 3.2, opacity: 0.5, delay: 1.7, duration: 12 },
+  { id: "w-snow-6", kind: "snow", x: 79, y: 46, size: 2.4, opacity: 0.44, delay: 2.8, duration: 14 },
+  { id: "w-snow-7", kind: "snow", x: 91, y: 16, size: 2, opacity: 0.4, delay: 0.6, duration: 11 },
+  { id: "w-snow-8", kind: "snow", x: 86, y: 72, size: 3, opacity: 0.46, delay: 3.8, duration: 15 },
+];
+
+export const THEME_ATMOSPHERES: Record<ThemeId, ThemeAtmosphereConfig> = {
+  midnight: {
+    baseGlow:
+      "radial-gradient(circle at 18% 18%, rgba(167,139,250,0.18), transparent 28%), radial-gradient(circle at 78% 12%, rgba(245,158,11,0.12), transparent 24%)",
+    texture:
+      "linear-gradient(115deg, transparent 0 32%, rgba(167,139,250,0.08) 32.5%, transparent 34%), linear-gradient(68deg, transparent 0 58%, rgba(245,158,11,0.07) 58.4%, transparent 60%)",
+    particles: STAR_PARTICLES,
+    lines: [
+      { id: "m-line-1", x1: 9, y1: 14, x2: 31, y2: 11, opacity: 0.34 },
+      { id: "m-line-2", x1: 31, y1: 11, x2: 49, y2: 19, opacity: 0.28 },
+      { id: "m-line-3", x1: 49, y1: 19, x2: 66, y2: 10, opacity: 0.3 },
+      { id: "m-line-4", x1: 66, y1: 10, x2: 84, y2: 23, opacity: 0.26 },
+    ],
+  },
+  dawn: {
+    baseGlow:
+      "linear-gradient(180deg, rgba(244,114,182,0.16) 0%, rgba(96,165,250,0.08) 42%, transparent 72%), radial-gradient(ellipse at 50% 82%, rgba(251,191,36,0.16), transparent 48%)",
+    particles: MIST_PARTICLES,
+    ribbons: [
+      { id: "d-ribbon-1", path: "M-5 38 C18 20 38 42 58 27 C78 12 94 26 106 12", color: "rgba(244, 114, 182, 0.24)", opacity: 0.8, delay: 0, duration: 10 },
+      { id: "d-ribbon-2", path: "M-6 48 C20 35 32 54 54 39 C76 24 91 42 108 28", color: "rgba(96, 165, 250, 0.2)", opacity: 0.7, delay: 1.4, duration: 12 },
+      { id: "d-ribbon-3", path: "M-4 58 C19 49 40 63 61 50 C82 37 95 52 106 44", color: "rgba(251, 191, 36, 0.14)", opacity: 0.62, delay: 2.5, duration: 11 },
+    ],
+  },
+  sunset: {
+    baseGlow:
+      "radial-gradient(ellipse at 48% 82%, rgba(251,146,60,0.22), transparent 54%), radial-gradient(circle at 82% 22%, rgba(252,211,77,0.14), transparent 28%)",
+    particles: DUST_PARTICLES,
+    rays: [
+      { id: "s-ray-1", left: 8, width: 14, rotate: 16, opacity: 0.2, color: "rgba(252, 211, 77, 0.4)", delay: 0 },
+      { id: "s-ray-2", left: 34, width: 18, rotate: -10, opacity: 0.16, color: "rgba(251, 146, 60, 0.42)", delay: 0.8 },
+      { id: "s-ray-3", left: 67, width: 16, rotate: 12, opacity: 0.14, color: "rgba(244, 114, 182, 0.28)", delay: 1.6 },
+    ],
+  },
+  spring: {
+    baseGlow:
+      "radial-gradient(circle at 18% 24%, rgba(249,168,212,0.16), transparent 26%), radial-gradient(circle at 72% 34%, rgba(167,243,208,0.11), transparent 30%)",
+    particles: PETALS,
+  },
+  summer: {
+    baseGlow:
+      "radial-gradient(circle at 22% 80%, rgba(251,191,36,0.12), transparent 24%), radial-gradient(circle at 76% 28%, rgba(56,189,248,0.14), transparent 32%)",
+    texture:
+      "radial-gradient(circle at 50% 50%, rgba(125,211,252,0.08) 0 1px, transparent 1.5px)",
+    particles: FIREFLIES,
+  },
+  autumn: {
+    baseGlow:
+      "radial-gradient(ellipse at 50% 84%, rgba(217,119,6,0.2), transparent 50%), radial-gradient(circle at 18% 26%, rgba(220,38,38,0.12), transparent 26%)",
+    particles: LEAVES_AND_EMBERS,
+  },
+  winter: {
+    baseGlow:
+      "radial-gradient(circle at 18% 20%, rgba(226,232,240,0.14), transparent 26%), radial-gradient(circle at 78% 72%, rgba(147,197,253,0.12), transparent 32%)",
+    texture:
+      "linear-gradient(135deg, transparent 0 46%, rgba(226,232,240,0.08) 46.4%, transparent 47%), linear-gradient(45deg, transparent 0 64%, rgba(147,197,253,0.07) 64.4%, transparent 65%)",
+    particles: SNOW,
+  },
+};

--- a/src/components/home/HeroSection.tsx
+++ b/src/components/home/HeroSection.tsx
@@ -5,7 +5,7 @@ import Image from "next/image";
 import Link from "next/link";
 import { motion, AnimatePresence } from "framer-motion";
 import { ParticleOverlay } from "@/components/effects/ParticleOverlay";
-import { MysticBackground } from "@/components/effects/MysticBackground";
+import { MysticBackground, ThemeAtmosphere } from "@/components/effects/MysticBackground";
 import { CharacterDisplay } from "@/components/character/CharacterDisplay";
 import { getCharacterById } from "@/data/characters";
 import { useThemeStore, type ThemeId } from "@/hooks/useTheme";
@@ -58,6 +58,7 @@ export function HeroSection() {
       </div>
 
       <ParticleOverlay density={particleDensity} className="z-10" />
+      <ThemeAtmosphere theme={activeTheme} intensity="hero" className="z-[11]" />
       <MysticBackground service="home" />
 
       <div className="flex-1 flex flex-col md:flex-row items-center z-20 px-4 md:px-8">


### PR DESCRIPTION
## Summary
- Add deterministic 7-theme atmospheric art direction: midnight constellations, dawn aurora mist, sunset rays/dust, spring petals, summer fireflies, autumn leaves/embers, and winter snow/frost.
- Layer theme atmosphere into the home hero and service backgrounds while preserving service identity and reduced-motion support.
- Polish transparent character cutout edges with subtle edge-support shadows and reduce large sprite-level blur.
- Apply cutout edge treatment to the direct character profile image.
- Document the design in `docs/superpowers/specs/2026-05-09-theme-atmosphere-character-polish-design.md`.

## Verification
- `pnpm lint`
- `pnpm type-check`
- `pnpm build`
- `pnpm check:doc-links` (exits 0; existing archive link warnings remain)
- `git diff --check`
- Browser: verified home hero theme atmosphere across all 7 themes, summer screenshot review, and `/character/arcana` profile cutout edge treatment. Console errors were 0 after fixing the background/backgroundSize style conflict; existing Next image aspect-ratio warnings remain.

## Spawn Agent Usage
- Worker A implemented character edge polish in `SpriteAnimator` and the character detail page.
- Worker B implemented theme atmosphere config/rendering and service/home integration.