### PR TITLE
fix: extend theme atmosphere to flow screens

### DIFF
--- a/docs/superpowers/specs/2026-05-09-theme-atmosphere-flow-coverage-design.md
+++ b/docs/superpowers/specs/2026-05-09-theme-atmosphere-flow-coverage-design.md
@@ -1,0 +1,31 @@
+# Theme Atmosphere Flow Coverage Design
+
+Date: 2026-05-09
+
+## Root Cause
+
+The theme atmosphere system existed, but coverage was uneven:
+
+- `/tarot`, `/saju`, and `/shinjeom` entry pages received theme atmosphere only through `ServiceBackground`, with a low service opacity that made the effect easy to miss.
+- `/character/[id]`, which also works as a counselor/service selection screen, still used only a static background plus generic particles.
+- Tarot, saju, and shinjeom session pages used `MysticBackground` but did not render active-theme atmosphere.
+
+## Fix Direction
+
+- Make `ThemeAtmosphere` testable with stable `data-testid`, theme, and intensity attributes.
+- Increase service-page atmosphere intensity enough to be visible while preserving service-specific backgrounds.
+- Add theme atmosphere to `/character/[id]`.
+- Add low-intensity ambient theme atmosphere to tarot, saju, and shinjeom session pages.
+- Add Playwright structural coverage for counselor selection, category selection, and tarot spread selection steps.
+
+## Verification Strategy
+
+Visual effects should not rely on screenshot diffs. The regression test checks that:
+
+- A fixed service background exists.
+- The expected atmosphere layer is attached.
+- The layer carries the active theme id.
+- Decorative particle nodes render under the atmosphere layer.
+- The layer persists after step transitions.
+
+Manual browser review remains useful for judging taste/readability after the structural test proves the effect is wired.

--- a/e2e/theme-atmosphere.spec.ts
+++ b/e2e/theme-atmosphere.spec.ts
@@ -1,0 +1,75 @@
+import { expect, test, type Page } from "@playwright/test";
+
+async function forceTheme(page: Page, theme = "winter") {
+  await page.addInitScript((themeId) => {
+    window.localStorage.setItem("arcana-theme-mode", themeId);
+  }, theme);
+  await page.emulateMedia({ reducedMotion: "reduce" });
+}
+
+async function expectAtmosphere(page: Page, testId: string, theme = "winter") {
+  const atmosphere = page.locator(`[data-testid="${testId}"]`);
+  await expect(atmosphere).toBeAttached({ timeout: 5_000 });
+  await expect(atmosphere).toHaveAttribute("data-theme-atmosphere", theme);
+  await expect(atmosphere.locator("span.absolute.block").first()).toBeAttached({ timeout: 5_000 });
+}
+
+async function selectFirstCounselor(page: Page) {
+  const cards = page.locator("button").filter({ hasText: /아르카나|미코|선화|루나/ });
+  await expect(cards.first()).toBeVisible({ timeout: 10_000 });
+  await cards.first().click();
+}
+
+test.describe("테마 atmosphere 적용 범위", () => {
+  test("타로 상담사/카테고리/리딩 방식 선택 단계에 테마 atmosphere가 유지된다", async ({ page }) => {
+    await forceTheme(page);
+    await page.goto("/tarot");
+
+    await expectAtmosphere(page, "service-theme-atmosphere-tarot");
+    await selectFirstCounselor(page);
+
+    await expect(page.locator("[data-testid='topic-btn-general']")).toBeVisible({ timeout: 5_000 });
+    await expectAtmosphere(page, "service-theme-atmosphere-tarot");
+
+    await page.locator("[data-testid='topic-btn-general']").click();
+    await expect(page.locator("[data-testid='spread-btn-one-card']")).toBeVisible({ timeout: 5_000 });
+    await expectAtmosphere(page, "service-theme-atmosphere-tarot");
+  });
+
+  test("사주 상담사/리딩 카테고리 선택 단계에 테마 atmosphere가 유지된다", async ({ page }) => {
+    await forceTheme(page);
+    await page.goto("/saju");
+
+    await expectAtmosphere(page, "service-theme-atmosphere-saju");
+    await selectFirstCounselor(page);
+
+    await page.locator("input[type='date']").fill("1995-06-15");
+    await page.getByRole("button", { name: "여성" }).click();
+    const hourSelect = page.locator("select");
+    if (await hourSelect.isVisible()) await hourSelect.selectOption({ index: 1 });
+    await page.locator("button").filter({ hasText: /시작|다음|확인/ }).last().click();
+
+    await expect(page.locator("[data-testid^='saju-time-btn-']").first()).toBeVisible({ timeout: 5_000 });
+    await expect(page.locator("[data-testid^='saju-area-btn-']").first()).toBeVisible({ timeout: 5_000 });
+    await expectAtmosphere(page, "service-theme-atmosphere-saju");
+  });
+
+  test("신점 상담사/리딩 카테고리 선택 단계에 테마 atmosphere가 유지된다", async ({ page }) => {
+    await forceTheme(page);
+    await page.goto("/shinjeom");
+
+    await expectAtmosphere(page, "service-theme-atmosphere-shinjeom");
+    await selectFirstCounselor(page);
+
+    await expect(page.locator("[data-testid^='shinjeom-topic-btn-']").first()).toBeVisible({ timeout: 5_000 });
+    await expectAtmosphere(page, "service-theme-atmosphere-shinjeom");
+  });
+
+  test("캐릭터 상세 서비스 선택 화면에도 테마 atmosphere가 적용된다", async ({ page }) => {
+    await forceTheme(page, "spring");
+    await page.goto("/character/arcana");
+
+    await expect(page.getByRole("heading", { name: "아르카나" })).toBeVisible({ timeout: 5_000 });
+    await expectAtmosphere(page, "character-theme-atmosphere", "spring");
+  });
+});

--- a/src/app/character/[id]/page.tsx
+++ b/src/app/character/[id]/page.tsx
@@ -9,6 +9,8 @@ import { useLocaleStore } from "@/hooks/useLocaleStore";
 import { useT } from "@/i18n/useT";
 import { ParticleOverlay } from "@/components/effects/ParticleOverlay";
 import { getCharacterCutoutImageStyle } from "@/components/character/SpriteAnimator";
+import { ThemeAtmosphere } from "@/components/effects/MysticBackground";
+import { useThemeStore } from "@/hooks/useTheme";
 
 const SERVICE_IDS = [
   { id: "tarot",    icon: "🃏" },
@@ -22,6 +24,7 @@ export default function CharacterPage() {
   const router = useRouter();
   const locale = useLocaleStore((s) => s.locale);
   const { t } = useT();
+  const { activeTheme } = useThemeStore();
   const id = typeof params.id === "string" ? params.id : "";
   const character = getCharacterById(id);
 
@@ -47,6 +50,7 @@ export default function CharacterPage() {
       <div className="fixed inset-0 -z-10">
         <Image src="/images/backgrounds/tarot-topic-bg.jpg" alt="" fill className="object-cover"  sizes="100vw" />
         <div className="absolute inset-0 bg-arcana-bg/60" />
+        <ThemeAtmosphere theme={activeTheme} intensity="service" className="mix-blend-screen" testId="character-theme-atmosphere" />
       </div>
       <ParticleOverlay density="low" className="z-10" />
 

--- a/src/app/saju/session/page.tsx
+++ b/src/app/saju/session/page.tsx
@@ -13,7 +13,7 @@ import { useCharacterStore } from "@/hooks/useCharacter";
 import { CharacterDisplay } from "@/components/character/CharacterDisplay";
 import { DialogueBox } from "@/components/chat/DialogueBox";
 import { ParticleOverlay } from "@/components/effects/ParticleOverlay";
-import { MysticBackground } from "@/components/effects/MysticBackground";
+import { MysticBackground, ThemeAtmosphere } from "@/components/effects/MysticBackground";
 import { SajuChart } from "@/components/saju/SajuChart";
 import { OhaengGraph } from "@/components/saju/OhaengGraph";
 import { DaeunTimeline } from "@/components/saju/DaeunTimeline";
@@ -24,6 +24,7 @@ import { useLocaleStore } from "@/hooks/useLocaleStore";
 import { useT } from "@/i18n/useT";
 import { t as translate } from "@/i18n/translations";
 import type { Locale } from "@/i18n/config";
+import { useThemeStore } from "@/hooks/useTheme";
 
 const SITE_NAME = "ArcanaInsight";
 
@@ -230,6 +231,7 @@ export default function SajuSessionPage() {
   }, []);
 
   const birthYear = userInfo ? parseInt(userInfo.birthDate.split("-")[0]) : 2000;
+  const { activeTheme } = useThemeStore();
 
   return (
     <div className="relative h-[calc(100dvh-7rem)] md:h-[calc(100dvh-3.5rem)] flex flex-col overflow-hidden">
@@ -239,6 +241,7 @@ export default function SajuSessionPage() {
       </div>
       <ParticleOverlay density={phase === "reading" ? "medium" : "low"} className="z-10" />
       <MysticBackground service="saju" />
+      <ThemeAtmosphere theme={activeTheme} intensity="ambient" className="z-[6] mix-blend-screen" testId="session-theme-atmosphere-saju" />
 
       <div className="relative flex-1 min-h-0 flex flex-col md:flex-row z-20">
         {/* 좌측 컬럼: 캐릭터 + 대사 */}

--- a/src/app/shinjeom/session/page.tsx
+++ b/src/app/shinjeom/session/page.tsx
@@ -7,7 +7,7 @@ import { motion, AnimatePresence } from "framer-motion";
 import { useShinjeomSessionStore } from "@/hooks/useShinjeomSession";
 import { CharacterDisplay } from "@/components/character/CharacterDisplay";
 import { ParticleOverlay } from "@/components/effects/ParticleOverlay";
-import { MysticBackground } from "@/components/effects/MysticBackground";
+import { MysticBackground, ThemeAtmosphere } from "@/components/effects/MysticBackground";
 import { ReadingText } from "@/components/common/ReadingText";
 import { getCharacterById } from "@/data/characters";
 import { useCharacterStore } from "@/hooks/useCharacter";
@@ -18,6 +18,7 @@ import { useLocaleStore } from "@/hooks/useLocaleStore";
 import { useT } from "@/i18n/useT";
 import { t as translate } from "@/i18n/translations";
 import { fetchSSEStream } from "@/hooks/useSSEStream";
+import { useThemeStore } from "@/hooks/useTheme";
 
 function getErrorMsg(charId: string | null | undefined, type: "api" | "reading"): string {
   const wl = getWaitingLinesData(useLocaleStore.getState().locale);
@@ -236,6 +237,7 @@ export default function ShinjeomSessionPage() {
     });
   };
 
+  const { activeTheme } = useThemeStore();
   if (!character) return null;
 
   return (
@@ -246,6 +248,7 @@ export default function ShinjeomSessionPage() {
       </div>
       <ParticleOverlay density="low" className="z-10" />
       <MysticBackground service="shinjeom" />
+      <ThemeAtmosphere theme={activeTheme} intensity="ambient" className="z-[6] mix-blend-screen" testId="session-theme-atmosphere-shinjeom" />
 
       <div className="relative flex-1 min-h-0 flex flex-col md:flex-row z-20">
         {/* 캐릭터 */}

--- a/src/app/tarot/session/page.tsx
+++ b/src/app/tarot/session/page.tsx
@@ -29,7 +29,7 @@ const ReadingProgressIndicator = dynamic(
   { loading: () => null },
 );
 import { ParticleOverlay } from "@/components/effects/ParticleOverlay";
-import { MysticBackground } from "@/components/effects/MysticBackground";
+import { MysticBackground, ThemeAtmosphere } from "@/components/effects/MysticBackground";
 import { getCharacterById } from "@/data/characters";
 import { CHARACTER_RESULT_MOODS } from "@/data/characters/waiting-lines";
 import { getWaitingLinesData } from "@/data/characters/waiting-lines-i18n";
@@ -43,6 +43,7 @@ import { ReadingResult } from "@/types/service";
 import { SpreadDefinition, ChatMessage } from "@/types/session";
 import { fetchSSEStream } from "@/hooks/useSSEStream";
 import { useT } from "@/i18n/useT";
+import { useThemeStore } from "@/hooks/useTheme";
 import { t as translate } from "@/i18n/translations";
 import type { Locale } from "@/i18n/config";
 
@@ -556,6 +557,7 @@ export default function TarotSessionPage() {
   const particleDensityMap: Record<string, "low" | "medium" | "high"> = { reading: "medium", result: "low" };
   const particleDensity = particleDensityMap[phase] ?? "medium";
   const effectTheme = character?.effectTheme;
+  const { activeTheme } = useThemeStore();
 
   return (
     <div className="relative h-[calc(100dvh-7rem)] md:h-[calc(100dvh-3.5rem)] flex flex-col overflow-hidden">
@@ -576,6 +578,7 @@ export default function TarotSessionPage() {
         className="z-10"
       />
       <MysticBackground service="tarot" />
+      <ThemeAtmosphere theme={activeTheme} intensity="ambient" className="z-[6] mix-blend-screen" testId="session-theme-atmosphere-tarot" />
 
       {/* 무대: 모바일 세로 / 데스크탑 가로 5:5 */}
       <div className="relative flex-1 min-h-0 flex flex-col md:flex-row z-20">

--- a/src/components/effects/MysticBackground.tsx
+++ b/src/components/effects/MysticBackground.tsx
@@ -14,8 +14,9 @@ interface MysticBackgroundProps {
 
 interface ThemeAtmosphereProps {
   readonly theme: ThemeId;
-  readonly intensity?: "hero" | "service";
+  readonly intensity?: "hero" | "service" | "ambient";
   readonly className?: string;
+  readonly testId?: string;
 }
 
 const MIST_COLOR: Record<Service, string> = {
@@ -63,7 +64,8 @@ const RUNE_POSITIONS = [
 
 const INTENSITY_OPACITY: Record<NonNullable<ThemeAtmosphereProps["intensity"]>, number> = {
   hero: 1,
-  service: 0.56,
+  service: 0.74,
+  ambient: 0.46,
 };
 
 function particleStyle(particle: AtmosphereParticle): CSSProperties {
@@ -201,7 +203,7 @@ function particleMotion(particle: AtmosphereParticle, shouldReduceMotion: boolea
   };
 }
 
-export function ThemeAtmosphere({ theme, intensity = "hero", className = "" }: ThemeAtmosphereProps) {
+export function ThemeAtmosphere({ theme, intensity = "hero", className = "", testId }: ThemeAtmosphereProps) {
   const shouldReduceMotion = useReducedMotion();
   const config = THEME_ATMOSPHERES[theme];
   const opacity = INTENSITY_OPACITY[intensity];
@@ -211,6 +213,9 @@ export function ThemeAtmosphere({ theme, intensity = "hero", className = "" }: T
       className={`absolute inset-0 overflow-hidden pointer-events-none ${className}`}
       style={{ opacity }}
       aria-hidden
+      data-testid={testId ?? `theme-atmosphere-${theme}`}
+      data-theme-atmosphere={theme}
+      data-theme-atmosphere-intensity={intensity}
     >
       <motion.div
         className="absolute inset-0"

--- a/src/components/effects/ServiceBackground.tsx
+++ b/src/components/effects/ServiceBackground.tsx
@@ -106,11 +106,11 @@ export function ServiceBackground({ service }: ServiceBackgroundProps) {
   const shouldReduceMotion = Boolean(useReducedMotion());
 
   return (
-    <div className="fixed inset-0 -z-10 overflow-hidden pointer-events-none" aria-hidden>
+    <div className="fixed inset-0 -z-10 overflow-hidden pointer-events-none" aria-hidden data-testid={`service-background-${service}`}>
       {service === "tarot" && <TarotBackground shouldReduceMotion={shouldReduceMotion} />}
       {service === "saju" && <SajuBackground shouldReduceMotion={shouldReduceMotion} />}
       {service === "shinjeom" && <ShinjeomBackground shouldReduceMotion={shouldReduceMotion} />}
-      <ThemeAtmosphere theme={activeTheme} intensity="service" className="mix-blend-screen" />
+      <ThemeAtmosphere theme={activeTheme} intensity="service" className="mix-blend-screen" testId={`service-theme-atmosphere-${service}`} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Extend theme atmosphere coverage to flow screens and reading sessions.
- Increase service-page atmosphere visibility while preserving service backgrounds.
- Add stable `data-testid` and theme/intensity attributes to `ThemeAtmosphere` for operational verification.
- Add active theme atmosphere to `/character/[id]` service chooser and tarot/saju/shinjeom session pages.
- Add Playwright regression coverage for counselor selection, category selection, tarot spread selection, and character service chooser.

## Root Cause
- Service entry pages only received subtle theme atmosphere indirectly through `ServiceBackground`.
- `/character/[id]` used a static background and generic particles only.
- Session pages used `MysticBackground` but did not render active-theme atmosphere.

## Verification
- `pnpm lint`
- `pnpm type-check`
- `pnpm exec playwright test e2e/theme-atmosphere.spec.ts --reporter=line` (12 passed across Desktop Chrome, Mobile Android, Mobile iOS)
- `pnpm check:doc-links` (exits 0; existing archive link warnings remain)
- `git diff --check`
- `pnpm build`

## Spawn Agent Usage
- Explorer 1 mapped flow files and identified missing/uneven atmosphere coverage.
- Explorer 2 designed robust structural Playwright verification for theme atmosphere presence without brittle screenshots.