### PR TITLE
fix(settings): 카드 스킨 섹션 통합 — 아트 스타일 + 팔레트 스킨 11개 단일 그리드

### DIFF
--- a/e2e/settings.spec.ts
+++ b/e2e/settings.spec.ts
@@ -28,7 +28,7 @@ test.describe("설정 페이지", () => {
     await page.waitForLoadState("networkidle");
 
     const skinButtons = page.locator("section").filter({ hasText: "카드 스킨" }).locator("button");
-    expect(await skinButtons.count()).toBe(6);
+    expect(await skinButtons.count()).toBe(11);
   });
 
   test("성별 필터 — 3버튼 존재 + 클릭 동작", async ({ page }) => {

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -8,10 +8,18 @@ import { useSkinStore } from "@/hooks/useSkinStore";
 import { useGenderStore } from "@/hooks/useGenderStore";
 import { useReducedMotionStore } from "@/hooks/useReducedMotionStore";
 import { cardSkins, getSkinName, getSkinDescription } from "@/data/skins";
+import { cardStyles, getStyleName, getStyleDescription } from "@/data/cardStyles";
+import { useCardStyleStore } from "@/hooks/useCardStyleStore";
 import { GenderFilter } from "@/types/character";
 import { useT } from "@/i18n/useT";
 import { useLocaleStore } from "@/hooks/useLocaleStore";
-import { CardStyleSelector } from "@/components/card/CardStyleSelector";
+
+const STYLE_COLORS: Record<string, string> = {
+  "dark-fantasy": "linear-gradient(135deg, #1a0a2e, #6b21a8)",
+  "art-nouveau": "linear-gradient(135deg, #7c5c1e, #d4af37)",
+  "anime-mystical": "linear-gradient(135deg, #1e3a8a, #60a5fa)",
+  "modern-digital": "linear-gradient(135deg, #0f2944, #00b4d8)",
+};
 
 const USER_INFO_KEY = "arcana_user_info";
 const USER_INFO_CONSENT_KEY = "arcana_privacy_agreed";
@@ -71,6 +79,7 @@ export default function SettingsPage() {
   const locale = useLocaleStore((s) => s.locale);
   const { mode, activeTheme, setMode } = useThemeStore();
   const { selectedSkinId, setSkin } = useSkinStore();
+  const { styleOverride, setStyleOverride, clearOverride, resolvedStyle } = useCardStyleStore();
   const { genderFilter, setGenderFilter } = useGenderStore();
   const { reducedMotion, setReducedMotion } = useReducedMotionStore();
 
@@ -179,43 +188,67 @@ export default function SettingsPage() {
             </div>
           </section>
 
-          {/* 카드 스킨 */}
+          {/* 카드 스킨 (아트 스타일 5 + 팔레트 6 = 11) */}
           <section className="bg-arcana-card/70 backdrop-blur-sm border border-arcana-border rounded-2xl p-5">
             <h2 className="font-sans font-bold text-base md:text-lg text-arcana-text mb-1">{t("settings.section.card-skin")}</h2>
+            <p className="text-arcana-muted text-xs mb-4">{t("settings.card-style.description")}</p>
+            <div className="grid grid-cols-2 md:grid-cols-3 gap-3">
+              {/* 테마 자동 매핑 */}
+              <button
+                onClick={() => { clearOverride(); showToast(); }}
+                className={`p-3 rounded-xl border text-left transition-all ${
+                  styleOverride === null
+                    ? "border-arcana-purple bg-arcana-purple/10 shadow-sm shadow-arcana-purple/10"
+                    : "border-arcana-border/50 hover:border-arcana-border"
+                }`}
+              >
+                <div className="flex items-center gap-2 mb-1.5">
+                  <span className="w-4 h-4 rounded-full border border-white/20 flex items-center justify-center text-[10px]">🎨</span>
+                  <span className="font-sans font-bold text-xs text-arcana-text">{t("settings.card-style.auto-label")}</span>
+                </div>
+                <p className="text-arcana-muted text-xs leading-relaxed">{t("settings.card-style.auto-active")} ({resolvedStyle(activeTheme)})</p>
+              </button>
 
-            {/* 카드 아트 스타일 */}
-            <p className="text-arcana-muted text-xs mb-3">{t('settings.card-style.description')}</p>
-            <CardStyleSelector />
+              {/* 4개 아트 스타일 */}
+              {cardStyles.map((style) => (
+                <button
+                  key={style.id}
+                  onClick={() => { setStyleOverride(style.id); showToast(); }}
+                  className={`p-3 rounded-xl border text-left transition-all ${
+                    styleOverride === style.id
+                      ? "border-arcana-purple bg-arcana-purple/10 shadow-sm shadow-arcana-purple/10"
+                      : "border-arcana-border/50 hover:border-arcana-border"
+                  }`}
+                >
+                  <div className="flex items-center gap-2 mb-1.5">
+                    <span className="w-4 h-4 rounded-full border border-white/20" style={{ background: STYLE_COLORS[style.id] }} />
+                    <span className="font-sans font-bold text-xs text-arcana-text">{getStyleName(style, locale)}</span>
+                  </div>
+                  <p className="text-arcana-muted text-xs leading-relaxed">{getStyleDescription(style, locale)}</p>
+                </button>
+              ))}
 
-            {/* 카드 스킨 팔레트 */}
-            <div className="mt-5 pt-4 border-t border-arcana-border/40">
-              <p className="text-arcana-muted text-xs mb-3">{(() => {
-                const cur = cardSkins.find((s) => s.id === selectedSkinId);
-                const skinLabel = cur ? getSkinName(cur, locale) : t("settings.theme.auto");
-                return `${t("settings.theme.current")} ${skinLabel}`;
-              })()}</p>
-              <div className="grid grid-cols-2 md:grid-cols-3 gap-3">
-                {cardSkins.map((skin) => (
-                  <button
-                    key={skin.id}
-                    onClick={() => handleSkinChange(skin.id)}
-                    className={`p-3 rounded-xl border text-left transition-all ${
-                      selectedSkinId === skin.id
-                        ? "border-arcana-purple bg-arcana-purple/10 shadow-sm shadow-arcana-purple/10"
-                        : "border-arcana-border/50 hover:border-arcana-border"
-                    }`}
-                  >
-                    <div className="flex items-center gap-2 mb-1.5">
-                      <span
-                        className="w-4 h-4 rounded-full border border-white/20"
-                        style={{ background: `linear-gradient(135deg, ${skin.palette.primary}, ${skin.palette.secondary})` }}
-                      />
-                      <span className="font-sans font-bold text-xs text-arcana-text">{getSkinName(skin, locale)}</span>
-                    </div>
-                    <p className="text-arcana-muted text-xs leading-relaxed">{getSkinDescription(skin, locale)}</p>
-                  </button>
-                ))}
-              </div>
+              {/* 6개 팔레트 스킨 */}
+              {cardSkins.map((skin) => (
+                <button
+                  key={skin.id}
+                  onClick={() => handleSkinChange(skin.id)}
+                  className={`p-3 rounded-xl border text-left transition-all ${
+                    selectedSkinId === skin.id
+                      ? "border-arcana-purple bg-arcana-purple/10 shadow-sm shadow-arcana-purple/10"
+                      : "border-arcana-border/50 hover:border-arcana-border"
+                  }`}
+                >
+                  <div className="flex items-center gap-2 mb-1.5">
+                    <span
+                      className="w-4 h-4 rounded-full border border-white/20"
+                      style={{ background: `linear-gradient(135deg, ${skin.palette.primary}, ${skin.palette.secondary})` }}
+                    />
+                    <span className="font-sans font-bold text-xs text-arcana-text">{getSkinName(skin, locale)}</span>
+                  </div>
+                  <p className="text-arcana-muted text-xs leading-relaxed">{getSkinDescription(skin, locale)}</p>
+                </button>
+              ))}
             </div>
           </section>
 

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -179,46 +179,43 @@ export default function SettingsPage() {
             </div>
           </section>
 
-          {/* 카드 아트 스타일 */}
-          <section className="bg-arcana-card/70 backdrop-blur-sm border border-arcana-border rounded-2xl p-5">
-            <h2 className="font-sans font-bold text-base md:text-lg text-arcana-text mb-1">
-              {t('settings.section.card-style')}
-            </h2>
-            <p className="text-arcana-muted text-xs mb-4">
-              {t('settings.card-style.description')}
-            </p>
-            <CardStyleSelector />
-          </section>
-
           {/* 카드 스킨 */}
           <section className="bg-arcana-card/70 backdrop-blur-sm border border-arcana-border rounded-2xl p-5">
             <h2 className="font-sans font-bold text-base md:text-lg text-arcana-text mb-1">{t("settings.section.card-skin")}</h2>
-            <p className="text-arcana-muted text-xs mb-4">{(() => {
-              const cur = cardSkins.find((s) => s.id === selectedSkinId);
-              const skinLabel = cur ? getSkinName(cur, locale) : t("settings.theme.auto");
-              return `${t("settings.theme.current")} ${skinLabel}`;
-            })()}</p>
-            <div className="grid grid-cols-2 md:grid-cols-3 gap-3">
-              {cardSkins.map((skin) => (
-                <button
-                  key={skin.id}
-                  onClick={() => handleSkinChange(skin.id)}
-                  className={`p-3 rounded-xl border text-left transition-all ${
-                    selectedSkinId === skin.id
-                      ? "border-arcana-purple bg-arcana-purple/10 shadow-sm shadow-arcana-purple/10"
-                      : "border-arcana-border/50 hover:border-arcana-border"
-                  }`}
-                >
-                  <div className="flex items-center gap-2 mb-1.5">
-                    <span
-                      className="w-4 h-4 rounded-full border border-white/20"
-                      style={{ background: `linear-gradient(135deg, ${skin.palette.primary}, ${skin.palette.secondary})` }}
-                    />
-                    <span className="font-sans font-bold text-xs text-arcana-text">{getSkinName(skin, locale)}</span>
-                  </div>
-                  <p className="text-arcana-muted text-xs leading-relaxed">{getSkinDescription(skin, locale)}</p>
-                </button>
-              ))}
+
+            {/* 카드 아트 스타일 */}
+            <p className="text-arcana-muted text-xs mb-3">{t('settings.card-style.description')}</p>
+            <CardStyleSelector />
+
+            {/* 카드 스킨 팔레트 */}
+            <div className="mt-5 pt-4 border-t border-arcana-border/40">
+              <p className="text-arcana-muted text-xs mb-3">{(() => {
+                const cur = cardSkins.find((s) => s.id === selectedSkinId);
+                const skinLabel = cur ? getSkinName(cur, locale) : t("settings.theme.auto");
+                return `${t("settings.theme.current")} ${skinLabel}`;
+              })()}</p>
+              <div className="grid grid-cols-2 md:grid-cols-3 gap-3">
+                {cardSkins.map((skin) => (
+                  <button
+                    key={skin.id}
+                    onClick={() => handleSkinChange(skin.id)}
+                    className={`p-3 rounded-xl border text-left transition-all ${
+                      selectedSkinId === skin.id
+                        ? "border-arcana-purple bg-arcana-purple/10 shadow-sm shadow-arcana-purple/10"
+                        : "border-arcana-border/50 hover:border-arcana-border"
+                    }`}
+                  >
+                    <div className="flex items-center gap-2 mb-1.5">
+                      <span
+                        className="w-4 h-4 rounded-full border border-white/20"
+                        style={{ background: `linear-gradient(135deg, ${skin.palette.primary}, ${skin.palette.secondary})` }}
+                      />
+                      <span className="font-sans font-bold text-xs text-arcana-text">{getSkinName(skin, locale)}</span>
+                    </div>
+                    <p className="text-arcana-muted text-xs leading-relaxed">{getSkinDescription(skin, locale)}</p>
+                  </button>
+                ))}
+              </div>
             </div>
           </section>
 


### PR DESCRIPTION
## Summary

- `CardStyleSelector` 컴포넌트 제거, 설정 페이지에서 `useCardStyleStore` 직접 사용
- 기존에 시각적으로 분리되어 있던 카드 아트 스타일 선택 UI와 팔레트 스킨 선택 UI를 **하나의 `grid-cols-2 md:grid-cols-3` 그리드**로 통합
- 총 11개 버튼이 동일한 버튼 스타일로 표시됨:
  - 🎨 테마 자동 매핑 (1)
  - 아트 스타일 4개 (다크 판타지 · 아르누보 · 애니메 미스티컬 · 모던 디지털) — 특성 색상 그라디언트 스와치
  - 팔레트 스킨 6개 — 기존 그라디언트 스와치
- E2E `settings.spec.ts` 버튼 카운트 `.toBe(11)` 정합

## Test Plan

- [ ] 설정 페이지 `/settings` 접속 → "카드 스킨" 섹션에 11개 버튼이 동일한 스타일로 표시되는지 확인
- [ ] 아트 스타일 버튼 클릭 → 선택 강조 표시 + 토스트 표시 확인
- [ ] 팔레트 스킨 버튼 클릭 → 선택 강조 표시 + 토스트 표시 확인
- [ ] "테마 자동 매핑" 선택 시 현재 테마 기반 스타일 ID 표시 확인
- [ ] CI E2E 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)