### PR TITLE
fix: 설정 페이지 카드 아트 스타일을 카드 스킨 섹션으로 통합

### DIFF
--- a/e2e/settings.spec.ts
+++ b/e2e/settings.spec.ts
@@ -28,7 +28,7 @@ test.describe("설정 페이지", () => {
     await page.waitForLoadState("networkidle");
 
     const skinButtons = page.locator("section").filter({ hasText: "카드 스킨" }).locator("button");
-    expect(await skinButtons.count()).toBe(6);
+    expect(await skinButtons.count()).toBe(11);
   });
 
   test("성별 필터 — 3버튼 존재 + 클릭 동작", async ({ page }) => {

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -179,46 +179,43 @@ export default function SettingsPage() {
             </div>
           </section>
 
-          {/* 카드 아트 스타일 */}
-          <section className="bg-arcana-card/70 backdrop-blur-sm border border-arcana-border rounded-2xl p-5">
-            <h2 className="font-sans font-bold text-base md:text-lg text-arcana-text mb-1">
-              {t('settings.section.card-style')}
-            </h2>
-            <p className="text-arcana-muted text-xs mb-4">
-              {t('settings.card-style.description')}
-            </p>
-            <CardStyleSelector />
-          </section>
-
           {/* 카드 스킨 */}
           <section className="bg-arcana-card/70 backdrop-blur-sm border border-arcana-border rounded-2xl p-5">
             <h2 className="font-sans font-bold text-base md:text-lg text-arcana-text mb-1">{t("settings.section.card-skin")}</h2>
-            <p className="text-arcana-muted text-xs mb-4">{(() => {
-              const cur = cardSkins.find((s) => s.id === selectedSkinId);
-              const skinLabel = cur ? getSkinName(cur, locale) : t("settings.theme.auto");
-              return `${t("settings.theme.current")} ${skinLabel}`;
-            })()}</p>
-            <div className="grid grid-cols-2 md:grid-cols-3 gap-3">
-              {cardSkins.map((skin) => (
-                <button
-                  key={skin.id}
-                  onClick={() => handleSkinChange(skin.id)}
-                  className={`p-3 rounded-xl border text-left transition-all ${
-                    selectedSkinId === skin.id
-                      ? "border-arcana-purple bg-arcana-purple/10 shadow-sm shadow-arcana-purple/10"
-                      : "border-arcana-border/50 hover:border-arcana-border"
-                  }`}
-                >
-                  <div className="flex items-center gap-2 mb-1.5">
-                    <span
-                      className="w-4 h-4 rounded-full border border-white/20"
-                      style={{ background: `linear-gradient(135deg, ${skin.palette.primary}, ${skin.palette.secondary})` }}
-                    />
-                    <span className="font-sans font-bold text-xs text-arcana-text">{getSkinName(skin, locale)}</span>
-                  </div>
-                  <p className="text-arcana-muted text-xs leading-relaxed">{getSkinDescription(skin, locale)}</p>
-                </button>
-              ))}
+
+            {/* 카드 아트 스타일 */}
+            <p className="text-arcana-muted text-xs mb-3">{t('settings.card-style.description')}</p>
+            <CardStyleSelector />
+
+            {/* 카드 스킨 팔레트 */}
+            <div className="mt-5 pt-4 border-t border-arcana-border/40">
+              <p className="text-arcana-muted text-xs mb-3">{(() => {
+                const cur = cardSkins.find((s) => s.id === selectedSkinId);
+                const skinLabel = cur ? getSkinName(cur, locale) : t("settings.theme.auto");
+                return `${t("settings.theme.current")} ${skinLabel}`;
+              })()}</p>
+              <div className="grid grid-cols-2 md:grid-cols-3 gap-3">
+                {cardSkins.map((skin) => (
+                  <button
+                    key={skin.id}
+                    onClick={() => handleSkinChange(skin.id)}
+                    className={`p-3 rounded-xl border text-left transition-all ${
+                      selectedSkinId === skin.id
+                        ? "border-arcana-purple bg-arcana-purple/10 shadow-sm shadow-arcana-purple/10"
+                        : "border-arcana-border/50 hover:border-arcana-border"
+                    }`}
+                  >
+                    <div className="flex items-center gap-2 mb-1.5">
+                      <span
+                        className="w-4 h-4 rounded-full border border-white/20"
+                        style={{ background: `linear-gradient(135deg, ${skin.palette.primary}, ${skin.palette.secondary})` }}
+                      />
+                      <span className="font-sans font-bold text-xs text-arcana-text">{getSkinName(skin, locale)}</span>
+                    </div>
+                    <p className="text-arcana-muted text-xs leading-relaxed">{getSkinDescription(skin, locale)}</p>
+                  </button>
+                ))}
+              </div>
             </div>
           </section>
 


### PR DESCRIPTION
## Summary
- 기존에 별도 섹션이었던 **카드 아트 스타일** (`CardStyleSelector`)을 **카드 스킨** 섹션 안으로 이동
- 카드 스킨 섹션이 위(아트 스타일) + 구분선 + 아래(팔레트 스킨)로 구성되는 단일 섹션으로 통합
- 두 섹션이 같은 카드 외관 관련 설정임에도 분리되어 혼란을 주던 UX 개선

## Before / After
- **Before**: 테마 → 카드 아트 스타일 (별도 섹션) → 카드 스킨 (별도 섹션) → ...
- **After**: 테마 → 카드 스킨 (아트 스타일 + 구분선 + 팔레트 스킨 통합) → ...

🤖 Generated with [Claude Code](https://claude.com/claude-code)