### PR TITLE
fix: 데스크탑 헤더 설정 아이콘 버튼 누락 수정

### DIFF
--- a/e2e/navigation.spec.ts
+++ b/e2e/navigation.spec.ts
@@ -118,7 +118,7 @@ test.describe("네비게이션 — 모바일 Header", () => {
     await page.goto("/");
     await page.waitForLoadState("domcontentloaded");
 
-    const settingsIcon = page.locator("header a[href='/settings']");
+    const settingsIcon = page.locator("header .md\:hidden a[href='/settings']");
     await expect(settingsIcon).toBeVisible();
   });
 
@@ -127,7 +127,7 @@ test.describe("네비게이션 — 모바일 Header", () => {
     await page.goto("/");
     await page.waitForLoadState("domcontentloaded");
 
-    const settingsIcon = page.locator("header a[href='/settings']");
+    const settingsIcon = page.locator("header .md\:hidden a[href='/settings']");
     await settingsIcon.click();
     await page.waitForURL("**/settings");
   });

--- a/e2e/navigation.spec.ts
+++ b/e2e/navigation.spec.ts
@@ -118,7 +118,7 @@ test.describe("네비게이션 — 모바일 Header", () => {
     await page.goto("/");
     await page.waitForLoadState("domcontentloaded");
 
-    const settingsIcon = page.locator("header .md\:hidden a[href='/settings']");
+    const settingsIcon = page.locator("[data-testid='mobile-settings-link']");
     await expect(settingsIcon).toBeVisible();
   });
 
@@ -127,7 +127,7 @@ test.describe("네비게이션 — 모바일 Header", () => {
     await page.goto("/");
     await page.waitForLoadState("domcontentloaded");
 
-    const settingsIcon = page.locator("header .md\:hidden a[href='/settings']");
+    const settingsIcon = page.locator("[data-testid='mobile-settings-link']");
     await settingsIcon.click();
     await page.waitForURL("**/settings");
   });

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -119,6 +119,15 @@ export function Header() {
 
           <LanguageSwitcher variant="desktop" />
 
+          {/* 설정 */}
+          <Link
+            href="/settings"
+            className="text-lg hover:scale-110 transition-transform min-h-[44px] min-w-[44px] flex items-center justify-center"
+            aria-label={t("header.nav.settings")}
+          >
+            <Icon id="ui-settings" size={20} />
+          </Link>
+
           {/* 테마 선택 */}
           <div ref={themeRef} className="relative">
             <button

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -186,8 +186,9 @@ export function Header() {
           <LanguageSwitcher variant="mobile" />
           <Link
             href="/settings"
+            data-testid="mobile-settings-link"
             className="text-lg hover:scale-110 transition-transform min-h-[44px] min-w-[44px] flex items-center justify-center"
-            aria-label={t("header.nav.mypage")}
+            aria-label={t("header.nav.settings")}
           >
             <Icon id="ui-settings" size={20} />
           </Link>

--- a/src/i18n/__tests__/keys.test.ts
+++ b/src/i18n/__tests__/keys.test.ts
@@ -10,6 +10,7 @@ describe("flatten — namespace 키 결합", () => {
       "nav.saju": "사주",
       "nav.shinjeom": "신점",
       "nav.mypage": "마이페이지",
+      "nav.settings": "설정",
       "auth.login": "로그인",
       "auth.logout": "로그아웃",
       "auth.signup": "회원가입",
@@ -21,7 +22,7 @@ describe("flatten — namespace 키 결합", () => {
     });
     expect(out["header.nav.tarot"]).toBe("타로");
     expect(out["header.auth.login"]).toBe("로그인");
-    expect(Object.keys(out)).toHaveLength(14);
+    expect(Object.keys(out)).toHaveLength(15);
   });
 
   it("빈 사전이면 빈 객체 반환", () => {

--- a/src/i18n/translations/en/index.ts
+++ b/src/i18n/translations/en/index.ts
@@ -28,6 +28,7 @@ export const en: Partial<SharedKeys> = {
     "nav.saju": "Saju",
     "nav.shinjeom": "Shinjeom",
     "nav.mypage": "My Page",
+    "nav.settings": "Settings",
     "auth.login": "Sign in",
     "auth.logout": "Sign out",
     "auth.signup": "Sign up",

--- a/src/i18n/translations/ja/index.ts
+++ b/src/i18n/translations/ja/index.ts
@@ -15,6 +15,7 @@ export const ja: Partial<SharedKeys> = {
     "nav.saju": "四柱",
     "nav.shinjeom": "神占",
     "nav.mypage": "マイページ",
+    "nav.settings": "設定",
     "auth.login": "ログイン",
     "auth.logout": "ログアウト",
     "auth.signup": "新規登録",

--- a/src/i18n/translations/ko/index.ts
+++ b/src/i18n/translations/ko/index.ts
@@ -23,6 +23,7 @@ export const ko: SharedKeys = {
     "nav.saju": "사주",
     "nav.shinjeom": "신점",
     "nav.mypage": "마이페이지",
+    "nav.settings": "설정",
     "auth.login": "로그인",
     "auth.logout": "로그아웃",
     "auth.signup": "회원가입",

--- a/src/i18n/translations/shared/keys.ts
+++ b/src/i18n/translations/shared/keys.ts
@@ -27,6 +27,7 @@ export interface SharedKeys {
     "nav.saju": string;
     "nav.shinjeom": string;
     "nav.mypage": string;
+    "nav.settings": string;
     "auth.login": string;
     "auth.logout": string;
     "auth.signup": string;


### PR DESCRIPTION
## Summary
- 데스크탑 헤더 nav에 설정 아이콘 버튼(`ui-settings`) 추가 — `/settings` 페이지로 이동
- 모바일에는 기존부터 존재했으나 데스크탑에는 누락되어 있었음
- 번역 키 `header.nav.settings` 추가 (ko/en/ja 3개 언어)

## Test plan
- [ ] 데스크탑 브라우저에서 헤더 우측에 설정 아이콘(⚙) 표시 확인
- [ ] 아이콘 클릭 시 `/settings` 페이지로 이동 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)