### PR TITLE
fix: card-back 확장자 webp 수정 + 업로드 스크립트 webp 포함

### DIFF
--- a/scripts/generate-assets/upload-to-supabase.ts
+++ b/scripts/generate-assets/upload-to-supabase.ts
@@ -55,13 +55,13 @@ function collectCardTargets(): UploadTarget[] {
 
       if (stat.isDirectory()) {
         for (const file of fs.readdirSync(itemPath)) {
-          if (!file.endsWith('.png')) continue;
+          if (!file.endsWith('.png') && !file.endsWith('.webp')) continue;
           targets.push({
             localPath: path.join(itemPath, file),
             storagePath: `cards/${styleId}/${item}/${file}`,
           });
         }
-      } else if (item.endsWith('.png')) {
+      } else if (item.endsWith('.png') || item.endsWith('.webp')) {
         targets.push({
           localPath: itemPath,
           storagePath: `cards/${styleId}/${item}`,

--- a/src/__tests__/lib/storage/card-style.test.ts
+++ b/src/__tests__/lib/storage/card-style.test.ts
@@ -59,10 +59,10 @@ describe('getCardStyleImageUrl', () => {
 describe('getCardStyleBackUrl', () => {
   it('카드 뒷면 URL을 올바르게 반환한다', () => {
     expect(getCardStyleBackUrl('dark-fantasy')).toBe(
-      `${BASE}/cards/dark-fantasy/card-back.png`
+      `${BASE}/cards/dark-fantasy/card-back.webp`
     );
     expect(getCardStyleBackUrl('anime-mystical')).toBe(
-      `${BASE}/cards/anime-mystical/card-back.png`
+      `${BASE}/cards/anime-mystical/card-back.webp`
     );
   });
 });

--- a/src/lib/storage/card-style.ts
+++ b/src/lib/storage/card-style.ts
@@ -29,7 +29,7 @@ export function getCardStyleImageUrl(styleId: CardStyleId, cardId: string): stri
 }
 
 export function getCardStyleBackUrl(styleId: CardStyleId): string {
-  return `${storageBase()}/cards/${styleId}/card-back.png`;
+  return `${storageBase()}/cards/${styleId}/card-back.webp`;
 }
 
 export function getServiceBackgroundUrl(service: ServiceType, theme: string): string {


### PR DESCRIPTION
## 원인

Visual Overhaul Phase 1에서 카드 뒷면 이미지 CDN URL 함수가 `.png`를 반환하도록 작성되었으나, 실제 생성된 파일은 `.webp` 포맷이었습니다.

## 수정 내용

**`src/lib/storage/card-style.ts`**
- `getCardStyleBackUrl()`: `card-back.png` → `card-back.webp`
- 실제 `public/images/cards/{styleId}/card-back.webp` 파일 경로와 일치

**`scripts/generate-assets/upload-to-supabase.ts`**
- `collectCardTargets()`: `.webp` 파일도 업로드 대상에 포함
  - 서브 디렉터리 필터: `.png` 전용 → `.png || .webp`
  - 최상위 파일 필터: `.png` 전용 → `.png || .webp`
- `uploadFile()` contentType 분기는 이미 `image/webp` 처리 중 (변경 없음)
- `ShuffleCeremony.tsx`, `CardBack.tsx` 오류 폴백 이미 존재 (변경 없음)

## 영향

이 수정 후 `pnpm generate:assets` 또는 업로드 스크립트 재실행 시 `card-back.webp`가 Supabase Storage에 정상 업로드됩니다. 이후 ShuffleCeremony 카드 뒷면 및 CardBack 컴포넌트가 CDN 이미지를 올바르게 로드합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)