### PR TITLE
fix(DailyFortune): 역방향 카드 3D 플립 렌더링 붕괴 수정

### DIFF
--- a/src/components/home/DailyFortune.tsx
+++ b/src/components/home/DailyFortune.tsx
@@ -73,7 +73,12 @@ function AreaCardSlot({
             </div>
             <div style={{ backfaceVisibility: "hidden", transform: "rotateY(180deg)" }} className="absolute inset-0">
               {card && (
-                <CardFace card={card} isReversed={areaResult.isReversed} size="md" className="w-full h-full" skinId={selectedSkinId} styleId={styleId} />
+                <CardFace card={card} isReversed={false} size="md" className="w-full h-full" skinId={selectedSkinId} styleId={styleId} />
+              )}
+              {areaResult.isReversed && (
+                <span className="absolute bottom-1 left-1/2 -translate-x-1/2 text-[9px] text-red-400 bg-red-900/50 px-1.5 py-0.5 rounded-full pointer-events-none">
+                  {tr("tarot.result.card.reversed-badge")}
+                </span>
               )}
             </div>
           </motion.div>


### PR DESCRIPTION
## 문제

역방향 카드(`isReversed=true`)가 뒤집히면 카드가 얇은 선으로 찌그러져 보이는 버그.

## 원인

3D 플립 컨테이너(`rotateY(180deg)`)와 CardFace의 역방향 CSS(`rotate-180` = `rotateZ(180deg)`)가 중첩되어 렌더링 붕괴 발생.

```
face container: transform: rotateY(180deg)   ← 3D 플립
  └ CardFace div: rotate-180 (rotateZ)        ← 역방향 표시
      → 두 축 회전 중첩 → 얇은 선으로 찌그러짐
```

## 수정

- `CardFace`에 `isReversed={false}` 전달 → 내부 `rotate-180` 제거
- 역방향 표시는 카드 하단 별도 배지(`역`)로 처리

## Test plan

- [ ] 역방향 카드가 뒤집혔을 때 정상적으로 카드 이미지가 표시되는지 확인
- [ ] 역방향 배지(`역`)가 카드 하단에 표시되는지 확인
- [ ] 정방향 카드 뒤집기는 기존과 동일하게 동작하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)