### PR TITLE
fix: CardSpreadEffects useReducedMotion 접근성 게이트 추가

### DIFF
--- a/src/components/tarot/CardSpreadEffects.tsx
+++ b/src/components/tarot/CardSpreadEffects.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { motion, AnimatePresence } from "framer-motion";
+import { motion, AnimatePresence, useReducedMotion } from "framer-motion";
 
 interface CardSpreadEffectsProps {
   readonly isActive: boolean;
@@ -16,7 +16,10 @@ const RUNE_MARKS = ["✦", "◈", "⊕", "❋", "✦", "◈", "⊕", "❋"] as c
  * isActive=true 로 바꾸면 1.6초 동안 애니메이션 후 자연스럽게 사라진다.
  */
 export function CardSpreadEffects({ isActive, color = "rgba(167,139,250,0.7)", size = 200 }: CardSpreadEffectsProps) {
+  const shouldReduceMotion = useReducedMotion();
   const cx = size / 2;
+
+  if (shouldReduceMotion) return null;
 
   return (
     <AnimatePresence>


### PR DESCRIPTION
## Summary
- `CardSpreadEffects` 컴포넌트에 `useReducedMotion()` 게이트 추가
- 동작 감소 설정(prefers-reduced-motion)이 활성화된 경우 매직 서클 오버레이를 렌더링하지 않음
- Visual Overhaul Phase 3 코드 리뷰에서 발견된 접근성 누락 수정

## Test plan
- [ ] `prefers-reduced-motion` 미디어 쿼리 활성화 시 CardSpreadEffects 렌더링 없음 확인
- [ ] 일반 환경에서 타로 카드 뒤집기 시 매직 서클 정상 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)