### PR TITLE
feat: Visual Overhaul — Phase 1+2+3 전체 통합 (카드 스타일·테마 이펙트·서비스 애니메이션)

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -34,6 +34,7 @@ sonar.coverage.exclusions=\
   src/hooks/useSkinStore.ts,\
   src/hooks/useCardStyleStore.ts,\
   src/hooks/useTheme.ts,\
+  src/hooks/useReadingReveal.ts,\
   src/data/characters/**,\
   src/data/shinjeom/**,\
   src/data/skins/**,\

--- a/src/__tests__/lib/storage/card-style.test.ts
+++ b/src/__tests__/lib/storage/card-style.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeAll } from 'vitest';
 import {
   getCardStyleImageUrl,
   getCardStyleBackUrl,
+  getServiceBackgroundUrl,
 } from '@/lib/storage/card-style';
 
 const SUPABASE_URL = 'https://test.supabase.co';
@@ -62,6 +63,20 @@ describe('getCardStyleBackUrl', () => {
     );
     expect(getCardStyleBackUrl('anime-mystical')).toBe(
       `${BASE}/cards/anime-mystical/card-back.png`
+    );
+  });
+});
+
+describe('getServiceBackgroundUrl', () => {
+  it('서비스·테마 배경 URL을 올바르게 반환한다', () => {
+    expect(getServiceBackgroundUrl('tarot', 'midnight')).toBe(
+      `${BASE}/backgrounds/tarot/midnight.png`
+    );
+    expect(getServiceBackgroundUrl('saju', 'spring')).toBe(
+      `${BASE}/backgrounds/saju/spring.png`
+    );
+    expect(getServiceBackgroundUrl('shinjeom', 'winter')).toBe(
+      `${BASE}/backgrounds/shinjeom/winter.png`
     );
   });
 });

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -121,6 +121,67 @@
     70% { transform: translateY(-50px) scale(1.2); opacity: 0.3; }
     100% { transform: translateY(-100px) scale(0.6); opacity: 0; }
   }
+
+  /* 테마 이펙트 animate 토큰 */
+  --animate-rune-float: rune-float 6s ease-in-out infinite;
+  --animate-aurora-shift: aurora-shift 12s ease-in-out infinite;
+  --animate-firefly-blink: firefly-blink 3s ease-in-out infinite;
+  --animate-meteor-streak: meteor-streak 4s ease-out infinite;
+  --animate-scanline: scanline 6s linear infinite;
+  --animate-glitch: glitch 8s steps(1) infinite;
+  --animate-haze-warp: haze-warp 5s ease-in-out infinite;
+  --animate-ice-shimmer: ice-shimmer 4s ease-in-out infinite;
+  --animate-sakura-fall: sakura-fall 8s ease-in infinite;
+
+  @keyframes rune-float {
+    0%, 100% { transform: translateY(0) rotate(0deg); opacity: 0.4; }
+    50% { transform: translateY(-15px) rotate(180deg); opacity: 0.8; }
+  }
+
+  @keyframes aurora-shift {
+    0% { background-position: 0% 50%; }
+    50% { background-position: 100% 50%; }
+    100% { background-position: 0% 50%; }
+  }
+
+  @keyframes firefly-blink {
+    0%, 100% { opacity: 0; transform: scale(0.5); }
+    50% { opacity: 0.8; transform: scale(1.2); }
+  }
+
+  @keyframes meteor-streak {
+    0% { transform: translateX(0) translateY(0); opacity: 1; }
+    100% { transform: translateX(200px) translateY(200px); opacity: 0; }
+  }
+
+  @keyframes scanline {
+    0% { transform: translateY(-100%); }
+    100% { transform: translateY(100vh); }
+  }
+
+  @keyframes glitch {
+    0%, 90%, 100% { transform: none; filter: none; }
+    92% { transform: skew(-2deg); filter: hue-rotate(90deg); }
+    94% { transform: skew(2deg); }
+    96% { transform: none; filter: hue-rotate(-90deg); }
+  }
+
+  @keyframes haze-warp {
+    0%, 100% { transform: scaleY(1); }
+    50% { transform: scaleY(1.02) skewX(0.5deg); }
+  }
+
+  @keyframes ice-shimmer {
+    0%, 100% { opacity: 0.3; transform: scale(1); }
+    50% { opacity: 0.7; transform: scale(1.05); }
+  }
+
+  @keyframes sakura-fall {
+    0% { transform: translateY(-20px) rotate(0deg); opacity: 0; }
+    10% { opacity: 1; }
+    90% { opacity: 0.8; }
+    100% { transform: translateY(100vh) rotate(720deg); opacity: 0; }
+  }
 }
 
 @layer base {

--- a/src/app/saju/session/page.tsx
+++ b/src/app/saju/session/page.tsx
@@ -25,6 +25,7 @@ import { useT } from "@/i18n/useT";
 import { t as translate } from "@/i18n/translations";
 import type { Locale } from "@/i18n/config";
 import { useThemeStore } from "@/hooks/useTheme";
+import { getServiceBackgroundUrl } from "@/lib/storage/card-style";
 
 const SITE_NAME = "ArcanaInsight";
 
@@ -236,7 +237,7 @@ export default function SajuSessionPage() {
   return (
     <div className="relative h-[calc(100dvh-7rem)] md:h-[calc(100dvh-3.5rem)] flex flex-col overflow-hidden">
       <div className="absolute inset-0 -z-10">
-        <Image src="/images/backgrounds/session-bg.jpg" alt="" fill className="object-cover" priority  sizes="100vw" />
+        <Image src={getServiceBackgroundUrl('saju', activeTheme)} alt="" fill className="object-cover" priority sizes="100vw" unoptimized />
         <div className="absolute inset-0 bg-arcana-bg/50" />
       </div>
       <ParticleOverlay density={phase === "reading" ? "medium" : "low"} className="z-10" />

--- a/src/app/saju/session/page.tsx
+++ b/src/app/saju/session/page.tsx
@@ -17,6 +17,7 @@ import { MysticBackground, ThemeAtmosphere } from "@/components/effects/MysticBa
 import { SajuChart } from "@/components/saju/SajuChart";
 import { OhaengGraph } from "@/components/saju/OhaengGraph";
 import { DaeunTimeline } from "@/components/saju/DaeunTimeline";
+import { SajuChartReveal } from "@/components/saju/SajuChartReveal";
 import { getCharacterById } from "@/data/characters";
 import { CHARACTER_RESULT_MOODS } from "@/data/characters/waiting-lines";
 import { getWaitingLinesData } from "@/data/characters/waiting-lines-i18n";
@@ -267,13 +268,13 @@ export default function SajuSessionPage() {
             <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} transition={{ duration: 0.5, ease: "easeOut" }}
               className="w-full flex-1 flex flex-col overflow-hidden py-4">
               <div ref={resultContainerRef} className="space-y-4 md:space-y-5 flex-1 overflow-y-auto pr-2">
-                <motion.div initial={{ opacity: 0, y: 16 }} animate={{ opacity: 1, y: 0 }} transition={{ duration: 0.5, delay: 0.1, ease: "easeOut" }}>
+                <SajuChartReveal index={0}>
                   <SajuChart pillars={sajuData.pillars} dayMaster={sajuData.dayMaster}
                     dayMasterElement={sajuData.dayMasterElement} isStrong={sajuData.isStrong} yongsin={sajuData.yongsin} />
-                </motion.div>
-                <motion.div initial={{ opacity: 0, y: 16 }} animate={{ opacity: 1, y: 0 }} transition={{ duration: 0.5, delay: 0.25, ease: "easeOut" }}>
+                </SajuChartReveal>
+                <SajuChartReveal index={1}>
                   <OhaengGraph elements={sajuData.elements} yongsinElement={sajuData.yongsin.element} />
-                </motion.div>
+                </SajuChartReveal>
 
                 {readingResult.overallReading && (
                   <motion.div
@@ -305,9 +306,9 @@ export default function SajuSessionPage() {
                   </motion.div>
                 )}
 
-                <motion.div initial={{ opacity: 0, y: 16 }} animate={{ opacity: 1, y: 0 }} transition={{ duration: 0.5, delay: 0.7, ease: "easeOut" }}>
+                <SajuChartReveal index={4}>
                   <DaeunTimeline majorFortunes={sajuData.majorFortunes} yearlyFortune={sajuData.yearlyFortune} birthYear={birthYear} />
-                </motion.div>
+                </SajuChartReveal>
 
                 {readingResult.advice && (
                   <motion.div

--- a/src/app/shinjeom/session/page.tsx
+++ b/src/app/shinjeom/session/page.tsx
@@ -20,6 +20,7 @@ import { t as translate } from "@/i18n/translations";
 import { fetchSSEStream } from "@/hooks/useSSEStream";
 import { useThemeStore } from "@/hooks/useTheme";
 import { getServiceBackgroundUrl } from "@/lib/storage/card-style";
+import { ShinjeomEnergyEffect } from "@/components/shinjeom/ShinjeomEnergyEffect";
 
 function getErrorMsg(charId: string | null | undefined, type: "api" | "reading"): string {
   const wl = getWaitingLinesData(useLocaleStore.getState().locale);
@@ -55,6 +56,7 @@ export default function ShinjeomSessionPage() {
   const character = characterId ? getCharacterById(characterId) : null;
   const [inputText, setInputText] = useState("");
   const [sessionCreated, setSessionCreated] = useState(false);
+  const [showEnergyEffect, setShowEnergyEffect] = useState(true);
   const redirectedRef = useRef(false);
   const readingAbortRef = useRef<AbortController | null>(null);
 
@@ -250,6 +252,9 @@ export default function ShinjeomSessionPage() {
       <ParticleOverlay density="low" className="z-10" />
       <MysticBackground service="shinjeom" />
       <ThemeAtmosphere theme={activeTheme} intensity="ambient" className="z-[6] mix-blend-screen" testId="session-theme-atmosphere-shinjeom" />
+      {showEnergyEffect && (
+        <ShinjeomEnergyEffect onComplete={() => setShowEnergyEffect(false)} />
+      )}
 
       <div className="relative flex-1 min-h-0 flex flex-col md:flex-row z-20">
         {/* 캐릭터 */}

--- a/src/app/shinjeom/session/page.tsx
+++ b/src/app/shinjeom/session/page.tsx
@@ -19,6 +19,7 @@ import { useT } from "@/i18n/useT";
 import { t as translate } from "@/i18n/translations";
 import { fetchSSEStream } from "@/hooks/useSSEStream";
 import { useThemeStore } from "@/hooks/useTheme";
+import { getServiceBackgroundUrl } from "@/lib/storage/card-style";
 
 function getErrorMsg(charId: string | null | undefined, type: "api" | "reading"): string {
   const wl = getWaitingLinesData(useLocaleStore.getState().locale);
@@ -243,7 +244,7 @@ export default function ShinjeomSessionPage() {
   return (
     <div className="relative h-[calc(100dvh-7rem)] md:h-[calc(100dvh-3.5rem)] flex flex-col overflow-hidden">
       <div className="absolute inset-0 -z-10">
-        <Image src="/images/backgrounds/session-bg.jpg" alt="" fill className="object-cover" priority  sizes="100vw" />
+        <Image src={getServiceBackgroundUrl('shinjeom', activeTheme)} alt="" fill className="object-cover" priority sizes="100vw" unoptimized />
         <div className="absolute inset-0 bg-arcana-bg/50" />
       </div>
       <ParticleOverlay density="low" className="z-10" />

--- a/src/app/tarot/result/[id]/ResultCardFace.tsx
+++ b/src/app/tarot/result/[id]/ResultCardFace.tsx
@@ -2,6 +2,8 @@
 
 import { CardFace } from "@/components/card/CardFace";
 import { useSkinStore } from "@/hooks/useSkinStore";
+import { useCardStyleStore } from "@/hooks/useCardStyleStore";
+import { useThemeStore } from "@/hooks/useTheme";
 import { TarotCard } from "@/types/card";
 
 interface ResultCardFaceProps {
@@ -11,5 +13,8 @@ interface ResultCardFaceProps {
 
 export function ResultCardFace({ card, isReversed }: ResultCardFaceProps) {
   const { selectedSkinId } = useSkinStore();
-  return <CardFace card={card} isReversed={isReversed} size="sm" skinId={selectedSkinId} />;
+  const { activeTheme } = useThemeStore();
+  const { resolvedStyle } = useCardStyleStore();
+  const styleId = resolvedStyle(activeTheme);
+  return <CardFace card={card} isReversed={isReversed} size="sm" skinId={selectedSkinId} styleId={styleId} />;
 }

--- a/src/app/tarot/session/page.tsx
+++ b/src/app/tarot/session/page.tsx
@@ -44,6 +44,7 @@ import { SpreadDefinition, ChatMessage } from "@/types/session";
 import { fetchSSEStream } from "@/hooks/useSSEStream";
 import { useT } from "@/i18n/useT";
 import { useThemeStore } from "@/hooks/useTheme";
+import { getServiceBackgroundUrl } from "@/lib/storage/card-style";
 import { t as translate } from "@/i18n/translations";
 import type { Locale } from "@/i18n/config";
 
@@ -563,7 +564,7 @@ export default function TarotSessionPage() {
     <div className="relative h-[calc(100dvh-7rem)] md:h-[calc(100dvh-3.5rem)] flex flex-col overflow-hidden">
       {/* 배경 */}
       <div className="absolute inset-0 -z-10">
-        <Image src="/images/backgrounds/session-bg.jpg" alt="" fill className="object-cover" priority  sizes="100vw" />
+        <Image src={getServiceBackgroundUrl('tarot', activeTheme)} alt="" fill className="object-cover" priority sizes="100vw" unoptimized />
         <div className="absolute inset-0 bg-arcana-bg/50" />
         <div className="absolute inset-0" style={{
           background: "radial-gradient(ellipse at center, transparent 40%, rgba(10,10,26,0.7) 100%)",

--- a/src/components/card/CardDeck.tsx
+++ b/src/components/card/CardDeck.tsx
@@ -5,6 +5,8 @@ import { motion } from "framer-motion";
 import { TarotCard } from "@/types/card";
 import { CardItem } from "./CardItem";
 import { useSkinStore } from "@/hooks/useSkinStore";
+import { useCardStyleStore } from "@/hooks/useCardStyleStore";
+import { useThemeStore } from "@/hooks/useTheme";
 
 interface CardDeckProps {
   readonly cards: TarotCard[];
@@ -44,6 +46,9 @@ function getCardTransform({ index, totalCards, overlap, cardH, effectivelySpread
 
 export const CardDeck = React.memo(function CardDeck({ cards, isSpread, selectedIndices, onCardSelect }: CardDeckProps) {
   const { selectedSkinId } = useSkinStore();
+  const { activeTheme } = useThemeStore();
+  const { resolvedStyle } = useCardStyleStore();
+  const styleId = resolvedStyle(activeTheme);
   const containerRef = useRef<HTMLDivElement>(null);
   const [containerWidth, setContainerWidth] = useState(0);
   const [containerHeight, setContainerHeight] = useState(0);
@@ -158,6 +163,7 @@ export const CardDeck = React.memo(function CardDeck({ cards, isSpread, selected
               width={layout.cardW}
               height={layout.cardH}
               skinId={selectedSkinId}
+              styleId={styleId}
             />
           </motion.div>
         );

--- a/src/components/card/CardFace.tsx
+++ b/src/components/card/CardFace.tsx
@@ -20,6 +20,7 @@ interface CardFaceProps {
   readonly className?: string;
   readonly skinId?: string;
   readonly styleId?: CardStyleId;
+  readonly showLabel?: boolean;
 }
 
 const sizeDimensions = {
@@ -28,7 +29,7 @@ const sizeDimensions = {
   lg: { w: 128, h: 192 },
 };
 
-export function CardFace({ card, isReversed, size = "md", width, height, className = "", skinId, styleId }: CardFaceProps) {
+export function CardFace({ card, isReversed, size = "md", width, height, className = "", skinId, styleId, showLabel = true }: CardFaceProps) {
   const [imageError, setImageError] = useState(false);
   const locale = useLocaleStore((s) => s.locale);
   const preset = sizeDimensions[size];
@@ -150,15 +151,18 @@ export function CardFace({ card, isReversed, size = "md", width, height, classNa
           </g>
         )}
 
-        <text x={cx} y={h * 0.82} textAnchor="middle" dominantBaseline="central"
-          fill="#e2e8f0" fontSize={fontSize} fontFamily="serif" letterSpacing="1">
-          {card.name.toUpperCase()}
-        </text>
-
-        <text x={cx} y={h * 0.92} textAnchor="middle" dominantBaseline="central"
-          fill="#94a3b8" fontSize={fontSize - 2}>
-          {getCardName(card, locale)}
-        </text>
+        {showLabel && (
+          <>
+            <text x={cx} y={h * 0.82} textAnchor="middle" dominantBaseline="central"
+              fill="#e2e8f0" fontSize={fontSize} fontFamily="serif" letterSpacing="1">
+              {card.name.toUpperCase()}
+            </text>
+            <text x={cx} y={h * 0.92} textAnchor="middle" dominantBaseline="central"
+              fill="#94a3b8" fontSize={fontSize - 2}>
+              {getCardName(card, locale)}
+            </text>
+          </>
+        )}
       </svg>
 
       {isReversed && (

--- a/src/components/card/CardSpread.tsx
+++ b/src/components/card/CardSpread.tsx
@@ -6,6 +6,8 @@ import { SelectedCard } from "@/types/card";
 import { SpreadDefinition, SpreadPosition } from "@/types/session";
 import { CardItem } from "./CardItem";
 import { useSkinStore } from "@/hooks/useSkinStore";
+import { useCardStyleStore } from "@/hooks/useCardStyleStore";
+import { useThemeStore } from "@/hooks/useTheme";
 import { useLocaleStore } from "@/hooks/useLocaleStore";
 import { hexToRgbBase } from "@/lib/color-utils";
 import { getPositionLabel } from "@/data/spreads";
@@ -98,6 +100,9 @@ function computeLayout(
 export const CardSpread = React.memo(
   function CardSpread({ selectedCards, spread, revealedPositions, glowColor }: CardSpreadProps) {
   const { selectedSkinId } = useSkinStore();
+  const { activeTheme } = useThemeStore();
+  const { resolvedStyle } = useCardStyleStore();
+  const styleId = resolvedStyle(activeTheme);
   const locale = useLocaleStore((s) => s.locale);
   const rgb = glowColor ? hexToRgbBase(glowColor) : "212, 175, 55";
   const containerRef = useRef<HTMLDivElement>(null);
@@ -169,6 +174,7 @@ export const CardSpread = React.memo(
                     width={layout.cardW}
                     height={layout.cardH}
                     skinId={selectedSkinId}
+                    styleId={styleId}
                     glowColor={glowColor}
                   />
                 </div>

--- a/src/components/character/CharacterAuraLayer.tsx
+++ b/src/components/character/CharacterAuraLayer.tsx
@@ -51,6 +51,14 @@ export function CharacterAuraLayer({ mood, isTransitioning, primaryColor }: Char
             opacity: 0.5,
           }}
         />
+        <div
+          className="absolute inset-0"
+          style={{
+            background: "radial-gradient(ellipse 70% 90% at 50% 65%, var(--theme-aura-color, rgba(167,139,250,0.1)) 0%, transparent 60%)",
+            mixBlendMode: "screen",
+            opacity: 0.6,
+          }}
+        />
       </div>
     );
   }
@@ -66,6 +74,15 @@ export function CharacterAuraLayer({ mood, isTransitioning, primaryColor }: Char
         }}
         animate={{ scale: [1, 1.08, 1], opacity: [0.5, 0.85, 0.5] }}
         transition={{ duration: 3.5, repeat: Infinity, ease: "easeInOut" }}
+      />
+
+      {/* 테마 오라 오버레이 — ThemeEffectEngine CSS 변수 사용 */}
+      <div
+        className="absolute inset-0"
+        style={{
+          background: "radial-gradient(ellipse 70% 90% at 50% 65%, var(--theme-aura-color, rgba(167,139,250,0.1)) 0%, transparent 60%)",
+          mixBlendMode: "screen",
+        }}
       />
 
       {/* 상시 파티클 3개 */}

--- a/src/components/effects/MysticBackground.tsx
+++ b/src/components/effects/MysticBackground.tsx
@@ -144,6 +144,100 @@ function particleStyle(particle: AtmosphereParticle): CSSProperties {
     };
   }
 
+  if (particle.kind === "rune") {
+    return {
+      left: `${particle.x}%`,
+      top: `${particle.y}%`,
+      width: "auto",
+      height: "auto",
+      opacity: particle.opacity,
+      background: "transparent",
+      fontSize: particle.size,
+      color: "var(--theme-glow-color, rgba(167,139,250,0.6))",
+      textShadow: "0 0 10px var(--theme-glow-color, rgba(167,139,250,0.4))",
+      userSelect: "none",
+      lineHeight: 1,
+    };
+  }
+
+  if (particle.kind === "meteor") {
+    return {
+      ...base,
+      width: particle.size * 6,
+      height: particle.size * 0.35,
+      background: `linear-gradient(90deg, transparent, ${particle.color ?? "rgba(200,200,255,0.85)"})`,
+      borderRadius: "999px",
+      transform: `rotate(${particle.rotate ?? 45}deg)`,
+      transformOrigin: "left center",
+      filter: `blur(${Math.round(particle.size * 0.2)}px)`,
+    };
+  }
+
+  if (particle.kind === "butterfly") {
+    return {
+      ...base,
+      width: particle.size * 2.4,
+      height: particle.size * 1.1,
+      background: particle.color ?? "linear-gradient(135deg, rgba(240,171,252,0.65), rgba(251,191,36,0.4))",
+      borderRadius: "0 100% 0 100% / 100% 0 100% 0",
+      transform: `rotate(${particle.rotate ?? 0}deg)`,
+      filter: `blur(${Math.round(particle.size * 0.08)}px)`,
+    };
+  }
+
+  if (particle.kind === "hexagon") {
+    return {
+      ...base,
+      clipPath: "polygon(50% 0%, 100% 25%, 100% 75%, 50% 100%, 0% 75%, 0% 25%)",
+      background: particle.color ?? "rgba(56,189,248,0.36)",
+      filter: `blur(${Math.round(particle.size * 0.06)}px)`,
+    };
+  }
+
+  if (particle.kind === "sparkle") {
+    return {
+      left: `${particle.x}%`,
+      top: `${particle.y}%`,
+      width: "auto",
+      height: "auto",
+      opacity: particle.opacity,
+      background: "transparent",
+      fontSize: particle.size,
+      color: particle.color ?? "rgba(255,255,255,0.88)",
+      textShadow: `0 0 8px ${particle.color ?? "rgba(255,255,255,0.5)"}`,
+      userSelect: "none",
+      lineHeight: 1,
+    };
+  }
+
+  if (particle.kind === "lantern") {
+    return {
+      ...base,
+      width: particle.size * 0.65,
+      height: particle.size * 1.3,
+      background: particle.color ?? "rgba(251,146,60,0.65)",
+      borderRadius: "40% 40% 50% 50% / 30% 30% 50% 50%",
+      boxShadow: `0 0 ${particle.size * 2}px ${particle.color ?? "rgba(251,146,60,0.55)"}, 0 0 ${particle.size * 4}px ${particle.color ?? "rgba(251,146,60,0.3)"}`,
+      filter: `blur(${Math.round(particle.size * 0.04)}px)`,
+    };
+  }
+
+  if (particle.kind === "snowflake") {
+    return {
+      left: `${particle.x}%`,
+      top: `${particle.y}%`,
+      width: "auto",
+      height: "auto",
+      opacity: particle.opacity,
+      background: "transparent",
+      fontSize: particle.size,
+      color: "rgba(191,219,254,0.82)",
+      textShadow: "0 0 10px rgba(147,197,253,0.6)",
+      userSelect: "none",
+      lineHeight: 1,
+    };
+  }
+
   return {
     ...base,
     background: "rgba(255, 255, 255, 0.88)",
@@ -194,6 +288,80 @@ function particleMotion(particle: AtmosphereParticle, shouldReduceMotion: boolea
       y: [0, -24, -54],
       x: [0, 6, -4],
       opacity: [particle.opacity * 0.2, particle.opacity, 0],
+    };
+  }
+
+  if (particle.kind === "rune") {
+    return {
+      y: [0, -20, -5],
+      rotate: [0, 15, -8],
+      opacity: [particle.opacity * 0.3, particle.opacity, particle.opacity * 0.4],
+      scale: [0.85, 1.1, 0.9],
+    };
+  }
+
+  if (particle.kind === "meteor") {
+    return {
+      x: [0, particle.size * 5],
+      y: [0, particle.size * 5],
+      opacity: [particle.opacity, particle.opacity * 0.8, 0],
+      scaleX: [1, 1.4, 0.6],
+    };
+  }
+
+  if (particle.kind === "butterfly") {
+    return {
+      x: [0, 12, -8, 6, 0],
+      y: [0, -10, 5, -8, 0],
+      rotate: [
+        particle.rotate ?? 0,
+        (particle.rotate ?? 0) + 12,
+        (particle.rotate ?? 0) - 8,
+        (particle.rotate ?? 0) + 4,
+        particle.rotate ?? 0,
+      ],
+      scaleX: [1, -1, 1, -1, 1],
+      opacity: [particle.opacity * 0.6, particle.opacity, particle.opacity * 0.8],
+    };
+  }
+
+  if (particle.kind === "hexagon") {
+    return {
+      rotate: [0, 180, 360],
+      scale: [0.88, 1.12, 0.88],
+      opacity: [particle.opacity * 0.5, particle.opacity, particle.opacity * 0.5],
+    };
+  }
+
+  if (particle.kind === "sparkle") {
+    return {
+      scale: [0, 1.3, 0.8, 1.5, 0],
+      opacity: [0, particle.opacity, particle.opacity * 0.6, particle.opacity, 0],
+      rotate: [0, 45, 90, 135, 180],
+    };
+  }
+
+  if (particle.kind === "lantern") {
+    return {
+      y: [0, -18, 0, -12, 0],
+      x: [0, 5, -4, 6, 0],
+      opacity: [
+        particle.opacity * 0.7,
+        particle.opacity,
+        particle.opacity * 0.8,
+        particle.opacity * 0.9,
+        particle.opacity * 0.7,
+      ],
+      scale: [0.95, 1, 0.97, 1.02, 0.95],
+    };
+  }
+
+  if (particle.kind === "snowflake") {
+    return {
+      x: [0, 8, -6, 10, -4, 0],
+      y: [0, 28, 56, 84],
+      rotate: [0, 90, 180, 270],
+      opacity: [particle.opacity * 0.3, particle.opacity, particle.opacity * 0.9, 0],
     };
   }
 
@@ -302,7 +470,7 @@ export function ThemeAtmosphere({ theme, intensity = "hero", className = "", tes
               ? { duration: 0 }
               : { duration: particle.duration, repeat: Infinity, ease: "easeInOut", delay: particle.delay }
           }
-        />
+        >{particle.text ?? ""}</motion.span>
       ))}
     </div>
   );

--- a/src/components/effects/ThemeEffectEngine.tsx
+++ b/src/components/effects/ThemeEffectEngine.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import { useEffect } from "react";
+import { useThemeStore } from "@/hooks/useTheme";
+import type { ThemeId } from "@/hooks/useTheme";
+
+type ThemeEffectVars = {
+  readonly "--theme-glow-color": string;
+  readonly "--theme-glow-intense": string;
+  readonly "--theme-particle-color": string;
+  readonly "--theme-border-glow": string;
+  readonly "--theme-text-glow": string;
+  readonly "--theme-aura-color": string;
+  readonly "--theme-aura-intense": string;
+  readonly "--theme-scanline": string;
+  readonly "--theme-glitch": string;
+};
+
+export const THEME_EFFECT_VARS: Record<ThemeId, ThemeEffectVars> = {
+  midnight: {
+    "--theme-glow-color": "rgba(167,139,250,0.6)",
+    "--theme-glow-intense": "rgba(167,139,250,0.9)",
+    "--theme-particle-color": "#a78bfa",
+    "--theme-border-glow": "0 0 8px rgba(167,139,250,0.4), 0 0 20px rgba(167,139,250,0.2)",
+    "--theme-text-glow": "0 0 12px rgba(167,139,250,0.3)",
+    "--theme-aura-color": "rgba(167,139,250,0.2)",
+    "--theme-aura-intense": "rgba(167,139,250,0.5)",
+    "--theme-scanline": "none",
+    "--theme-glitch": "none",
+  },
+  dawn: {
+    "--theme-glow-color": "rgba(240,171,252,0.6)",
+    "--theme-glow-intense": "rgba(240,171,252,0.9)",
+    "--theme-particle-color": "#f0abfc",
+    "--theme-border-glow": "0 0 8px rgba(240,171,252,0.4), 0 0 20px rgba(251,191,36,0.15)",
+    "--theme-text-glow": "0 0 12px rgba(240,171,252,0.3)",
+    "--theme-aura-color": "rgba(240,171,252,0.2)",
+    "--theme-aura-intense": "rgba(240,171,252,0.45)",
+    "--theme-scanline": "none",
+    "--theme-glitch": "none",
+  },
+  sunset: {
+    "--theme-glow-color": "rgba(251,146,60,0.6)",
+    "--theme-glow-intense": "rgba(251,146,60,0.9)",
+    "--theme-particle-color": "#fb923c",
+    "--theme-border-glow": "0 0 8px rgba(251,146,60,0.4), 0 0 20px rgba(34,211,238,0.2)",
+    "--theme-text-glow": "0 0 12px rgba(251,146,60,0.3)",
+    "--theme-aura-color": "rgba(251,146,60,0.2)",
+    "--theme-aura-intense": "rgba(251,146,60,0.45)",
+    "--theme-scanline":
+      "repeating-linear-gradient(0deg, transparent, transparent 2px, rgba(251,146,60,0.03) 2px, rgba(251,146,60,0.03) 4px)",
+    "--theme-glitch": "glitch 8s infinite",
+  },
+  spring: {
+    "--theme-glow-color": "rgba(249,168,212,0.6)",
+    "--theme-glow-intense": "rgba(249,168,212,0.9)",
+    "--theme-particle-color": "#f9a8d4",
+    "--theme-border-glow": "0 0 8px rgba(249,168,212,0.4), 0 0 20px rgba(167,243,208,0.2)",
+    "--theme-text-glow": "0 0 12px rgba(249,168,212,0.3)",
+    "--theme-aura-color": "rgba(249,168,212,0.2)",
+    "--theme-aura-intense": "rgba(249,168,212,0.45)",
+    "--theme-scanline": "none",
+    "--theme-glitch": "none",
+  },
+  summer: {
+    "--theme-glow-color": "rgba(56,189,248,0.6)",
+    "--theme-glow-intense": "rgba(56,189,248,0.9)",
+    "--theme-particle-color": "#38bdf8",
+    "--theme-border-glow": "0 0 8px rgba(56,189,248,0.4), 0 0 20px rgba(251,191,36,0.2)",
+    "--theme-text-glow": "0 0 12px rgba(56,189,248,0.3)",
+    "--theme-aura-color": "rgba(56,189,248,0.2)",
+    "--theme-aura-intense": "rgba(56,189,248,0.45)",
+    "--theme-scanline": "none",
+    "--theme-glitch": "none",
+  },
+  autumn: {
+    "--theme-glow-color": "rgba(217,119,6,0.6)",
+    "--theme-glow-intense": "rgba(217,119,6,0.9)",
+    "--theme-particle-color": "#d97706",
+    "--theme-border-glow": "0 0 8px rgba(217,119,6,0.4), 0 0 20px rgba(220,38,38,0.2)",
+    "--theme-text-glow": "0 0 12px rgba(217,119,6,0.3)",
+    "--theme-aura-color": "rgba(217,119,6,0.2)",
+    "--theme-aura-intense": "rgba(217,119,6,0.45)",
+    "--theme-scanline": "none",
+    "--theme-glitch": "none",
+  },
+  winter: {
+    "--theme-glow-color": "rgba(147,197,253,0.6)",
+    "--theme-glow-intense": "rgba(147,197,253,0.9)",
+    "--theme-particle-color": "#93c5fd",
+    "--theme-border-glow": "0 0 8px rgba(147,197,253,0.4), 0 0 20px rgba(226,232,240,0.2)",
+    "--theme-text-glow": "0 0 12px rgba(147,197,253,0.3)",
+    "--theme-aura-color": "rgba(147,197,253,0.2)",
+    "--theme-aura-intense": "rgba(147,197,253,0.45)",
+    "--theme-scanline": "none",
+    "--theme-glitch": "none",
+  },
+};
+
+/** :root에 테마별 CSS 이펙트 변수를 주입한다. ThemeProvider 하위에 배치한다. */
+export function ThemeEffectEngine() {
+  const { activeTheme } = useThemeStore();
+
+  useEffect(() => {
+    const vars = THEME_EFFECT_VARS[activeTheme];
+    const root = document.documentElement;
+    (Object.entries(vars) as [string, string][]).forEach(([key, val]) => {
+      root.style.setProperty(key, val);
+    });
+  }, [activeTheme]);
+
+  return null;
+}
+
+/** 현재 테마의 이펙트 변수 객체를 반환한다 (컴포넌트 직접 소비용). */
+export function useThemeEffectVars(): ThemeEffectVars {
+  const { activeTheme } = useThemeStore();
+  return THEME_EFFECT_VARS[activeTheme];
+}

--- a/src/components/effects/themeAtmosphere.ts
+++ b/src/components/effects/themeAtmosphere.ts
@@ -1,6 +1,8 @@
 import type { ThemeId } from "@/hooks/useTheme";
 
-type DriftParticleKind = "star" | "mist" | "dust" | "petal" | "firefly" | "leaf" | "snow" | "ember";
+type DriftParticleKind =
+  | "star" | "mist" | "dust" | "petal" | "firefly" | "leaf" | "snow" | "ember"
+  | "rune" | "meteor" | "butterfly" | "hexagon" | "sparkle" | "lantern" | "snowflake";
 
 export interface AtmosphereParticle {
   readonly id: string;
@@ -13,6 +15,7 @@ export interface AtmosphereParticle {
   readonly duration: number;
   readonly color?: string;
   readonly rotate?: number;
+  readonly text?: string;
 }
 
 export interface AtmosphereLine {
@@ -52,74 +55,191 @@ export interface ThemeAtmosphereConfig {
   readonly rays?: readonly AtmosphereRay[];
 }
 
+// ── midnight ───────────────────────────────────────────────────────────────
+
 const STAR_PARTICLES: readonly AtmosphereParticle[] = [
-  { id: "m-star-1", kind: "star", x: 9, y: 14, size: 2, opacity: 0.76, delay: 0.1, duration: 3.6 },
-  { id: "m-star-2", kind: "star", x: 19, y: 24, size: 1.4, opacity: 0.56, delay: 0.8, duration: 4.2 },
-  { id: "m-star-3", kind: "star", x: 31, y: 11, size: 2.8, opacity: 0.72, delay: 1.2, duration: 5 },
-  { id: "m-star-4", kind: "star", x: 49, y: 19, size: 1.8, opacity: 0.62, delay: 0.4, duration: 3.8 },
-  { id: "m-star-5", kind: "star", x: 66, y: 10, size: 2.2, opacity: 0.7, delay: 1.6, duration: 4.8 },
-  { id: "m-star-6", kind: "star", x: 84, y: 23, size: 1.6, opacity: 0.6, delay: 0.6, duration: 3.4 },
-  { id: "m-star-7", kind: "star", x: 91, y: 44, size: 2.4, opacity: 0.64, delay: 1.1, duration: 4.6 },
-  { id: "m-star-8", kind: "star", x: 14, y: 68, size: 1.5, opacity: 0.48, delay: 0.2, duration: 4.4 },
-  { id: "m-star-9", kind: "star", x: 72, y: 74, size: 1.7, opacity: 0.5, delay: 1.9, duration: 5.4 },
+  { id: "m-star-1",  kind: "star", x: 9,  y: 14, size: 2,   opacity: 0.76, delay: 0.1, duration: 3.6 },
+  { id: "m-star-2",  kind: "star", x: 19, y: 24, size: 1.4, opacity: 0.56, delay: 0.8, duration: 4.2 },
+  { id: "m-star-3",  kind: "star", x: 31, y: 11, size: 2.8, opacity: 0.72, delay: 1.2, duration: 5 },
+  { id: "m-star-4",  kind: "star", x: 49, y: 19, size: 1.8, opacity: 0.62, delay: 0.4, duration: 3.8 },
+  { id: "m-star-5",  kind: "star", x: 66, y: 10, size: 2.2, opacity: 0.7,  delay: 1.6, duration: 4.8 },
+  { id: "m-star-6",  kind: "star", x: 84, y: 23, size: 1.6, opacity: 0.6,  delay: 0.6, duration: 3.4 },
+  { id: "m-star-7",  kind: "star", x: 91, y: 44, size: 2.4, opacity: 0.64, delay: 1.1, duration: 4.6 },
+  { id: "m-star-8",  kind: "star", x: 14, y: 68, size: 1.5, opacity: 0.48, delay: 0.2, duration: 4.4 },
+  { id: "m-star-9",  kind: "star", x: 72, y: 74, size: 1.7, opacity: 0.5,  delay: 1.9, duration: 5.4 },
+  { id: "m-star-10", kind: "star", x: 26, y: 42, size: 1.9, opacity: 0.54, delay: 2.3, duration: 4.2 },
+  { id: "m-star-11", kind: "star", x: 43, y: 62, size: 1.6, opacity: 0.48, delay: 0.9, duration: 3.8 },
+  { id: "m-star-12", kind: "star", x: 58, y: 34, size: 2.1, opacity: 0.58, delay: 1.7, duration: 5.2 },
+  { id: "m-star-13", kind: "star", x: 76, y: 52, size: 1.8, opacity: 0.5,  delay: 3.4, duration: 4.6 },
+  { id: "m-star-14", kind: "star", x: 12, y: 82, size: 2.3, opacity: 0.52, delay: 0.4, duration: 5.8 },
 ];
+
+const RUNE_PARTICLES: readonly AtmosphereParticle[] = [
+  { id: "m-rune-1", kind: "rune", x: 6,  y: 30, size: 14, opacity: 0.22, delay: 0,   duration: 8,    text: "✦" },
+  { id: "m-rune-2", kind: "rune", x: 27, y: 55, size: 12, opacity: 0.18, delay: 2.4, duration: 9,    text: "◈" },
+  { id: "m-rune-3", kind: "rune", x: 58, y: 38, size: 16, opacity: 0.2,  delay: 1.1, duration: 10,   text: "⊕" },
+  { id: "m-rune-4", kind: "rune", x: 78, y: 60, size: 13, opacity: 0.18, delay: 3.2, duration: 8.5,  text: "❋" },
+  { id: "m-rune-5", kind: "rune", x: 92, y: 32, size: 14, opacity: 0.2,  delay: 0.8, duration: 9.5,  text: "✦" },
+  { id: "m-rune-6", kind: "rune", x: 44, y: 72, size: 11, opacity: 0.16, delay: 4.1, duration: 11,   text: "◈" },
+];
+
+const METEOR_PARTICLES: readonly AtmosphereParticle[] = [
+  { id: "m-meteor-1", kind: "meteor", x: 12, y: 8,  size: 6, opacity: 0.54, delay: 0,   duration: 4.5, rotate: 45 },
+  { id: "m-meteor-2", kind: "meteor", x: 52, y: 14, size: 5, opacity: 0.46, delay: 2.8, duration: 5,   rotate: 42 },
+  { id: "m-meteor-3", kind: "meteor", x: 74, y: 6,  size: 4, opacity: 0.38, delay: 5.5, duration: 4.8, rotate: 48 },
+];
+
+// ── dawn ──────────────────────────────────────────────────────────────────
 
 const MIST_PARTICLES: readonly AtmosphereParticle[] = [
-  { id: "d-mist-1", kind: "mist", x: 11, y: 62, size: 34, opacity: 0.2, delay: 0, duration: 8, color: "rgba(248, 187, 217, 0.34)" },
-  { id: "d-mist-2", kind: "mist", x: 33, y: 72, size: 42, opacity: 0.18, delay: 1.5, duration: 10, color: "rgba(147, 197, 253, 0.28)" },
-  { id: "d-mist-3", kind: "mist", x: 64, y: 58, size: 38, opacity: 0.2, delay: 0.8, duration: 9, color: "rgba(251, 191, 36, 0.18)" },
-  { id: "d-mist-4", kind: "mist", x: 84, y: 76, size: 46, opacity: 0.16, delay: 2.2, duration: 11, color: "rgba(192, 132, 252, 0.28)" },
+  { id: "d-mist-1", kind: "mist", x: 11, y: 62, size: 34, opacity: 0.2,  delay: 0,   duration: 8,  color: "rgba(248,187,217,0.34)" },
+  { id: "d-mist-2", kind: "mist", x: 33, y: 72, size: 42, opacity: 0.18, delay: 1.5, duration: 10, color: "rgba(147,197,253,0.28)" },
+  { id: "d-mist-3", kind: "mist", x: 64, y: 58, size: 38, opacity: 0.2,  delay: 0.8, duration: 9,  color: "rgba(251,191,36,0.18)" },
+  { id: "d-mist-4", kind: "mist", x: 84, y: 76, size: 46, opacity: 0.16, delay: 2.2, duration: 11, color: "rgba(192,132,252,0.28)" },
+  { id: "d-mist-5", kind: "mist", x: 48, y: 44, size: 36, opacity: 0.16, delay: 3.1, duration: 12, color: "rgba(248,187,217,0.24)" },
+  { id: "d-mist-6", kind: "mist", x: 72, y: 82, size: 40, opacity: 0.14, delay: 1.8, duration: 13, color: "rgba(167,243,208,0.18)" },
 ];
 
+const SPARKLE_PARTICLES: readonly AtmosphereParticle[] = [
+  { id: "d-sparkle-1", kind: "sparkle", x: 14, y: 26, size: 8, opacity: 0.52, delay: 0,   duration: 3.2, text: "✦" },
+  { id: "d-sparkle-2", kind: "sparkle", x: 38, y: 48, size: 6, opacity: 0.44, delay: 1.1, duration: 2.8, text: "✧" },
+  { id: "d-sparkle-3", kind: "sparkle", x: 61, y: 22, size: 9, opacity: 0.5,  delay: 0.6, duration: 3.5, text: "✦" },
+  { id: "d-sparkle-4", kind: "sparkle", x: 82, y: 44, size: 7, opacity: 0.46, delay: 2,   duration: 3,   text: "✧" },
+  { id: "d-sparkle-5", kind: "sparkle", x: 26, y: 68, size: 7, opacity: 0.42, delay: 1.7, duration: 4,   text: "✦" },
+];
+
+const DAWN_BUTTERFLY_PARTICLES: readonly AtmosphereParticle[] = [
+  { id: "d-butterfly-1", kind: "butterfly", x: 18, y: 42, size: 10, opacity: 0.36, delay: 0,   duration: 8,  rotate: 12 },
+  { id: "d-butterfly-2", kind: "butterfly", x: 44, y: 62, size: 8,  opacity: 0.3,  delay: 2.1, duration: 9,  rotate: -8 },
+  { id: "d-butterfly-3", kind: "butterfly", x: 72, y: 34, size: 9,  opacity: 0.34, delay: 1.4, duration: 10, rotate: 18 },
+];
+
+// ── sunset ────────────────────────────────────────────────────────────────
+
 const DUST_PARTICLES: readonly AtmosphereParticle[] = [
-  { id: "s-dust-1", kind: "dust", x: 12, y: 40, size: 2, opacity: 0.36, delay: 0.1, duration: 7 },
-  { id: "s-dust-2", kind: "dust", x: 24, y: 61, size: 1.4, opacity: 0.3, delay: 1.3, duration: 8 },
+  { id: "s-dust-1", kind: "dust", x: 12, y: 40, size: 2,   opacity: 0.36, delay: 0.1, duration: 7 },
+  { id: "s-dust-2", kind: "dust", x: 24, y: 61, size: 1.4, opacity: 0.3,  delay: 1.3, duration: 8 },
   { id: "s-dust-3", kind: "dust", x: 38, y: 28, size: 2.2, opacity: 0.34, delay: 0.7, duration: 6.5 },
   { id: "s-dust-4", kind: "dust", x: 52, y: 52, size: 1.6, opacity: 0.32, delay: 2.1, duration: 7.8 },
   { id: "s-dust-5", kind: "dust", x: 70, y: 34, size: 2.4, opacity: 0.34, delay: 1.6, duration: 8.4 },
-  { id: "s-dust-6", kind: "dust", x: 83, y: 66, size: 1.8, opacity: 0.3, delay: 0.4, duration: 7.2 },
-  { id: "s-dust-7", kind: "dust", x: 91, y: 43, size: 2, opacity: 0.32, delay: 2.6, duration: 9 },
+  { id: "s-dust-6", kind: "dust", x: 83, y: 66, size: 1.8, opacity: 0.3,  delay: 0.4, duration: 7.2 },
+  { id: "s-dust-7", kind: "dust", x: 91, y: 43, size: 2,   opacity: 0.32, delay: 2.6, duration: 9 },
+  { id: "s-dust-8", kind: "dust", x: 6,  y: 58, size: 2.2, opacity: 0.3,  delay: 3.4, duration: 8.6 },
+  { id: "s-dust-9", kind: "dust", x: 62, y: 74, size: 1.6, opacity: 0.28, delay: 1.9, duration: 7.4 },
 ];
+
+const SUNSET_LANTERNS: readonly AtmosphereParticle[] = [
+  { id: "s-lantern-1", kind: "lantern", x: 18, y: 58, size: 14, opacity: 0.4,  delay: 0,   duration: 7,   color: "rgba(252,211,77,0.72)" },
+  { id: "s-lantern-2", kind: "lantern", x: 44, y: 72, size: 11, opacity: 0.34, delay: 1.8, duration: 8,   color: "rgba(251,146,60,0.68)" },
+  { id: "s-lantern-3", kind: "lantern", x: 78, y: 64, size: 12, opacity: 0.38, delay: 3.2, duration: 7.5, color: "rgba(244,114,182,0.56)" },
+];
+
+// ── spring ────────────────────────────────────────────────────────────────
 
 const PETALS: readonly AtmosphereParticle[] = [
-  { id: "sp-petal-1", kind: "petal", x: 8, y: 20, size: 12, opacity: 0.42, delay: 0, duration: 10, rotate: -18 },
-  { id: "sp-petal-2", kind: "petal", x: 22, y: 46, size: 9, opacity: 0.34, delay: 1.8, duration: 12, rotate: 26 },
-  { id: "sp-petal-3", kind: "petal", x: 39, y: 18, size: 11, opacity: 0.4, delay: 3.1, duration: 11, rotate: 12 },
-  { id: "sp-petal-4", kind: "petal", x: 56, y: 58, size: 8, opacity: 0.32, delay: 0.9, duration: 13, rotate: -30 },
+  { id: "sp-petal-1", kind: "petal", x: 8,  y: 20, size: 12, opacity: 0.42, delay: 0,   duration: 10, rotate: -18 },
+  { id: "sp-petal-2", kind: "petal", x: 22, y: 46, size: 9,  opacity: 0.34, delay: 1.8, duration: 12, rotate: 26 },
+  { id: "sp-petal-3", kind: "petal", x: 39, y: 18, size: 11, opacity: 0.4,  delay: 3.1, duration: 11, rotate: 12 },
+  { id: "sp-petal-4", kind: "petal", x: 56, y: 58, size: 8,  opacity: 0.32, delay: 0.9, duration: 13, rotate: -30 },
   { id: "sp-petal-5", kind: "petal", x: 74, y: 29, size: 12, opacity: 0.38, delay: 2.4, duration: 12, rotate: 18 },
-  { id: "sp-petal-6", kind: "petal", x: 89, y: 51, size: 10, opacity: 0.34, delay: 4, duration: 14, rotate: -10 },
+  { id: "sp-petal-6", kind: "petal", x: 89, y: 51, size: 10, opacity: 0.34, delay: 4,   duration: 14, rotate: -10 },
+  { id: "sp-petal-7", kind: "petal", x: 30, y: 74, size: 9,  opacity: 0.3,  delay: 1.4, duration: 11, rotate: 34 },
+  { id: "sp-petal-8", kind: "petal", x: 65, y: 68, size: 11, opacity: 0.36, delay: 3.7, duration: 13, rotate: -22 },
 ];
+
+const SPRING_BUTTERFLY_PARTICLES: readonly AtmosphereParticle[] = [
+  { id: "sp-butterfly-1", kind: "butterfly", x: 14, y: 32, size: 12, opacity: 0.38, delay: 0.5, duration: 9,    rotate: 10 },
+  { id: "sp-butterfly-2", kind: "butterfly", x: 32, y: 58, size: 9,  opacity: 0.32, delay: 2.8, duration: 10,   rotate: -15 },
+  { id: "sp-butterfly-3", kind: "butterfly", x: 62, y: 40, size: 11, opacity: 0.36, delay: 1.6, duration: 8.5,  rotate: 22 },
+  { id: "sp-butterfly-4", kind: "butterfly", x: 82, y: 62, size: 10, opacity: 0.3,  delay: 3.8, duration: 11,   rotate: -8 },
+];
+
+const SPRING_SPARKLE_PARTICLES: readonly AtmosphereParticle[] = [
+  { id: "sp-sparkle-1", kind: "sparkle", x: 10, y: 52, size: 7, opacity: 0.48, delay: 0,   duration: 2.8, text: "✦", color: "rgba(249,168,212,0.9)" },
+  { id: "sp-sparkle-2", kind: "sparkle", x: 35, y: 28, size: 6, opacity: 0.42, delay: 1.4, duration: 3.2, text: "✧", color: "rgba(167,243,208,0.9)" },
+  { id: "sp-sparkle-3", kind: "sparkle", x: 68, y: 54, size: 8, opacity: 0.46, delay: 0.8, duration: 3,   text: "✦", color: "rgba(249,168,212,0.9)" },
+  { id: "sp-sparkle-4", kind: "sparkle", x: 88, y: 30, size: 6, opacity: 0.4,  delay: 2.3, duration: 3.5, text: "✧", color: "rgba(167,243,208,0.9)" },
+];
+
+// ── summer ────────────────────────────────────────────────────────────────
 
 const FIREFLIES: readonly AtmosphereParticle[] = [
-  { id: "su-firefly-1", kind: "firefly", x: 12, y: 72, size: 5, opacity: 0.58, delay: 0, duration: 5.4 },
-  { id: "su-firefly-2", kind: "firefly", x: 29, y: 38, size: 3, opacity: 0.48, delay: 1.3, duration: 6.2 },
-  { id: "su-firefly-3", kind: "firefly", x: 43, y: 66, size: 4, opacity: 0.52, delay: 2.1, duration: 5.8 },
-  { id: "su-firefly-4", kind: "firefly", x: 63, y: 32, size: 3, opacity: 0.48, delay: 0.7, duration: 6.5 },
-  { id: "su-firefly-5", kind: "firefly", x: 78, y: 70, size: 5, opacity: 0.56, delay: 1.8, duration: 5.6 },
-  { id: "su-glint-1", kind: "star", x: 87, y: 18, size: 2, opacity: 0.58, delay: 0.4, duration: 3.8 },
-  { id: "su-glint-2", kind: "star", x: 55, y: 15, size: 1.6, opacity: 0.48, delay: 1.5, duration: 4.4 },
+  { id: "su-firefly-1",  kind: "firefly", x: 12, y: 72, size: 5,   opacity: 0.58, delay: 0,   duration: 5.4 },
+  { id: "su-firefly-2",  kind: "firefly", x: 29, y: 38, size: 3,   opacity: 0.48, delay: 1.3, duration: 6.2 },
+  { id: "su-firefly-3",  kind: "firefly", x: 43, y: 66, size: 4,   opacity: 0.52, delay: 2.1, duration: 5.8 },
+  { id: "su-firefly-4",  kind: "firefly", x: 63, y: 32, size: 3,   opacity: 0.48, delay: 0.7, duration: 6.5 },
+  { id: "su-firefly-5",  kind: "firefly", x: 78, y: 70, size: 5,   opacity: 0.56, delay: 1.8, duration: 5.6 },
+  { id: "su-firefly-6",  kind: "firefly", x: 19, y: 52, size: 4,   opacity: 0.5,  delay: 0.6, duration: 5 },
+  { id: "su-firefly-7",  kind: "firefly", x: 48, y: 44, size: 3,   opacity: 0.44, delay: 2.4, duration: 6.8 },
+  { id: "su-firefly-8",  kind: "firefly", x: 71, y: 55, size: 5,   opacity: 0.54, delay: 1.1, duration: 5.4 },
+  { id: "su-firefly-9",  kind: "firefly", x: 84, y: 46, size: 3,   opacity: 0.44, delay: 3.2, duration: 6.2 },
+  { id: "su-firefly-10", kind: "firefly", x: 57, y: 72, size: 4,   opacity: 0.48, delay: 0.3, duration: 5.6 },
+  { id: "su-glint-1",    kind: "star",    x: 87, y: 18, size: 2,   opacity: 0.58, delay: 0.4, duration: 3.8 },
+  { id: "su-glint-2",    kind: "star",    x: 55, y: 15, size: 1.6, opacity: 0.48, delay: 1.5, duration: 4.4 },
 ];
+
+const HEXAGON_PARTICLES: readonly AtmosphereParticle[] = [
+  { id: "su-hex-1", kind: "hexagon", x: 8,  y: 48, size: 16, opacity: 0.18, delay: 0,   duration: 7 },
+  { id: "su-hex-2", kind: "hexagon", x: 34, y: 22, size: 12, opacity: 0.16, delay: 1.6, duration: 8 },
+  { id: "su-hex-3", kind: "hexagon", x: 68, y: 58, size: 14, opacity: 0.2,  delay: 0.9, duration: 7.5 },
+  { id: "su-hex-4", kind: "hexagon", x: 88, y: 36, size: 11, opacity: 0.15, delay: 2.8, duration: 9 },
+  { id: "su-hex-5", kind: "hexagon", x: 52, y: 82, size: 13, opacity: 0.14, delay: 4.1, duration: 8.5 },
+];
+
+// ── autumn ────────────────────────────────────────────────────────────────
 
 const LEAVES_AND_EMBERS: readonly AtmosphereParticle[] = [
-  { id: "a-leaf-1", kind: "leaf", x: 10, y: 18, size: 14, opacity: 0.38, delay: 0, duration: 13, color: "rgba(245, 158, 11, 0.72)", rotate: -24 },
-  { id: "a-leaf-2", kind: "leaf", x: 26, y: 48, size: 11, opacity: 0.34, delay: 2, duration: 15, color: "rgba(220, 38, 38, 0.58)", rotate: 18 },
-  { id: "a-leaf-3", kind: "leaf", x: 48, y: 26, size: 13, opacity: 0.36, delay: 3.6, duration: 14, color: "rgba(180, 83, 9, 0.7)", rotate: 34 },
-  { id: "a-leaf-4", kind: "leaf", x: 76, y: 42, size: 12, opacity: 0.34, delay: 1.1, duration: 16, color: "rgba(251, 191, 36, 0.55)", rotate: -12 },
-  { id: "a-ember-1", kind: "ember", x: 18, y: 80, size: 2, opacity: 0.42, delay: 0.4, duration: 5.8 },
+  { id: "a-leaf-1",  kind: "leaf",  x: 10, y: 18, size: 14, opacity: 0.38, delay: 0,   duration: 13, color: "rgba(245,158,11,0.72)",  rotate: -24 },
+  { id: "a-leaf-2",  kind: "leaf",  x: 26, y: 48, size: 11, opacity: 0.34, delay: 2,   duration: 15, color: "rgba(220,38,38,0.58)",   rotate: 18 },
+  { id: "a-leaf-3",  kind: "leaf",  x: 48, y: 26, size: 13, opacity: 0.36, delay: 3.6, duration: 14, color: "rgba(180,83,9,0.7)",     rotate: 34 },
+  { id: "a-leaf-4",  kind: "leaf",  x: 76, y: 42, size: 12, opacity: 0.34, delay: 1.1, duration: 16, color: "rgba(251,191,36,0.55)",  rotate: -12 },
+  { id: "a-leaf-5",  kind: "leaf",  x: 62, y: 22, size: 10, opacity: 0.3,  delay: 4.8, duration: 12, color: "rgba(245,158,11,0.6)",   rotate: 26 },
+  { id: "a-leaf-6",  kind: "leaf",  x: 38, y: 64, size: 12, opacity: 0.32, delay: 2.8, duration: 14, color: "rgba(220,38,38,0.5)",    rotate: -18 },
+  { id: "a-ember-1", kind: "ember", x: 18, y: 80, size: 2,   opacity: 0.42, delay: 0.4, duration: 5.8 },
   { id: "a-ember-2", kind: "ember", x: 61, y: 74, size: 2.4, opacity: 0.46, delay: 1.8, duration: 6.4 },
   { id: "a-ember-3", kind: "ember", x: 88, y: 78, size: 1.8, opacity: 0.38, delay: 2.7, duration: 5.2 },
+  { id: "a-ember-4", kind: "ember", x: 32, y: 82, size: 2.2, opacity: 0.44, delay: 0.8, duration: 6 },
+  { id: "a-ember-5", kind: "ember", x: 48, y: 76, size: 1.6, opacity: 0.38, delay: 3.4, duration: 5.6 },
+  { id: "a-ember-6", kind: "ember", x: 72, y: 80, size: 2,   opacity: 0.4,  delay: 1.6, duration: 6.8 },
+  { id: "a-ember-7", kind: "ember", x: 94, y: 72, size: 2.4, opacity: 0.42, delay: 2.2, duration: 5.4 },
 ];
 
-const SNOW: readonly AtmosphereParticle[] = [
-  { id: "w-snow-1", kind: "snow", x: 8, y: 12, size: 3, opacity: 0.54, delay: 0, duration: 10 },
-  { id: "w-snow-2", kind: "snow", x: 19, y: 36, size: 2, opacity: 0.42, delay: 2, duration: 12 },
-  { id: "w-snow-3", kind: "snow", x: 32, y: 18, size: 2.8, opacity: 0.48, delay: 1.1, duration: 11 },
-  { id: "w-snow-4", kind: "snow", x: 47, y: 54, size: 2, opacity: 0.4, delay: 3, duration: 13 },
-  { id: "w-snow-5", kind: "snow", x: 63, y: 24, size: 3.2, opacity: 0.5, delay: 1.7, duration: 12 },
-  { id: "w-snow-6", kind: "snow", x: 79, y: 46, size: 2.4, opacity: 0.44, delay: 2.8, duration: 14 },
-  { id: "w-snow-7", kind: "snow", x: 91, y: 16, size: 2, opacity: 0.4, delay: 0.6, duration: 11 },
-  { id: "w-snow-8", kind: "snow", x: 86, y: 72, size: 3, opacity: 0.46, delay: 3.8, duration: 15 },
+const AUTUMN_LANTERNS: readonly AtmosphereParticle[] = [
+  { id: "a-lantern-1", kind: "lantern", x: 22, y: 56, size: 13, opacity: 0.38, delay: 0.6, duration: 8,   color: "rgba(245,158,11,0.68)" },
+  { id: "a-lantern-2", kind: "lantern", x: 56, y: 70, size: 10, opacity: 0.32, delay: 2.4, duration: 9,   color: "rgba(220,38,38,0.58)" },
+  { id: "a-lantern-3", kind: "lantern", x: 84, y: 60, size: 12, opacity: 0.36, delay: 1.2, duration: 7.5, color: "rgba(180,83,9,0.64)" },
 ];
+
+// ── winter ────────────────────────────────────────────────────────────────
+
+const SNOW: readonly AtmosphereParticle[] = [
+  { id: "w-snow-1",  kind: "snow", x: 8,  y: 12, size: 3,   opacity: 0.54, delay: 0,   duration: 10 },
+  { id: "w-snow-2",  kind: "snow", x: 19, y: 36, size: 2,   opacity: 0.42, delay: 2,   duration: 12 },
+  { id: "w-snow-3",  kind: "snow", x: 32, y: 18, size: 2.8, opacity: 0.48, delay: 1.1, duration: 11 },
+  { id: "w-snow-4",  kind: "snow", x: 47, y: 54, size: 2,   opacity: 0.4,  delay: 3,   duration: 13 },
+  { id: "w-snow-5",  kind: "snow", x: 63, y: 24, size: 3.2, opacity: 0.5,  delay: 1.7, duration: 12 },
+  { id: "w-snow-6",  kind: "snow", x: 79, y: 46, size: 2.4, opacity: 0.44, delay: 2.8, duration: 14 },
+  { id: "w-snow-7",  kind: "snow", x: 91, y: 16, size: 2,   opacity: 0.4,  delay: 0.6, duration: 11 },
+  { id: "w-snow-8",  kind: "snow", x: 86, y: 72, size: 3,   opacity: 0.46, delay: 3.8, duration: 15 },
+  { id: "w-snow-9",  kind: "snow", x: 22, y: 64, size: 2.2, opacity: 0.38, delay: 1.4, duration: 12 },
+  { id: "w-snow-10", kind: "snow", x: 54, y: 40, size: 2.6, opacity: 0.44, delay: 4.2, duration: 13 },
+  { id: "w-snow-11", kind: "snow", x: 38, y: 78, size: 1.8, opacity: 0.36, delay: 2.1, duration: 14 },
+];
+
+const SNOWFLAKE_PARTICLES: readonly AtmosphereParticle[] = [
+  { id: "w-flake-1", kind: "snowflake", x: 14, y: 22, size: 14, opacity: 0.48, delay: 0,   duration: 14, text: "❄" },
+  { id: "w-flake-2", kind: "snowflake", x: 31, y: 54, size: 11, opacity: 0.42, delay: 2.6, duration: 16, text: "❄" },
+  { id: "w-flake-3", kind: "snowflake", x: 56, y: 30, size: 16, opacity: 0.44, delay: 1.4, duration: 15, text: "❄" },
+  { id: "w-flake-4", kind: "snowflake", x: 76, y: 62, size: 12, opacity: 0.4,  delay: 3.8, duration: 17, text: "❄" },
+  { id: "w-flake-5", kind: "snowflake", x: 92, y: 38, size: 13, opacity: 0.46, delay: 0.9, duration: 13, text: "❄" },
+];
+
+const WINTER_METEORS: readonly AtmosphereParticle[] = [
+  { id: "w-meteor-1", kind: "meteor", x: 8,  y: 12, size: 4,   opacity: 0.38, delay: 1.2, duration: 5.5, rotate: 44, color: "rgba(147,197,253,0.82)" },
+  { id: "w-meteor-2", kind: "meteor", x: 62, y: 8,  size: 3.5, opacity: 0.32, delay: 4.8, duration: 6,   rotate: 46, color: "rgba(226,232,240,0.78)" },
+];
+
+// ──────────────────────────────────────────────────────────────────────────
 
 export const THEME_ATMOSPHERES: Record<ThemeId, ThemeAtmosphereConfig> = {
   midnight: {
@@ -127,9 +247,9 @@ export const THEME_ATMOSPHERES: Record<ThemeId, ThemeAtmosphereConfig> = {
       "radial-gradient(circle at 18% 18%, rgba(167,139,250,0.18), transparent 28%), radial-gradient(circle at 78% 12%, rgba(245,158,11,0.12), transparent 24%)",
     texture:
       "linear-gradient(115deg, transparent 0 32%, rgba(167,139,250,0.08) 32.5%, transparent 34%), linear-gradient(68deg, transparent 0 58%, rgba(245,158,11,0.07) 58.4%, transparent 60%)",
-    particles: STAR_PARTICLES,
+    particles: [...STAR_PARTICLES, ...RUNE_PARTICLES, ...METEOR_PARTICLES],
     lines: [
-      { id: "m-line-1", x1: 9, y1: 14, x2: 31, y2: 11, opacity: 0.34 },
+      { id: "m-line-1", x1: 9,  y1: 14, x2: 31, y2: 11, opacity: 0.34 },
       { id: "m-line-2", x1: 31, y1: 11, x2: 49, y2: 19, opacity: 0.28 },
       { id: "m-line-3", x1: 49, y1: 19, x2: 66, y2: 10, opacity: 0.3 },
       { id: "m-line-4", x1: 66, y1: 10, x2: 84, y2: 23, opacity: 0.26 },
@@ -138,45 +258,45 @@ export const THEME_ATMOSPHERES: Record<ThemeId, ThemeAtmosphereConfig> = {
   dawn: {
     baseGlow:
       "linear-gradient(180deg, rgba(244,114,182,0.16) 0%, rgba(96,165,250,0.08) 42%, transparent 72%), radial-gradient(ellipse at 50% 82%, rgba(251,191,36,0.16), transparent 48%)",
-    particles: MIST_PARTICLES,
+    particles: [...MIST_PARTICLES, ...SPARKLE_PARTICLES, ...DAWN_BUTTERFLY_PARTICLES],
     ribbons: [
-      { id: "d-ribbon-1", path: "M-5 38 C18 20 38 42 58 27 C78 12 94 26 106 12", color: "rgba(244, 114, 182, 0.24)", opacity: 0.8, delay: 0, duration: 10 },
-      { id: "d-ribbon-2", path: "M-6 48 C20 35 32 54 54 39 C76 24 91 42 108 28", color: "rgba(96, 165, 250, 0.2)", opacity: 0.7, delay: 1.4, duration: 12 },
-      { id: "d-ribbon-3", path: "M-4 58 C19 49 40 63 61 50 C82 37 95 52 106 44", color: "rgba(251, 191, 36, 0.14)", opacity: 0.62, delay: 2.5, duration: 11 },
+      { id: "d-ribbon-1", path: "M-5 38 C18 20 38 42 58 27 C78 12 94 26 106 12",  color: "rgba(244,114,182,0.24)", opacity: 0.8,  delay: 0,   duration: 10 },
+      { id: "d-ribbon-2", path: "M-6 48 C20 35 32 54 54 39 C76 24 91 42 108 28",  color: "rgba(96,165,250,0.2)",   opacity: 0.7,  delay: 1.4, duration: 12 },
+      { id: "d-ribbon-3", path: "M-4 58 C19 49 40 63 61 50 C82 37 95 52 106 44",  color: "rgba(251,191,36,0.14)",  opacity: 0.62, delay: 2.5, duration: 11 },
     ],
   },
   sunset: {
     baseGlow:
       "radial-gradient(ellipse at 48% 82%, rgba(251,146,60,0.22), transparent 54%), radial-gradient(circle at 82% 22%, rgba(252,211,77,0.14), transparent 28%)",
-    particles: DUST_PARTICLES,
+    particles: [...DUST_PARTICLES, ...SUNSET_LANTERNS],
     rays: [
-      { id: "s-ray-1", left: 8, width: 14, rotate: 16, opacity: 0.2, color: "rgba(252, 211, 77, 0.4)", delay: 0 },
-      { id: "s-ray-2", left: 34, width: 18, rotate: -10, opacity: 0.16, color: "rgba(251, 146, 60, 0.42)", delay: 0.8 },
-      { id: "s-ray-3", left: 67, width: 16, rotate: 12, opacity: 0.14, color: "rgba(244, 114, 182, 0.28)", delay: 1.6 },
+      { id: "s-ray-1", left: 8,  width: 14, rotate: 16,  opacity: 0.2,  color: "rgba(252,211,77,0.4)",   delay: 0 },
+      { id: "s-ray-2", left: 34, width: 18, rotate: -10, opacity: 0.16, color: "rgba(251,146,60,0.42)",  delay: 0.8 },
+      { id: "s-ray-3", left: 67, width: 16, rotate: 12,  opacity: 0.14, color: "rgba(244,114,182,0.28)", delay: 1.6 },
     ],
   },
   spring: {
     baseGlow:
       "radial-gradient(circle at 18% 24%, rgba(249,168,212,0.16), transparent 26%), radial-gradient(circle at 72% 34%, rgba(167,243,208,0.11), transparent 30%)",
-    particles: PETALS,
+    particles: [...PETALS, ...SPRING_BUTTERFLY_PARTICLES, ...SPRING_SPARKLE_PARTICLES],
   },
   summer: {
     baseGlow:
       "radial-gradient(circle at 22% 80%, rgba(251,191,36,0.12), transparent 24%), radial-gradient(circle at 76% 28%, rgba(56,189,248,0.14), transparent 32%)",
     texture:
       "radial-gradient(circle at 50% 50%, rgba(125,211,252,0.08) 0 1px, transparent 1.5px)",
-    particles: FIREFLIES,
+    particles: [...FIREFLIES, ...HEXAGON_PARTICLES],
   },
   autumn: {
     baseGlow:
       "radial-gradient(ellipse at 50% 84%, rgba(217,119,6,0.2), transparent 50%), radial-gradient(circle at 18% 26%, rgba(220,38,38,0.12), transparent 26%)",
-    particles: LEAVES_AND_EMBERS,
+    particles: [...LEAVES_AND_EMBERS, ...AUTUMN_LANTERNS],
   },
   winter: {
     baseGlow:
       "radial-gradient(circle at 18% 20%, rgba(226,232,240,0.14), transparent 26%), radial-gradient(circle at 78% 72%, rgba(147,197,253,0.12), transparent 32%)",
     texture:
       "linear-gradient(135deg, transparent 0 46%, rgba(226,232,240,0.08) 46.4%, transparent 47%), linear-gradient(45deg, transparent 0 64%, rgba(147,197,253,0.07) 64.4%, transparent 65%)",
-    particles: SNOW,
+    particles: [...SNOW, ...SNOWFLAKE_PARTICLES, ...WINTER_METEORS],
   },
 };

--- a/src/components/home/DailyCard.tsx
+++ b/src/components/home/DailyCard.tsx
@@ -9,6 +9,9 @@ import { DeckManager } from "@/services/tarot/deck-manager";
 import { CardFace } from "@/components/card/CardFace";
 import { CardBack } from "@/components/card/CardBack";
 import { useSkinStore } from "@/hooks/useSkinStore";
+import { useCardStyleStore } from "@/hooks/useCardStyleStore";
+import { useThemeStore } from "@/hooks/useTheme";
+import type { CardStyleId } from "@/data/cardStyles";
 import { useT } from "@/i18n/useT";
 import { getCardName } from "@/data/cards/locale-helpers";
 
@@ -32,11 +35,12 @@ interface CardSlotProps {
   currentData: DailyCardData | undefined;
   isFlipped: boolean;
   selectedSkinId: string;
+  styleId: CardStyleId;
   onFlip: () => void;
   tr: (key: string) => string;
 }
 
-function renderCardSlot({ isLoading, currentCard, currentData, isFlipped, selectedSkinId, onFlip, tr }: CardSlotProps) {
+function renderCardSlot({ isLoading, currentCard, currentData, isFlipped, selectedSkinId, styleId, onFlip, tr }: CardSlotProps) {
   if (isLoading) {
     return (
       <div className="w-32 h-48 rounded-lg bg-arcana-card/60 border border-arcana-border flex items-center justify-center">
@@ -60,10 +64,10 @@ function renderCardSlot({ isLoading, currentCard, currentData, isFlipped, select
           className="relative w-32 h-48"
         >
           <div style={{ backfaceVisibility: "hidden" }} className="absolute inset-0">
-            <CardBack size="lg" className="w-full h-full" skinId={selectedSkinId} />
+            <CardBack size="lg" className="w-full h-full" skinId={selectedSkinId} styleId={styleId} />
           </div>
           <div style={{ backfaceVisibility: "hidden", transform: "rotateY(180deg)" }} className="absolute inset-0">
-            <CardFace card={currentCard} isReversed={currentData.isReversed} size="lg" className="w-full h-full" skinId={selectedSkinId} />
+            <CardFace card={currentCard} isReversed={currentData.isReversed} size="lg" className="w-full h-full" skinId={selectedSkinId} styleId={styleId} />
           </div>
         </motion.div>
         {!isFlipped && <p className="text-arcana-muted text-xs text-center mt-2">{tr("home.daily-card.tap-hint")}</p>}
@@ -145,6 +149,9 @@ export function DailyCard() {
   const { t: tr, locale } = useT();
   const characters = getAvailableCharacters();
   const { selectedSkinId } = useSkinStore();
+  const { activeTheme } = useThemeStore();
+  const { resolvedStyle } = useCardStyleStore();
+  const styleId = resolvedStyle(activeTheme);
   const [activeTab, setActiveTab] = useState(characters[0].id);
   const [data, setData] = useState<Record<string, DailyCardData>>({});
   const [loading, setLoading] = useState<string | null>(null);
@@ -250,6 +257,7 @@ export function DailyCard() {
                 currentData,
                 isFlipped,
                 selectedSkinId,
+                styleId,
                 onFlip: () => handleFlip(activeTab),
                 tr,
               })}

--- a/src/components/layout/ThemeProvider.tsx
+++ b/src/components/layout/ThemeProvider.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect } from "react";
 import { useThemeStore, themes } from "@/hooks/useTheme";
+import { ThemeEffectEngine } from "@/components/effects/ThemeEffectEngine";
 
 /** CSS 변수를 :root에 동적 적용하고, 시간 경과 시 자동 갱신 */
 export function ThemeProvider({ children }: { children: React.ReactNode }) {
@@ -39,5 +40,5 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
     return () => clearInterval(interval);
   }, [mode, refresh]);
 
-  return <>{children}</>;
+  return <><ThemeEffectEngine />{children}</>;
 }

--- a/src/components/saju/SajuChartReveal.tsx
+++ b/src/components/saju/SajuChartReveal.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { motion, useReducedMotion } from "framer-motion";
+
+interface SajuChartRevealProps {
+  readonly children: React.ReactNode;
+  readonly index?: number;
+  readonly className?: string;
+}
+
+/**
+ * 사주 차트 섹션을 순차 등장 애니메이션으로 감싸는 래퍼.
+ * index에 따라 딜레이가 달라진다 (0.15s 간격).
+ */
+export function SajuChartReveal({ children, index = 0, className = "" }: SajuChartRevealProps) {
+  const shouldReduceMotion = useReducedMotion();
+
+  if (shouldReduceMotion) {
+    return <div className={className}>{children}</div>;
+  }
+
+  return (
+    <motion.div
+      className={className}
+      initial={{ opacity: 0, y: 24, filter: "blur(6px)" }}
+      animate={{ opacity: 1, y: 0, filter: "blur(0px)" }}
+      transition={{
+        duration: 0.55,
+        delay: index * 0.18,
+        ease: [0.25, 0.46, 0.45, 0.94],
+      }}
+    >
+      {children}
+    </motion.div>
+  );
+}

--- a/src/components/shinjeom/ShinjeomEnergyEffect.tsx
+++ b/src/components/shinjeom/ShinjeomEnergyEffect.tsx
@@ -1,0 +1,162 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { motion, AnimatePresence, useReducedMotion } from "framer-motion";
+
+// 오행 색상: 木(청) 火(적) 土(황) 金(백) 水(흑/남)
+const OHAENG = [
+  { color: "rgba(34,197,94,0.82)",   shadow: "rgba(34,197,94,0.5)",  label: "木", angle: -90 },
+  { color: "rgba(239,68,68,0.82)",   shadow: "rgba(239,68,68,0.5)",  label: "火", angle: -18 },
+  { color: "rgba(234,179,8,0.82)",   shadow: "rgba(234,179,8,0.5)",  label: "土", angle: 54 },
+  { color: "rgba(226,232,240,0.82)", shadow: "rgba(226,232,240,0.5)", label: "金", angle: 126 },
+  { color: "rgba(59,130,246,0.82)",  shadow: "rgba(59,130,246,0.5)", label: "水", angle: 198 },
+] as const;
+
+const DURATION_MS = 2200;
+
+interface ShinjeomEnergyEffectProps {
+  readonly onComplete?: () => void;
+}
+
+/**
+ * 신점 세션 시작 시 오행 에너지가 수렴-폭발하는 1회성 인트로 이펙트.
+ * 2.2초 후 onComplete 콜백을 호출하고 자동으로 사라진다.
+ */
+export function ShinjeomEnergyEffect({ onComplete }: ShinjeomEnergyEffectProps) {
+  const shouldReduceMotion = useReducedMotion();
+  const [visible, setVisible] = useState(true);
+
+  useEffect(() => {
+    const tid = setTimeout(() => {
+      setVisible(false);
+      onComplete?.();
+    }, shouldReduceMotion ? 100 : DURATION_MS);
+    return () => clearTimeout(tid);
+  }, [onComplete, shouldReduceMotion]);
+
+  if (shouldReduceMotion) return null;
+
+  return (
+    <AnimatePresence>
+      {visible && (
+        <motion.div
+          className="absolute inset-0 pointer-events-none overflow-hidden"
+          style={{ zIndex: 50 }}
+          initial={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          transition={{ duration: 0.4 }}
+        >
+          {/* 다크 오버레이 배경 */}
+          <motion.div
+            className="absolute inset-0"
+            style={{ background: "rgba(5,0,20,0.65)" }}
+            initial={{ opacity: 0 }}
+            animate={{ opacity: [0, 0.65, 0.65, 0] }}
+            transition={{ duration: 2.2, times: [0, 0.15, 0.75, 1] }}
+          />
+
+          {/* 오행 에너지 구체들 */}
+          {OHAENG.map((elem, i) => {
+            const rad = (elem.angle * Math.PI) / 180;
+            const startX = Math.cos(rad) * 48;
+            const startY = Math.sin(rad) * 48;
+
+            return (
+              <motion.div
+                key={i}
+                className="absolute rounded-full"
+                style={{
+                  width: 32,
+                  height: 32,
+                  left: "calc(50% - 16px)",
+                  top: "calc(50% - 16px)",
+                  background: `radial-gradient(circle at 40% 35%, ${elem.color}, transparent 80%)`,
+                  boxShadow: `0 0 18px ${elem.shadow}, 0 0 40px ${elem.shadow}`,
+                }}
+                initial={{ x: `${startX}vw`, y: `${startY}vh`, scale: 0.4, opacity: 0 }}
+                animate={{
+                  x: [
+                    `${startX}vw`,
+                    `${startX * 0.15}vw`,
+                    "0vw",
+                    `${startX * 0.6}vw`,
+                    `${startX * 2.4}vw`,
+                  ],
+                  y: [
+                    `${startY}vh`,
+                    `${startY * 0.15}vh`,
+                    "0vh",
+                    `${startY * 0.6}vh`,
+                    `${startY * 2.4}vh`,
+                  ],
+                  scale: [0.4, 1.2, 1.6, 0.9, 0],
+                  opacity: [0, 0.9, 1, 0.6, 0],
+                }}
+                transition={{
+                  duration: 2,
+                  delay: i * 0.06,
+                  times: [0, 0.28, 0.5, 0.72, 1],
+                  ease: "easeInOut",
+                }}
+              />
+            );
+          })}
+
+          {/* 중앙 수렴 폭발 링 */}
+          <motion.div
+            className="absolute rounded-full pointer-events-none"
+            style={{
+              left: "50%",
+              top: "50%",
+              transform: "translate(-50%, -50%)",
+              border: "2px solid rgba(220,180,255,0.9)",
+              boxShadow: "0 0 30px rgba(167,139,250,0.6)",
+            }}
+            initial={{ width: 0, height: 0, opacity: 0 }}
+            animate={{
+              width: ["0px", "20px", "160px", "300px"],
+              height: ["0px", "20px", "160px", "300px"],
+              opacity: [0, 1, 0.8, 0],
+            }}
+            transition={{
+              duration: 0.9,
+              delay: 0.88,
+              times: [0, 0.06, 0.55, 1],
+              ease: "easeOut",
+            }}
+          />
+
+          {/* 오행 라벨 */}
+          {OHAENG.map((elem, i) => {
+            const rad = (elem.angle * Math.PI) / 180;
+            const lx = 50 + Math.cos(rad) * 32;
+            const ly = 50 + Math.sin(rad) * 32;
+            return (
+              <motion.span
+                key={`label-${i}`}
+                className="absolute font-serif font-bold select-none"
+                style={{
+                  left: `${lx}%`,
+                  top: `${ly}%`,
+                  transform: "translate(-50%, -50%)",
+                  fontSize: 18,
+                  color: elem.color,
+                  textShadow: `0 0 12px ${elem.shadow}`,
+                }}
+                initial={{ opacity: 0, scale: 0.5 }}
+                animate={{ opacity: [0, 1, 1, 0], scale: [0.5, 1.2, 1, 0.4] }}
+                transition={{
+                  duration: 1.8,
+                  delay: 0.1 + i * 0.06,
+                  times: [0, 0.18, 0.65, 1],
+                }}
+              >
+                {elem.label}
+              </motion.span>
+            );
+          })}
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/src/components/tarot/CardFlipEffect.tsx
+++ b/src/components/tarot/CardFlipEffect.tsx
@@ -1,0 +1,120 @@
+"use client";
+
+import { useEffect, useLayoutEffect, useRef } from "react";
+import { motion } from "framer-motion";
+import { useReducedMotion } from "framer-motion";
+
+const BURST_RAYS = [0, 45, 90, 135, 180, 225, 270, 315] as const;
+
+interface CardFlipEffectProps {
+  readonly isFlipped: boolean;
+  readonly front: React.ReactNode;
+  readonly back: React.ReactNode;
+  readonly width: number;
+  readonly height: number;
+  readonly glowColor?: string;
+  readonly onFlipComplete?: () => void;
+}
+
+/**
+ * 카드 3D Y축 플립 + 완료 시 광선 버스트 파티클.
+ * front = 카드 뒷면(뒤집기 전), back = 카드 앞면(뒤집은 후).
+ */
+export function CardFlipEffect({
+  isFlipped,
+  front,
+  back,
+  width,
+  height,
+  glowColor = "rgba(167,139,250,0.8)",
+  onFlipComplete,
+}: CardFlipEffectProps) {
+  const shouldReduceMotion = useReducedMotion();
+  const prevFlipped = useRef(isFlipped);
+  const onFlipCompleteRef = useRef(onFlipComplete);
+
+  useLayoutEffect(() => {
+    onFlipCompleteRef.current = onFlipComplete;
+  });
+
+  useEffect(() => {
+    if (!prevFlipped.current && isFlipped) {
+      const tid = setTimeout(() => onFlipCompleteRef.current?.(), shouldReduceMotion ? 0 : 320);
+      prevFlipped.current = true;
+      return () => clearTimeout(tid);
+    }
+  }, [isFlipped, shouldReduceMotion]);
+
+  if (shouldReduceMotion) {
+    return (
+      <div style={{ width, height, position: "relative" }}>
+        {isFlipped ? back : front}
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ width, height, perspective: width * 5, position: "relative" }}>
+      {/* burst rays — appear once at flip moment */}
+      {isFlipped && BURST_RAYS.map((angle) => (
+        <motion.div
+          key={angle}
+          className="absolute pointer-events-none"
+          style={{
+            width: 2,
+            height: height * 0.6,
+            top: "20%",
+            left: "50%",
+            transformOrigin: "top center",
+            background: `linear-gradient(180deg, ${glowColor}, transparent)`,
+            transform: `rotate(${angle}deg)`,
+          }}
+          initial={{ scaleY: 0, opacity: 0 }}
+          animate={{ scaleY: [0, 1, 0], opacity: [0, 0.8, 0] }}
+          transition={{ duration: 0.55, ease: "easeOut" }}
+        />
+      ))}
+
+      {/* flip card */}
+      <motion.div
+        style={{
+          width,
+          height,
+          position: "relative",
+          transformStyle: "preserve-3d",
+        }}
+        animate={{ rotateY: isFlipped ? 180 : 0 }}
+        transition={
+          isFlipped
+            ? { duration: 0.55, ease: [0.4, 0, 0.2, 1] }
+            : { duration: 0 }
+        }
+      >
+        {/* front face (card back image) */}
+        <div
+          style={{
+            position: "absolute",
+            inset: 0,
+            backfaceVisibility: "hidden",
+            WebkitBackfaceVisibility: "hidden",
+          }}
+        >
+          {front}
+        </div>
+
+        {/* back face (card art) */}
+        <div
+          style={{
+            position: "absolute",
+            inset: 0,
+            backfaceVisibility: "hidden",
+            WebkitBackfaceVisibility: "hidden",
+            transform: "rotateY(180deg)",
+          }}
+        >
+          {back}
+        </div>
+      </motion.div>
+    </div>
+  );
+}

--- a/src/components/tarot/CardSpreadEffects.tsx
+++ b/src/components/tarot/CardSpreadEffects.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import { motion, AnimatePresence } from "framer-motion";
+
+interface CardSpreadEffectsProps {
+  readonly isActive: boolean;
+  readonly color?: string;
+  readonly size?: number;
+}
+
+const RING_DELAYS = [0, 0.12, 0.24] as const;
+const RUNE_MARKS = ["✦", "◈", "⊕", "❋", "✦", "◈", "⊕", "❋"] as const;
+
+/**
+ * 카드 reveal 시 나타나는 매직 서클 오버레이.
+ * isActive=true 로 바꾸면 1.6초 동안 애니메이션 후 자연스럽게 사라진다.
+ */
+export function CardSpreadEffects({ isActive, color = "rgba(167,139,250,0.7)", size = 200 }: CardSpreadEffectsProps) {
+  const cx = size / 2;
+
+  return (
+    <AnimatePresence>
+      {isActive && (
+        <motion.div
+          className="absolute inset-0 pointer-events-none flex items-center justify-center"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          transition={{ duration: 0.2 }}
+          style={{ zIndex: 20 }}
+        >
+          <svg
+            width={size}
+            height={size}
+            viewBox={`0 0 ${size} ${size}`}
+            style={{ position: "absolute" }}
+          >
+            {/* Concentric expanding rings */}
+            {RING_DELAYS.map((delay, i) => {
+              const r = cx * (0.4 + i * 0.24);
+              return (
+                <motion.circle
+                  key={i}
+                  cx={cx}
+                  cy={cx}
+                  r={r}
+                  fill="none"
+                  stroke={color}
+                  strokeWidth={1.2 - i * 0.3}
+                  initial={{ scale: 0.3, opacity: 0 }}
+                  animate={{ scale: [0.3, 1.2, 1], opacity: [0, 0.9, 0] }}
+                  transition={{ duration: 1.4, delay, ease: "easeOut" }}
+                  style={{ transformOrigin: `${cx}px ${cx}px` }}
+                />
+              );
+            })}
+
+            {/* Inner rotating star polygon */}
+            <motion.polygon
+              points={`${cx},${cx * 0.22} ${cx * 1.14},${cx * 0.74} ${cx * 0.57},${cx * 1.54} ${cx * 1.43},${cx * 1.54} ${cx * 1.86},${cx * 0.74}`}
+              fill="none"
+              stroke={color}
+              strokeWidth={0.8}
+              opacity={0.5}
+              initial={{ rotate: 0, scale: 0, opacity: 0 }}
+              animate={{ rotate: 180, scale: [0, 0.85, 0.7], opacity: [0, 0.5, 0] }}
+              transition={{ duration: 1.4, ease: "easeInOut" }}
+              style={{ transformOrigin: `${cx}px ${cx}px` }}
+            />
+
+            {/* Rune marks around the outer ring */}
+            {RUNE_MARKS.map((mark, i) => {
+              const angle = (i / RUNE_MARKS.length) * Math.PI * 2 - Math.PI / 2;
+              const r2 = cx * 0.78;
+              const mx = cx + r2 * Math.cos(angle);
+              const my = cx + r2 * Math.sin(angle);
+              return (
+                <motion.text
+                  key={i}
+                  x={mx}
+                  y={my}
+                  textAnchor="middle"
+                  dominantBaseline="central"
+                  fontSize={cx * 0.14}
+                  fill={color}
+                  initial={{ opacity: 0, scale: 0 }}
+                  animate={{ opacity: [0, 0.8, 0], scale: [0, 1, 0.6] }}
+                  transition={{ duration: 1.2, delay: 0.1 + i * 0.05, ease: "easeOut" }}
+                  style={{ transformOrigin: `${mx}px ${my}px` }}
+                >
+                  {mark}
+                </motion.text>
+              );
+            })}
+          </svg>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/src/components/tarot/ShuffleCeremony.tsx
+++ b/src/components/tarot/ShuffleCeremony.tsx
@@ -7,7 +7,10 @@ import { hexToRgbComponents } from "@/lib/color-utils";
 import { t as translate } from "@/i18n/translations";
 import { useT } from "@/i18n/useT";
 import { useSkinStore } from "@/hooks/useSkinStore";
+import { useCardStyleStore } from "@/hooks/useCardStyleStore";
+import { useThemeStore } from "@/hooks/useTheme";
 import { getCardBackUrl } from "@/lib/storage";
+import { getCardStyleBackUrl } from "@/lib/storage/card-style";
 
 interface ShuffleCeremonyProps {
   readonly characterId: string;
@@ -73,17 +76,33 @@ export function ShuffleCeremony({ characterId, onComplete, primaryColor = "#8b5c
   onCompleteRef.current = onComplete;
   const cardImgRef = useRef<HTMLImageElement | null>(null);
   const { selectedSkinId } = useSkinStore();
+  const { activeTheme } = useThemeStore();
+  const { resolvedStyle } = useCardStyleStore();
+  const styleId = resolvedStyle(activeTheme);
 
   useEffect(() => {
     let cancelled = false;
-    const url = getCardBackUrl(selectedSkinId);
+    const url = getCardStyleBackUrl(styleId) ?? getCardBackUrl(selectedSkinId);
     const img = new Image();
     img.crossOrigin = "anonymous";
     img.onload = () => { if (!cancelled) cardImgRef.current = img; };
-    img.onerror = () => { if (!cancelled) cardImgRef.current = null; };
+    img.onerror = () => {
+      if (!cancelled) {
+        const fallbackUrl = getCardBackUrl(selectedSkinId);
+        if (fallbackUrl !== url) {
+          const fallbackImg = new Image();
+          fallbackImg.crossOrigin = "anonymous";
+          fallbackImg.onload = () => { if (!cancelled) cardImgRef.current = fallbackImg; };
+          fallbackImg.onerror = () => { if (!cancelled) cardImgRef.current = null; };
+          fallbackImg.src = fallbackUrl;
+        } else {
+          cardImgRef.current = null;
+        }
+      }
+    };
     img.src = url;
     return () => { cancelled = true; };
-  }, [selectedSkinId]);
+  }, [styleId, selectedSkinId]);
 
   useEffect(() => {
     function safeComplete() {

--- a/src/hooks/useReadingReveal.ts
+++ b/src/hooks/useReadingReveal.ts
@@ -1,0 +1,30 @@
+import { create } from "zustand";
+
+interface ReadingRevealState {
+  revealedCardIds: string[];
+  revealingCardId: string | null;
+  isRevealComplete: boolean;
+  revealCard: (cardId: string) => void;
+  revealAll: (cardIds: string[]) => void;
+  reset: () => void;
+}
+
+export const useReadingRevealStore = create<ReadingRevealState>((set) => ({
+  revealedCardIds: [],
+  revealingCardId: null,
+  isRevealComplete: false,
+
+  revealCard: (cardId) =>
+    set((s) => ({
+      revealingCardId: cardId,
+      revealedCardIds: s.revealedCardIds.includes(cardId)
+        ? s.revealedCardIds
+        : [...s.revealedCardIds, cardId],
+    })),
+
+  revealAll: (cardIds) =>
+    set({ revealedCardIds: cardIds, revealingCardId: null, isRevealComplete: true }),
+
+  reset: () =>
+    set({ revealedCardIds: [], revealingCardId: null, isRevealComplete: false }),
+}));

--- a/src/lib/storage/card-style.ts
+++ b/src/lib/storage/card-style.ts
@@ -2,6 +2,8 @@ import type { CardStyleId } from '@/data/cardStyles';
 
 const BUCKET = 'card-styles';
 
+type ServiceType = 'tarot' | 'saju' | 'shinjeom';
+
 function storageBase(): string {
   const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
   if (!url) throw new Error('NEXT_PUBLIC_SUPABASE_URL is not set');
@@ -28,4 +30,8 @@ export function getCardStyleImageUrl(styleId: CardStyleId, cardId: string): stri
 
 export function getCardStyleBackUrl(styleId: CardStyleId): string {
   return `${storageBase()}/cards/${styleId}/card-back.png`;
+}
+
+export function getServiceBackgroundUrl(service: ServiceType, theme: string): string {
+  return `${storageBase()}/backgrounds/${service}/${theme}.png`;
 }


### PR DESCRIPTION
## Summary

Visual Overhaul 3단계 전체를 main에 통합합니다.

### Phase 1 — 카드 스타일 & AI 배경 이미지 UI 연결
- 4가지 카드 아트 스타일(dark-fantasy, art-nouveau, anime-mystical, modern-digital) Supabase Storage CDN 서빙
- `useCardStyleStore.resolvedStyle(theme)` → CardFace / CardBack / CardItem / ShuffleCeremony에 `styleId` 전달 완료
- 타로/사주/신점 세션 배경: 테마별 AI 생성 이미지(`getServiceBackgroundUrl`)로 교체

### Phase 2 — 5-레이어 테마 이펙트 시스템
- `ThemeEffectEngine`: 7 테마 × 9 CSS custom properties 자동 주입
- 9 keyframe 토큰 추가 (rune-float, aurora-shift, meteor-streak, scanline, glitch 등)
- `themeAtmosphere.ts`: 7 파티클 종류 추가 (rune ✦◈, meteor, butterfly, hexagon, sparkle, lantern, snowflake ❄), 테마별 2-3배 확장
- `CharacterAuraLayer`: `--theme-aura-color` 연결 → 테마별 오라 색상 자동 적용

### Phase 3 — 서비스 애니메이션 & 카드 Reveal 시스템
- `CardFlipEffect`: 3D Y축 플립 + 8방향 광선 버스트
- `CardSpreadEffects`: 동심원 매직 서클 SVG 오버레이
- `SajuChartReveal`: 차트 블러-페이드인 순차 등장
- `ShinjeomEnergyEffect`: 오행(木火土金水) 에너지 인트로 2.2초
- `useReadingReveal`: 카드별 reveal 상태 스토어
- `CardFace.showLabel`: AI 리딩 전 카드 이름 숨김 옵션

## Test Plan

- [ ] 타로/사주/신점 세션 배경이 테마에 따라 다르게 표시되는지 확인
- [ ] 카드가 현재 테마에 맞는 아트 스타일로 렌더링되는지 확인
- [ ] 테마 전환 시 파티클 종류/색상이 바뀌는지 확인
- [ ] 신점 세션 진입 시 오행 에너지 이펙트(2.2초) 확인
- [ ] 사주 결과에서 차트가 블러 페이드인으로 순차 등장하는지 확인
- [ ] `prefers-reduced-motion` 시 모든 이펙트 정적 처리 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)