### PR TITLE
feat: card-style 이미지 Supabase Storage 서빙 전환

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,17 +31,23 @@
 src/
 ├── app/             # App Router 페이지와 API
 ├── components/      # card, character, chat, common, effects, home, layout, saju, shinjeom, skin, tarot
+│   └── card/        # CardFace, CardBack, CardItem, CardStyleSelector (스타일 선택 UI)
 ├── data/            # cards, characters, home, saju, shinjeom, skins, spreads, topics
+│   └── cardStyles.ts  # CardStyleId, 4가지 아트 스타일, THEME_TO_STYLE_MAP
 ├── hooks/           # Zustand store와 UI/streaming hooks
+│   └── useCardStyleStore.ts  # 카드 스타일 persist 스토어 (arcana-card-style)
 ├── i18n/            # locale 감지, Provider, useT, translations
 ├── lib/             # env, auth, db, storage, validation, request/rate-limit 유틸
+│   └── storage/card-style.ts  # getCardStyleImageUrl, getCardStyleBackUrl
 ├── services/        # core AI provider/fallback + tarot/saju/shinjeom 서비스
 ├── test-helpers/    # Vitest 공통 mock/setup
 └── types/           # 공유 타입
 
 docs/                # architecture, conventions, workflow, operations, archive
 e2e/                 # Playwright specs
-scripts/e2e-full/    # E2E 전수 검증 오케스트레이터
+scripts/
+├── e2e-full/        # E2E 전수 검증 오케스트레이터
+└── generate-assets/ # Replicate API 이미지 생성 (카드·배경·데코 341장)
 supabase/migrations/ # Supabase SQL migrations
 ```
 
@@ -52,6 +58,7 @@ supabase/migrations/ # Supabase SQL migrations
 - API 보안: Rate Limit -> Zod `safeParse` -> Auth -> 소유권 검증 순서. 새 API는 [`docs/conventions/zod-schemas.md`](docs/conventions/zod-schemas.md)를 먼저 확인.
 - SSE 스트리밍: 타로/사주/신점 리딩은 `SSE_HEADERS`, `fetchSSEStream()`, `AbortController` 패턴을 사용. 상세는 [`docs/architecture/ai-infrastructure.md`](docs/architecture/ai-infrastructure.md).
 - i18n: `middleware`가 locale을 결정하고 `x-locale` 헤더와 쿠키를 유지. 상세는 [`docs/architecture/i18n.md`](docs/architecture/i18n.md), [`docs/conventions/i18n-style.md`](docs/conventions/i18n-style.md).
+- 카드 아트 스타일: `CardStyleId`(dark-fantasy·art-nouveau·anime-mystical·modern-digital), `THEME_TO_STYLE_MAP`으로 테마 자동 매핑. `useCardStyleStore`가 사용자 override를 persist. `CardFace`/`CardBack`/`CardItem`은 styleId → skinId → SVG 순으로 이미지 우선순위 처리.
 
 ## 캐릭터/데이터 기준
 
@@ -75,6 +82,8 @@ pnpm sync:test-count      # 고정 테스트 수가 있는 문서 동기화
 pnpm check:env-docs       # env.ts와 env 문서 정합성
 pnpm check:doc-links      # 문서 링크 검증
 pnpm i18n:check           # 번역 키 drift 검출
+pnpm generate:assets      # Replicate API로 카드/배경/데코 이미지 생성 (REPLICATE_API_KEY 필요)
+pnpm generate:assets:skip # 이미 존재하는 이미지 건너뛰고 생성
 ```
 
 명령어 정책은 [`docs/workflow/scripts.md`](docs/workflow/scripts.md), 테스트 정책은 [`docs/workflow/unit-testing.md`](docs/workflow/unit-testing.md), [`docs/workflow/e2e-testing.md`](docs/workflow/e2e-testing.md)를 따른다.
@@ -106,6 +115,7 @@ pnpm i18n:check           # 번역 키 drift 검출
 - i18n: UI 텍스트는 번역 키를 우선 추가하고 `t()`/`useT()`로 노출한다.
 - 테스트 파일: API 라우트 테스트는 `src/__tests__/api/`에 둔다.
 - 패키지 추가: `pnpm-lock.yaml` 변동과 peer dependency 변화를 확인한다.
+- SonarCloud 동기화: 새 TS 파일 추가 시 `sonar.coverage.exclusions`와 `sonar.cpd.exclusions`를 `sonar-project.properties`에 함께 추가한다.
 
 ## 업무별 진입점
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,9 @@
     "sync:test-count": "tsx scripts/sync-test-count.ts",
     "download:skins": "tsx --env-file=.env.local scripts/download-skin-images.ts",
     "generate:assets": "npx tsx scripts/generate-assets/index.ts",
-    "generate:assets:skip": "npx tsx scripts/generate-assets/index.ts --skip-existing"
+    "generate:assets:skip": "npx tsx scripts/generate-assets/index.ts --skip-existing",
+    "upload:assets": "npx tsx scripts/generate-assets/upload-to-supabase.ts",
+    "upload:assets:skip": "npx tsx scripts/generate-assets/upload-to-supabase.ts --skip-existing"
   },
   "dependencies": {
     "@supabase/ssr": "^0.9.0",

--- a/scripts/generate-assets/config.ts
+++ b/scripts/generate-assets/config.ts
@@ -1,6 +1,6 @@
 export const REPLICATE_MODEL = 'black-forest-labs/flux-1.1-pro-ultra';
-export const CONCURRENT_JOBS = 5;
-export const OUTPUT_FORMAT = 'webp' as const;
+export const CONCURRENT_JOBS = 1;
+export const OUTPUT_FORMAT = 'png' as const;
 export const OUTPUT_BASE_DIR = 'public/images/cards';
 export const BACKGROUNDS_DIR = 'public/images/backgrounds';
 export const BACKUP_DIR = `public/images/backup/${new Date().toISOString().slice(0, 10)}`;

--- a/scripts/generate-assets/index.ts
+++ b/scripts/generate-assets/index.ts
@@ -1,3 +1,6 @@
+import { config } from 'dotenv';
+config({ path: '.env.local' });
+
 import * as fs from 'fs';
 import * as path from 'path';
 import {
@@ -58,7 +61,7 @@ function buildAllCardTargets(): CardTarget[] {
         suit: 'major',
         number,
         cardName,
-        outputPath: path.join(OUTPUT_BASE_DIR, styleId, 'major', `${number}.webp`),
+        outputPath: path.join(OUTPUT_BASE_DIR, styleId, 'major', `${number}.png`),
       });
     }
 
@@ -71,7 +74,7 @@ function buildAllCardTargets(): CardTarget[] {
           suit,
           number,
           cardName,
-          outputPath: path.join(OUTPUT_BASE_DIR, styleId, suit, `${number}.webp`),
+          outputPath: path.join(OUTPUT_BASE_DIR, styleId, suit, `${number}.png`),
         });
       }
     }
@@ -97,7 +100,7 @@ function buildAllBackgroundTargets(): BackgroundTarget[] {
       targets.push({
         service,
         theme,
-        outputPath: path.join(BACKGROUNDS_DIR, service, `${theme}.webp`),
+        outputPath: path.join(BACKGROUNDS_DIR, service, `${theme}.png`),
       });
     }
   }
@@ -108,7 +111,7 @@ function buildAllBackgroundTargets(): BackgroundTarget[] {
 function buildAllDecoTargets(): DecoTarget[] {
   return STYLE_IDS.map((styleId) => ({
     styleId,
-    outputPath: path.join(BACKGROUNDS_DIR, 'deco', `${styleId}.webp`),
+    outputPath: path.join(BACKGROUNDS_DIR, 'deco', `${styleId}.png`),
   }));
 }
 
@@ -183,7 +186,9 @@ async function main(): Promise<void> {
       const { label } = await task();
       tracker.tick(true, label);
     } catch (err) {
-      tracker.tick(false, String(err));
+      const msg = err instanceof Error ? err.message : String(err);
+      process.stderr.write(`\nERROR: ${msg}\n`);
+      tracker.tick(false, msg);
     }
   });
 

--- a/scripts/generate-assets/replicate.ts
+++ b/scripts/generate-assets/replicate.ts
@@ -5,12 +5,13 @@ import * as https from 'https';
 import * as http from 'http';
 import { REPLICATE_MODEL, OUTPUT_FORMAT } from './config';
 
-const apiKey = process.env.REPLICATE_API_KEY;
-if (!apiKey) {
-  throw new Error('REPLICATE_API_KEY 환경변수가 설정되지 않았습니다.');
+function getClient(): Replicate {
+  const apiKey = process.env.REPLICATE_API_KEY;
+  if (!apiKey) {
+    throw new Error('REPLICATE_API_KEY 환경변수가 설정되지 않았습니다. .env.local 파일을 확인하세요.');
+  }
+  return new Replicate({ auth: apiKey });
 }
-
-const replicate = new Replicate({ auth: apiKey });
 
 async function downloadImage(url: string, outputPath: string): Promise<void> {
   const dir = path.dirname(outputPath);
@@ -38,13 +39,18 @@ async function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+function parseRetryAfter(err: Error): number | null {
+  const match = err.message.match(/"retry_after"\s*:\s*(\d+)/);
+  return match ? parseInt(match[1], 10) : null;
+}
+
 export async function generateImage(prompt: string, outputPath: string): Promise<void> {
-  const maxRetries = 3;
+  const maxRetries = 5;
   let lastError: Error | null = null;
 
   for (let attempt = 1; attempt <= maxRetries; attempt++) {
     try {
-      const output = await replicate.run(REPLICATE_MODEL, {
+      const output = await getClient().run(REPLICATE_MODEL, {
         input: {
           prompt,
           output_format: OUTPUT_FORMAT,
@@ -64,8 +70,11 @@ export async function generateImage(prompt: string, outputPath: string): Promise
     } catch (err) {
       lastError = err instanceof Error ? err : new Error(String(err));
       if (attempt < maxRetries) {
-        const delayMs = Math.pow(2, attempt - 1) * 1000;
-        console.warn(`  [재시도 ${attempt}/${maxRetries}] ${delayMs}ms 후 재시도 중...`);
+        const retryAfter = parseRetryAfter(lastError);
+        const delayMs = retryAfter != null
+          ? (retryAfter + 1) * 1000
+          : Math.pow(2, attempt) * 1000;
+        console.warn(`  [재시도 ${attempt}/${maxRetries}] ${delayMs / 1000}s 후 재시도 중...`);
         await sleep(delayMs);
       }
     }

--- a/scripts/generate-assets/upload-to-supabase.ts
+++ b/scripts/generate-assets/upload-to-supabase.ts
@@ -1,0 +1,177 @@
+import { config } from 'dotenv';
+config({ path: '.env.local' });
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { createClient } from '@supabase/supabase-js';
+import { ProgressTracker, runConcurrent } from './progress';
+
+const BUCKET = 'card-styles';
+const CONCURRENT_UPLOADS = 5;
+const SKIP_EXISTING = process.argv.includes('--skip-existing');
+
+const CARDS_DIR = 'public/images/cards';
+const BACKGROUNDS_DIR = 'public/images/backgrounds';
+
+function getSupabaseAdmin() {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) {
+    throw new Error('NEXT_PUBLIC_SUPABASE_URL 또는 SUPABASE_SERVICE_ROLE_KEY가 설정되지 않았습니다.');
+  }
+  return createClient(url, key);
+}
+
+async function ensureBucket(supabase: ReturnType<typeof createClient>): Promise<void> {
+  const { data: buckets } = await supabase.storage.listBuckets();
+  const exists = buckets?.some((b) => b.name === BUCKET);
+  if (!exists) {
+    const { error } = await supabase.storage.createBucket(BUCKET, { public: true });
+    if (error) throw new Error(`버킷 생성 실패: ${error.message}`);
+    console.log(`버킷 '${BUCKET}' 생성 완료.`);
+  } else {
+    console.log(`버킷 '${BUCKET}' 이미 존재.`);
+  }
+}
+
+interface UploadTarget {
+  localPath: string;
+  storagePath: string;
+}
+
+function collectCardTargets(): UploadTarget[] {
+  const targets: UploadTarget[] = [];
+  if (!fs.existsSync(CARDS_DIR)) return targets;
+
+  for (const styleId of fs.readdirSync(CARDS_DIR)) {
+    const styleDir = path.join(CARDS_DIR, styleId);
+    if (!fs.statSync(styleDir).isDirectory()) continue;
+
+    for (const item of fs.readdirSync(styleDir)) {
+      const itemPath = path.join(styleDir, item);
+      const stat = fs.statSync(itemPath);
+
+      if (stat.isDirectory()) {
+        for (const file of fs.readdirSync(itemPath)) {
+          if (!file.endsWith('.png')) continue;
+          targets.push({
+            localPath: path.join(itemPath, file),
+            storagePath: `cards/${styleId}/${item}/${file}`,
+          });
+        }
+      } else if (item.endsWith('.png')) {
+        targets.push({
+          localPath: itemPath,
+          storagePath: `cards/${styleId}/${item}`,
+        });
+      }
+    }
+  }
+  return targets;
+}
+
+function collectBackgroundTargets(): UploadTarget[] {
+  const targets: UploadTarget[] = [];
+  if (!fs.existsSync(BACKGROUNDS_DIR)) return targets;
+
+  function walk(dir: string, prefix: string): void {
+    for (const item of fs.readdirSync(dir)) {
+      const fullPath = path.join(dir, item);
+      const stat = fs.statSync(fullPath);
+      if (stat.isDirectory()) {
+        walk(fullPath, `${prefix}/${item}`);
+      } else if (item.endsWith('.png') || item.endsWith('.webp') || item.endsWith('.jpg')) {
+        targets.push({
+          localPath: fullPath,
+          storagePath: `backgrounds${prefix}/${item}`,
+        });
+      }
+    }
+  }
+
+  walk(BACKGROUNDS_DIR, '');
+  return targets;
+}
+
+async function uploadFile(
+  supabase: ReturnType<typeof createClient>,
+  target: UploadTarget
+): Promise<void> {
+  const fileBuffer = fs.readFileSync(target.localPath);
+  const ext = path.extname(target.localPath).slice(1);
+  const contentType = ext === 'png' ? 'image/png' : ext === 'jpg' ? 'image/jpeg' : 'image/webp';
+
+  const { error } = await supabase.storage
+    .from(BUCKET)
+    .upload(target.storagePath, fileBuffer, {
+      contentType,
+      upsert: true,
+    });
+
+  if (error) throw new Error(error.message);
+}
+
+async function main(): Promise<void> {
+  console.log('=== Supabase Storage 업로드 시작 ===');
+  console.log(`버킷: ${BUCKET}`);
+  console.log(`기존 파일 스킵: ${SKIP_EXISTING}`);
+
+  const supabase = getSupabaseAdmin();
+  await ensureBucket(supabase);
+
+  const cardTargets = collectCardTargets();
+  const bgTargets = collectBackgroundTargets();
+  const allTargets = [...cardTargets, ...bgTargets];
+
+  console.log(`\n총 업로드 대상: ${allTargets.length}개`);
+
+  let skipped = 0;
+  const toUpload: UploadTarget[] = [];
+
+  if (SKIP_EXISTING) {
+    console.log('기존 파일 확인 중...');
+    const { data: existing } = await supabase.storage.from(BUCKET).list('cards', { limit: 9999 });
+    const existingPaths = new Set(existing?.map((f) => f.name) ?? []);
+
+    for (const t of allTargets) {
+      const fileName = path.basename(t.storagePath);
+      if (existingPaths.has(fileName)) {
+        skipped++;
+      } else {
+        toUpload.push(t);
+      }
+    }
+    console.log(`스킵: ${skipped}개 | 업로드 예정: ${toUpload.length}개`);
+  } else {
+    toUpload.push(...allTargets);
+  }
+
+  if (toUpload.length === 0) {
+    console.log('업로드할 파일이 없습니다.');
+    return;
+  }
+
+  const tracker = new ProgressTracker(toUpload.length);
+  console.log('업로드 시작...\n');
+
+  const tasks = toUpload.map((target) => async () => {
+    try {
+      await uploadFile(supabase, target);
+      tracker.tick(true, target.storagePath);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      process.stderr.write(`\nERROR [${target.storagePath}]: ${msg}\n`);
+      tracker.tick(false, target.storagePath);
+    }
+  });
+
+  await runConcurrent(tasks, CONCURRENT_UPLOADS);
+  tracker.summary();
+
+  console.log(`\nCDN base URL: ${process.env.NEXT_PUBLIC_SUPABASE_URL}/storage/v1/object/public/${BUCKET}`);
+}
+
+main().catch((err) => {
+  console.error('업로드 중 치명적 오류:', err);
+  process.exit(1);
+});

--- a/scripts/generate-assets/upload-to-supabase.ts
+++ b/scripts/generate-assets/upload-to-supabase.ts
@@ -22,7 +22,9 @@ function getSupabaseAdmin() {
   return createClient(url, key);
 }
 
-async function ensureBucket(supabase: ReturnType<typeof createClient>): Promise<void> {
+type SupabaseAdminClient = ReturnType<typeof getSupabaseAdmin>;
+
+async function ensureBucket(supabase: SupabaseAdminClient): Promise<void> {
   const { data: buckets } = await supabase.storage.listBuckets();
   const exists = buckets?.some((b) => b.name === BUCKET);
   if (!exists) {
@@ -94,7 +96,7 @@ function collectBackgroundTargets(): UploadTarget[] {
 }
 
 async function uploadFile(
-  supabase: ReturnType<typeof createClient>,
+  supabase: SupabaseAdminClient,
   target: UploadTarget
 ): Promise<void> {
   const fileBuffer = fs.readFileSync(target.localPath);

--- a/src/__tests__/lib/storage/card-style.test.ts
+++ b/src/__tests__/lib/storage/card-style.test.ts
@@ -7,37 +7,37 @@ import {
 describe('getCardStyleImageUrl', () => {
   it('Major Arcana 카드 URL을 올바르게 반환한다', () => {
     expect(getCardStyleImageUrl('dark-fantasy', 'major-00')).toBe(
-      '/images/cards/dark-fantasy/major/00.webp'
+      '/images/cards/dark-fantasy/major/00.png'
     );
     expect(getCardStyleImageUrl('dark-fantasy', 'major-21')).toBe(
-      '/images/cards/dark-fantasy/major/21.webp'
+      '/images/cards/dark-fantasy/major/21.png'
     );
   });
 
   it('Cups 슈트 카드 URL을 올바르게 반환한다', () => {
     expect(getCardStyleImageUrl('art-nouveau', 'cups-01')).toBe(
-      '/images/cards/art-nouveau/cups/01.webp'
+      '/images/cards/art-nouveau/cups/01.png'
     );
     expect(getCardStyleImageUrl('art-nouveau', 'cups-14')).toBe(
-      '/images/cards/art-nouveau/cups/14.webp'
+      '/images/cards/art-nouveau/cups/14.png'
     );
   });
 
   it('Wands 슈트 카드 URL을 올바르게 반환한다', () => {
     expect(getCardStyleImageUrl('anime-mystical', 'wands-07')).toBe(
-      '/images/cards/anime-mystical/wands/07.webp'
+      '/images/cards/anime-mystical/wands/07.png'
     );
   });
 
   it('Swords 슈트 카드 URL을 올바르게 반환한다', () => {
     expect(getCardStyleImageUrl('modern-digital', 'swords-10')).toBe(
-      '/images/cards/modern-digital/swords/10.webp'
+      '/images/cards/modern-digital/swords/10.png'
     );
   });
 
   it('Pentacles 슈트 카드 URL을 올바르게 반환한다', () => {
     expect(getCardStyleImageUrl('dark-fantasy', 'pentacles-14')).toBe(
-      '/images/cards/dark-fantasy/pentacles/14.webp'
+      '/images/cards/dark-fantasy/pentacles/14.png'
     );
   });
 
@@ -51,10 +51,10 @@ describe('getCardStyleImageUrl', () => {
 describe('getCardStyleBackUrl', () => {
   it('카드 뒷면 URL을 올바르게 반환한다', () => {
     expect(getCardStyleBackUrl('dark-fantasy')).toBe(
-      '/images/cards/dark-fantasy/card-back.webp'
+      '/images/cards/dark-fantasy/card-back.png'
     );
     expect(getCardStyleBackUrl('anime-mystical')).toBe(
-      '/images/cards/anime-mystical/card-back.webp'
+      '/images/cards/anime-mystical/card-back.png'
     );
   });
 });

--- a/src/__tests__/lib/storage/card-style.test.ts
+++ b/src/__tests__/lib/storage/card-style.test.ts
@@ -1,43 +1,50 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeAll } from 'vitest';
 import {
   getCardStyleImageUrl,
   getCardStyleBackUrl,
 } from '@/lib/storage/card-style';
 
+const SUPABASE_URL = 'https://test.supabase.co';
+const BASE = `${SUPABASE_URL}/storage/v1/object/public/card-styles`;
+
+beforeAll(() => {
+  process.env.NEXT_PUBLIC_SUPABASE_URL = SUPABASE_URL;
+});
+
 describe('getCardStyleImageUrl', () => {
   it('Major Arcana 카드 URL을 올바르게 반환한다', () => {
     expect(getCardStyleImageUrl('dark-fantasy', 'major-00')).toBe(
-      '/images/cards/dark-fantasy/major/00.png'
+      `${BASE}/cards/dark-fantasy/major/00.png`
     );
     expect(getCardStyleImageUrl('dark-fantasy', 'major-21')).toBe(
-      '/images/cards/dark-fantasy/major/21.png'
+      `${BASE}/cards/dark-fantasy/major/21.png`
     );
   });
 
   it('Cups 슈트 카드 URL을 올바르게 반환한다', () => {
     expect(getCardStyleImageUrl('art-nouveau', 'cups-01')).toBe(
-      '/images/cards/art-nouveau/cups/01.png'
+      `${BASE}/cards/art-nouveau/cups/01.png`
     );
     expect(getCardStyleImageUrl('art-nouveau', 'cups-14')).toBe(
-      '/images/cards/art-nouveau/cups/14.png'
+      `${BASE}/cards/art-nouveau/cups/14.png`
     );
   });
 
   it('Wands 슈트 카드 URL을 올바르게 반환한다', () => {
     expect(getCardStyleImageUrl('anime-mystical', 'wands-07')).toBe(
-      '/images/cards/anime-mystical/wands/07.png'
+      `${BASE}/cards/anime-mystical/wands/07.png`
     );
   });
 
   it('Swords 슈트 카드 URL을 올바르게 반환한다', () => {
     expect(getCardStyleImageUrl('modern-digital', 'swords-10')).toBe(
-      '/images/cards/modern-digital/swords/10.png'
+      `${BASE}/cards/modern-digital/swords/10.png`
     );
   });
 
   it('Pentacles 슈트 카드 URL을 올바르게 반환한다', () => {
     expect(getCardStyleImageUrl('dark-fantasy', 'pentacles-14')).toBe(
-      '/images/cards/dark-fantasy/pentacles/14.png'
+      `${BASE}/cards/dark-fantasy/pentacles/14.png`
     );
   });
 
@@ -51,10 +58,10 @@ describe('getCardStyleImageUrl', () => {
 describe('getCardStyleBackUrl', () => {
   it('카드 뒷면 URL을 올바르게 반환한다', () => {
     expect(getCardStyleBackUrl('dark-fantasy')).toBe(
-      '/images/cards/dark-fantasy/card-back.png'
+      `${BASE}/cards/dark-fantasy/card-back.png`
     );
     expect(getCardStyleBackUrl('anime-mystical')).toBe(
-      '/images/cards/anime-mystical/card-back.png'
+      `${BASE}/cards/anime-mystical/card-back.png`
     );
   });
 });

--- a/src/lib/storage/card-style.ts
+++ b/src/lib/storage/card-style.ts
@@ -20,17 +20,17 @@ function parseCardId(cardId: string): ParsedCardId {
 
 /**
  * 카드 스타일 이미지 URL을 반환한다.
- * 경로: /images/cards/[styleId]/[suit]/[number].webp
+ * 경로: /images/cards/[styleId]/[suit]/[number].png
  */
 export function getCardStyleImageUrl(styleId: CardStyleId, cardId: string): string {
   const { suit, number } = parseCardId(cardId);
-  return `/images/cards/${styleId}/${suit}/${number}.webp`;
+  return `/images/cards/${styleId}/${suit}/${number}.png`;
 }
 
 /**
  * 카드 뒷면 스타일 이미지 URL을 반환한다.
- * 경로: /images/cards/[styleId]/card-back.webp
+ * 경로: /images/cards/[styleId]/card-back.png
  */
 export function getCardStyleBackUrl(styleId: CardStyleId): string {
-  return `/images/cards/${styleId}/card-back.webp`;
+  return `/images/cards/${styleId}/card-back.png`;
 }

--- a/src/lib/storage/card-style.ts
+++ b/src/lib/storage/card-style.ts
@@ -1,15 +1,18 @@
 import type { CardStyleId } from '@/data/cardStyles';
 
+const BUCKET = 'card-styles';
+
+function storageBase(): string {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  if (!url) throw new Error('NEXT_PUBLIC_SUPABASE_URL is not set');
+  return `${url}/storage/v1/object/public/${BUCKET}`;
+}
+
 interface ParsedCardId {
   suit: string;
   number: string;
 }
 
-/**
- * 타로 카드 ID를 suit과 number로 파싱한다.
- * "major-00" → { suit: "major", number: "00" }
- * "cups-01"  → { suit: "cups", number: "01" }
- */
 function parseCardId(cardId: string): ParsedCardId {
   const parts = cardId.split('-');
   if (parts.length !== 2) {
@@ -18,19 +21,11 @@ function parseCardId(cardId: string): ParsedCardId {
   return { suit: parts[0], number: parts[1] };
 }
 
-/**
- * 카드 스타일 이미지 URL을 반환한다.
- * 경로: /images/cards/[styleId]/[suit]/[number].png
- */
 export function getCardStyleImageUrl(styleId: CardStyleId, cardId: string): string {
   const { suit, number } = parseCardId(cardId);
-  return `/images/cards/${styleId}/${suit}/${number}.png`;
+  return `${storageBase()}/cards/${styleId}/${suit}/${number}.png`;
 }
 
-/**
- * 카드 뒷면 스타일 이미지 URL을 반환한다.
- * 경로: /images/cards/[styleId]/card-back.png
- */
 export function getCardStyleBackUrl(styleId: CardStyleId): string {
-  return `/images/cards/${styleId}/card-back.png`;
+  return `${storageBase()}/cards/${styleId}/card-back.png`;
 }


### PR DESCRIPTION
## Summary

- **generate-assets 스크립트 수정**: png 포맷 전환 (flux-1.1-pro-ultra webp 미지원), rate-limit 재시도 로직 개선, dotenv 로드 추가
- **Supabase Storage 통합**: 카드·배경 이미지 347개를 `card-styles` public 버킷에 업로드, `src/lib/storage/card-style.ts` URL 빌더를 CDN URL로 전환
- **CLAUDE.md 업데이트**: Phase 1 신규 파일·아키텍처(CardStyleSelector, cardStyles.ts, useCardStyleStore, generate-assets, SonarCloud sync 규칙) 반영

## Background

이미지를 git에 커밋하면 2.1GB → GitHub 100MB 파일 제한 초과, Railway 배포 용량 초과 문제가 발생합니다.  
Supabase Storage public 버킷으로 서빙하여 Railway 배포와 무관하게 CDN에서 이미지를 제공합니다.

## CDN URL 구조

```
{SUPABASE_URL}/storage/v1/object/public/card-styles/cards/{styleId}/{suit}/{number}.png
{SUPABASE_URL}/storage/v1/object/public/card-styles/cards/{styleId}/card-back.png
{SUPABASE_URL}/storage/v1/object/public/card-styles/backgrounds/...
```

## Test Plan

- [ ] `pnpm type-check` — 타입 오류 없음
- [ ] `pnpm test:coverage` — card-style 스토리지 테스트 7개 통과
- [ ] Railway 배포 후 카드 이미지가 Supabase CDN에서 로드되는지 확인
- [ ] `pnpm upload:assets:skip` — 업로드 스크립트 재실행 시 기존 파일 스킵 정상 동작

🤖 Generated with [Claude Code](https://claude.com/claude-code)