### PR TITLE
docs: 전체 문서-코드 정합성 검사 및 수정

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,28 +1,49 @@
-# LLM providers
+# ============================================================
+# Supabase 모드 (기본값) — DB_PROVIDER=supabase 또는 미설정
+# ============================================================
+NEXT_PUBLIC_SUPABASE_URL=https://xxx.supabase.co
+NEXT_PUBLIC_SUPABASE_ANON_KEY=eyJ...
+SUPABASE_SERVICE_ROLE_KEY=eyJ...
+NEXT_PUBLIC_SITE_URL=http://localhost:3000
+
+# ============================================================
+# AI 공급자 (필수: GROK_API_KEY)
+# ============================================================
 GROK_API_KEY=xai-your_grok_api_key
 GROK_MODEL=grok-3
-ANTHROPIC_API_KEY=sk-ant-your_anthropic_key
-CLAUDE_MODEL=claude-sonnet-4-20250514
+# GROK_REASONING_EFFORT=low
 
-# AI tuning
-AI_TIMEOUT_MS=60000
-AI_DEFAULT_MAX_TOKENS=4000
-AI_TEMPERATURE=0.7
-AI_FALLBACK_COOLDOWN_MS=300000
-AI_AUTH_COOLDOWN_MS=1800000
+# Anthropic Claude (Grok 장애 시 자동 fallback — 선택)
+# ANTHROPIC_API_KEY=sk-ant-your_anthropic_key
+# CLAUDE_MODEL=claude-opus-4-7
 
-# Database
-DATABASE_URL=postgresql://user:password@host:5432/arcanainsight
+# ============================================================
+# AI 튜닝 (선택 — 기본값 사용 권장)
+# ============================================================
+# AI_TIMEOUT_MS=240000
+# AI_DEFAULT_MAX_TOKENS=4000
+# AI_TEMPERATURE=0.7
+# AI_FALLBACK_COOLDOWN_MS=300000
+# AI_AUTH_COOLDOWN_MS=1800000
 
-# Auth (NextAuth)
-NEXTAUTH_URL=http://localhost:3000
-NEXTAUTH_SECRET=your_nextauth_secret
-GITHUB_CLIENT_ID=your_github_client_id
-GITHUB_CLIENT_SECRET=your_github_client_secret
+# ============================================================
+# PostgreSQL 모드 (온프레미스 전환 시 활성화)
+# ============================================================
+# DB_PROVIDER=postgres
+# POSTGRES_URL=postgresql://user:password@host:5432/arcanainsight
+# POSTGRES_POOL_SIZE=10
+# NEXTAUTH_SECRET=your_nextauth_secret  # openssl rand -base64 32
+# NEXTAUTH_URL=http://localhost:3000
+# GOOGLE_CLIENT_ID=your_google_client_id
+# GOOGLE_CLIENT_SECRET=your_google_client_secret
 
-# Verum observability (Phase 0 — OTLP only)
-OTEL_EXPORTER_OTLP_ENDPOINT=https://verum-production.up.railway.app/api/v1/otlp
-OTEL_EXPORTER_OTLP_HEADERS=Authorization=Bearer YOUR_VERUM_API_KEY
-VERUM_API_URL=https://verum-production.up.railway.app
-VERUM_API_KEY=YOUR_VERUM_API_KEY
-VERUM_DEPLOYMENT_ID=YOUR_DEPLOYMENT_ID
+# ============================================================
+# Upstash Redis — Rate-Limit (선택, 다중 인스턴스 환경)
+# ============================================================
+# UPSTASH_REDIS_REST_URL=https://xxx.upstash.io
+# UPSTASH_REDIS_REST_TOKEN=AXxx...
+
+# ============================================================
+# 개발 도구 (런타임 불필요)
+# ============================================================
+# REPLICATE_API_KEY=r8_your_replicate_key  # pnpm generate:assets 실행 시만 필요

--- a/docs/architecture/auth-abstraction.md
+++ b/docs/architecture/auth-abstraction.md
@@ -10,7 +10,7 @@
 |------|------|
 | `getCurrentUser()` | 현재 로그인 사용자 반환. 비로그인 시 `null` |
 | `requireUser()` | 로그인 필수. 비로그인 시 `Error("Unauthorized")` throw |
-| `assertSessionOwnership(sessionId)` | 세션 소유자 확인. 불일치 시 403, 세션 없으면 404 |
+| `assertSessionOwnership(sessionId)` | 세션 소유자 확인. 불일치 시 403, 세션 없으면 404. 소유자 없는 세션(`user_id=null`)은 누구나 허용 |
 | `assertReadingAccess(sessionId, mode)` | `"public"` = 항상 허용, `"owner"` = 소유자만 허용 |
 
 ---

--- a/docs/architecture/data-model.md
+++ b/docs/architecture/data-model.md
@@ -166,7 +166,7 @@ export interface EffectTheme {
 - `persist` key: `'arcana-card-style'` (localStorage)
 
 **이미지 URL 헬퍼** (`src/lib/storage/card-style.ts`):
-- `getCardStyleImageUrl(cardId, styleId)` — Supabase Storage `card-styles` 버킷의 카드 앞면 URL
+- `getCardStyleImageUrl(styleId, cardId)` — Supabase Storage `card-styles` 버킷의 카드 앞면 URL
 - `getCardStyleBackUrl(styleId)` — 스타일별 카드 뒷면 URL (`card-back.webp`)
 
 ---

--- a/docs/architecture/db-abstraction.md
+++ b/docs/architecture/db-abstraction.md
@@ -36,13 +36,14 @@ API Route
 
 ```
 src/lib/db/
-├── index.ts              # getDb() 팩토리
-├── types.ts              # DbClient 공통 인터페이스 (findMany: limit/offset 옵션 포함)
-├── supabase-adapter.ts   # Supabase 구현체
-├── postgres-adapter.ts   # Drizzle ORM 구현체
-├── reading-saver.ts      # DB 저장 추상화 — 3회 retry + 지수 백오프
-├── character-context.ts  # getRecentCharacterMemory() / fetchMemoryPrompt() — 캐릭터 메모리 공통 추출 (tarot/saju/shinjeom 3개 라우트에서 import)
-└── schema/index.ts       # Drizzle 스키마 (supabase/migrations/ 동기화 대상)
+├── index.ts                    # getDb() 팩토리
+├── types.ts                    # DbClient 공통 인터페이스 (findMany: limit/offset 옵션 포함)
+├── supabase-adapter.ts         # Supabase 구현체
+├── supabase-admin-adapter.ts   # service_role 기반 RLS 우회 어댑터 (Supabase 전용)
+├── postgres-adapter.ts         # Drizzle ORM 구현체
+├── reading-saver.ts            # DB 저장 추상화 — 3회 retry + 지수 백오프
+├── character-context.ts        # getRecentCharacterMemory() / fetchMemoryPrompt() — 캐릭터 메모리 공통 추출 (tarot/saju/shinjeom 3개 라우트에서 import)
+└── schema/index.ts             # Drizzle 스키마 (supabase/migrations/ 동기화 대상)
 ```
 
 ---
@@ -66,6 +67,7 @@ src/lib/db/
 | `012_spread_type_expand.sql` | sessions.spread_type CHECK 제약 확장 (10개 스프레드, PR #216) |
 | `013_*` ~ `015_fix_sessions_rls.sql` | RLS 보강 (PR #219·#221 — share_token USING(true), 익명 세션 SELECT 허용 등) |
 | `016_locale_columns.sql` | 5개 테이블 locale 컬럼 + idx_sessions_user_locale (PR #223) |
+| `017_daily_fortune_areas.sql` | daily_cards.area 컬럼 추가 + UNIQUE(date, character_id, area) 재구성 (DailyFortune 5영역) |
 
 PostgreSQL 모드: `src/lib/db/schema/index.ts` (Drizzle)에 동일 스키마 정의됨
 
@@ -90,7 +92,7 @@ PostgreSQL 모드: `src/lib/db/schema/index.ts` (Drizzle)에 동일 스키마 �
 
 ```typescript
 // 호출 패턴 (fire-and-forget, 스트림 차단 없음)
-void saveTarotReading(db, sessionId, result, cards).catch(
+void saveTarotReading(db, sessionId, result, cards, locale).catch(
   (e) => console.error("타로 DB 저장 최종 실패:", e)
 )
 ```

--- a/docs/architecture/system-overview.md
+++ b/docs/architecture/system-overview.md
@@ -82,6 +82,7 @@ ArcanaInsight의 3개 운세 서비스(타로·사주·신점) 사용자 흐름 
 
 | 주제 | 노출 스프레드 |
 |------|-------------|
+| 연애 (전체) | 원카드, 쓰리카드, 5장 켈틱, 관계 스프레드, 10장 켈틱 |
 | 연애 (솔로) | 원카드, 쓰리카드, 5장 켈틱, 10장 켈틱 |
 | 연애 (커플) | 원카드, 쓰리카드, 관계 스프레드, 10장 켈틱 |
 | 직장/진로 | 원카드, 쓰리카드, 5장 켈틱, 말굽, 10장 켈틱 |
@@ -109,13 +110,13 @@ ArcanaInsight의 3개 운세 서비스(타로·사주·신점) 사용자 흐름 
 
 1. **HeroSection** — 풀스크린 히어로 (캐릭터 + 카피 + CTA)
 2. **CharacterGallery** — 12캐릭터 갤러리 (카드형, 성별 필터 내장)
-3. **DailyCard** — 캐릭터별 일일 운세 (탭 전환 + 카드 뒤집기 + 공유)
+3. **DailyFortune** — 캐릭터별 일일 운세 (5개 영역 1+4 레이아웃)
 4. **SkinGallery** — 카드 스킨 갤러리 (6종)
 5. **ServiceFlow** — 서비스 이용 흐름 소개
 6. **FAQ** — 아코디언 FAQ
 7. **BottomCTA** — 하단 행동 유도
 
-> `GenderFilterToggle` 컴포넌트는 `CharacterGallery` 내부에서 사용 중 (`components/home/CharacterGallery.tsx`)
+> `GenderFilterToggle` 컴포넌트는 `components/home/GenderFilter.tsx`에 정의되며 `CharacterGallery.tsx`에서 import해 사용
 
 ## 다국어(i18n) 인프라
 

--- a/docs/conventions/i18n-style.md
+++ b/docs/conventions/i18n-style.md
@@ -44,7 +44,7 @@ export async function POST(req: NextRequest) {
 ## 키 네이밍
 
 - 형식: `namespace.key` 또는 `namespace.section.key`
-- namespace: 5개 (`common`·`header`·`footer`·`home`·`settings`·`locale`)
+- namespace: 16개 (`common`·`header`·`footer`·`home`·`settings`·`locale`·`tarot`·`saju`·`mypage`·`character`·`auth`·`share`·`chat`·`api`·`meta`·`shinjeom`) — 전체 목록은 `src/i18n/translations/shared/keys.ts` 참조
 - 케이스: dot-notation, kebab-case 단어 분리 (`skip-link`, `nav.daily-card`)
 - 예: `header.nav.tarot`, `footer.section.services`, `home.hero.title`, `locale.modal.confirm`
 

--- a/docs/conventions/image-assets.md
+++ b/docs/conventions/image-assets.md
@@ -17,7 +17,7 @@
 | 카드 | SVG | `cards/major/`, `cards/cups/` 등 | — |
 | 배경 | JPG | `backgrounds/` | — |
 | 아이콘 | PNG RGBA (투명 배경) | `images/icons/` | 콘텐츠 크롭 |
-| 카드 스킨 | PNG/JPG | `images/skins/` | — |
+| 카드 스킨 | PNG/JPG | `images/skins/` (`pnpm download:skins` 실행 후 생성) | — |
 
 ---
 

--- a/docs/conventions/zod-schemas.md
+++ b/docs/conventions/zod-schemas.md
@@ -48,7 +48,7 @@ const body = await request.json() as { field1: string };
 
 ## 3. 기존 스키마 목록
 
-`src/lib/validation/api-schemas.ts` — 7종:
+`src/lib/validation/api-schemas.ts` — 9종:
 
 | 스키마 | 용도 |
 |--------|------|
@@ -59,6 +59,8 @@ const body = await request.json() as { field1: string };
 | `SajuSessionSchema` | 사주 세션 생성 |
 | `ShinjeomSessionSchema` | 신점 세션 생성 |
 | `DailyCardSchema` | 일일 카드 요청 |
+| `DailyFortuneSchema` | 일일 운세 요청 (5개 영역) |
+| `FavoriteCharacterSchema` | 선호 상담사 설정 |
 
 ---
 

--- a/docs/operations/deployment.md
+++ b/docs/operations/deployment.md
@@ -28,13 +28,14 @@ Railway는 `main` 브랜치의 모든 push에 자동으로 반응합니다. 수�
 
 | Secret | 설명 | 사용 워크플로우 |
 |--------|------|----------------|
-| `NEXT_PUBLIC_SUPABASE_URL` | Supabase 프로젝트 URL | deploy.yml, sonar.yml, weekly-qa.yml |
-| `NEXT_PUBLIC_SUPABASE_ANON_KEY` | Supabase 익명 키 | deploy.yml, sonar.yml, weekly-qa.yml |
-| `NEXT_PUBLIC_SITE_URL` | 사이트 URL | deploy.yml, sonar.yml, weekly-qa.yml |
-| `GROK_API_KEY` | Grok API 키 | deploy.yml, sonar.yml, weekly-qa.yml |
-| `SUPABASE_SERVICE_ROLE_KEY` | Supabase 서비스 키 | deploy.yml, sonar.yml, weekly-qa.yml |
+| `NEXT_PUBLIC_SUPABASE_URL` | Supabase 프로젝트 URL | deploy.yml, weekly-qa.yml |
+| `NEXT_PUBLIC_SUPABASE_ANON_KEY` | Supabase 익명 키 | deploy.yml, weekly-qa.yml |
+| `GROK_API_KEY` | Grok API 키 | deploy.yml, weekly-qa.yml |
+| `SUPABASE_SERVICE_ROLE_KEY` | Supabase 서비스 키 | deploy.yml, weekly-qa.yml |
 | `SONAR_TOKEN` | SonarCloud 분석 토큰 | sonar.yml |
 | `CODECOV_TOKEN` | Codecov 업로드 토큰 | sonar.yml |
+
+> `NEXT_PUBLIC_SITE_URL`은 CI에서 `http://localhost:3000`으로 하드코딩되어 있어 GitHub Secret 불필요.
 
 ---
 

--- a/docs/operations/env-variables.md
+++ b/docs/operations/env-variables.md
@@ -4,7 +4,8 @@
 > 협업 프로토콜 정본: [`../workflow/claude-codex-collaboration.md`](../workflow/claude-codex-collaboration.md)
 
 `src/lib/env.ts`의 getter 함수와 대응하는 전체 환경변수 목록입니다.
-환경변수는 코드에 하드코딩 금지 — 반드시 `src/lib/env.ts`의 getter 함수를 통해 접근합니다.
+환경변수는 코드에 하드코딩 금지 — 원칙적으로 `src/lib/env.ts`의 getter 함수를 통해 접근합니다.
+단, `NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_ANON_KEY`, `SUPABASE_SERVICE_ROLE_KEY`, `NEXT_PUBLIC_SITE_URL`은 Supabase 클라이언트 초기화 코드에서 `process.env.*`로 직접 접근합니다 (Next.js NEXT_PUBLIC_ 패턴 준수).
 
 ---
 
@@ -109,7 +110,7 @@ DB_PROVIDER=supabase
 
 ## 관련 파일
 
-- `src/lib/env.ts` — 모든 getter 함수 정의 (16개)
+- `src/lib/env.ts` — 모든 getter 함수 정의 (17개)
 - `src/lib/auth/index.ts` — DB_PROVIDER 기반 auth 전환
 - `src/lib/db/index.ts` — DB_PROVIDER 기반 DB 전환
 - `src/lib/storage/index.ts` — DB_PROVIDER 기반 이미지 URL 전환

--- a/docs/workflow/ci-cd.md
+++ b/docs/workflow/ci-cd.md
@@ -23,8 +23,8 @@ jobs:
 
 `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` 환경변수가 모든 워크플로우에 전역 적용되어 있습니다.
 
-- 3개 job이 모두 통과해야 PR 머지 가능 (branch protection rule)
-- E2E 실패 → 스크린샷·비디오 artifact 90일 보존
+- 5개 job(Lint, Unit Tests, Build, E2E Desktop, E2E Android) 중 branch protection 필수 체크 3개(`Lint & Type Check`, `Build`, `E2E Tests`)가 통과해야 PR 머지 가능
+- E2E 실패 → 스크린샷·비디오 artifact **7일** 보존
 - **GitHub Free 플랜**: 월 2,000분 한도, 예상 사용 ~100분
 
 ### 2. `weekly-qa.yml` — 주간 QA
@@ -54,8 +54,9 @@ jobs:
 **트리거**: PR마다 실행
 
 ```
-pnpm exec tsx scripts/check-env-docs.ts   # env-variables.md 정합성
-pnpm exec tsx scripts/check-doc-links.ts  # docs 상대 링크 검증
+pnpm exec tsx scripts/check-env-docs.ts        # env-variables.md 정합성
+pnpm exec tsx scripts/check-doc-links.ts       # docs 상대 링크 검증
+pnpm exec tsx scripts/check-translation-keys.ts  # i18n 번역 키 drift 검출
 ```
 
 > **sync-test-count**: 테스트 실행이 너무 느려 PR CI에서 제외. 로컬 수동 실행만: `pnpm exec tsx scripts/sync-test-count.ts --check`

--- a/docs/workflow/e2e-testing.md
+++ b/docs/workflow/e2e-testing.md
@@ -137,6 +137,8 @@ docker run --rm \
 | `cross-platform.spec.ts` | 콘솔 에러 · 이미지 로드 · safe-area · 링크 200 응답 | — | Desktop + Mobile |
 | `ui-quality.spec.ts` | JSON 잔여물 감지 · 핵심 텍스트 존재 · 레이아웃 깨짐 · 빈 페이지 감지 | — | 없음 |
 | `theme.spec.ts` | 테마 드롭다운 · 7종 테마 전환 · 3개 디바이스 | — | 없음 |
+| `i18n-matrix.spec.ts` | ko/en/ja 3개 locale 전환 · UI 텍스트 렌더링 검증 | — | 없음 |
+| `theme-atmosphere.spec.ts` | 7종 테마 분위기 이펙트 · 파티클·배경 렌더링 | — | 없음 |
 | `smart-ci.spec.ts` | 실 Supabase 세션 기반 플로우 검증 (CI `testIgnore` 대상) — 파일 상단 `// ⚠️ 실 Supabase 인증 세션 필요 — CI testIgnore 대상` 주석 필수 | — | ⚠️ 실 세션 필요 |
 
 ---

--- a/docs/workflow/scripts.md
+++ b/docs/workflow/scripts.md
@@ -11,6 +11,7 @@
 |---|---|---|
 | `pre-push-checks.sh` | `.claude/settings.json` PreToolUse hook | `tsc --noEmit` + `eslint` + `next build` 통과 확인 후 push 허용 |
 | `check-doc-links.ts` | `.github/workflows/docs-sync.yml` + `pnpm check:doc-links` | docs/ 내 상대 링크·앵커 검증, 깨진 링크 보고 |
+| `check-translation-keys.ts` | `.github/workflows/docs-sync.yml` + `pnpm i18n:check` | 번역 키 drift 검출 (ko/en/ja 동기화 검증) |
 | `e2e-full/orchestrator.ts` | `pnpm test:e2e:full` / `pnpm test:e2e:full:ci` | 252 조합 멀티 에이전트 E2E (CI 자동 미연동, 수동 또는 별도 트리거) |
 
 ## 2. 명령어 등록 (`pnpm <name>`)
@@ -19,10 +20,13 @@
 |---|---|---|
 | `pnpm check:doc-links` | `check-doc-links.ts` | docs 링크 검증 (로컬·CI) |
 | `pnpm check:env-docs` | `check-env-docs.ts` | `src/lib/env.ts` ↔ `docs/operations/env-variables.md` 정합성 |
+| `pnpm i18n:check` | `check-translation-keys.ts` | 번역 키 drift 검출 (로컬·CI) |
 | `pnpm sync:test-count` | `sync-test-count.ts` | vitest 실제 테스트 수 측정 후 CLAUDE.md·unit-testing.md 자동 갱신 |
+| `pnpm generate:assets` | `generate-assets/index.ts` | Replicate API로 카드·배경·데코 이미지 생성 (`REPLICATE_API_KEY` 필요) |
+| `pnpm generate:assets:skip` | `generate-assets/index.ts --skip-existing` | 이미 존재하는 이미지를 건너뛰고 생성 |
 | `pnpm download:skins` | `download-skin-images.ts` | Supabase Storage 스킨 이미지 로컬 다운로드 (관리자) |
-| `pnpm upload:assets` | `upload-to-supabase.ts` | 로컬 카드·배경·데코 이미지를 Supabase Storage 업로드 |
-| `pnpm upload:assets:skip` | `upload-to-supabase.ts --skip-existing` | 이미 존재하는 이미지를 건너뛰고 업로드 |
+| `pnpm upload:assets` | `generate-assets/upload-to-supabase.ts` | 로컬 카드·배경·데코 이미지를 Supabase Storage 업로드 |
+| `pnpm upload:assets:skip` | `generate-assets/upload-to-supabase.ts --skip-existing` | 이미 존재하는 이미지를 건너뛰고 업로드 |
 | `pnpm test:e2e:full` | `e2e-full/orchestrator.ts --mode=full --workers=6` | 전수 E2E (실서버 + 실 API 키 필요) |
 | `pnpm test:e2e:full:ci` | `e2e-full/orchestrator.ts --mode=ci` | CI 대표 12 조합 |
 
@@ -32,7 +36,8 @@
 
 | 스크립트 | 용도 |
 |---|---|
-| `generate-characters.ts` | 캐릭터 이미지 생성 (Grok 이미지 API) |
+| `generate-characters.ts` | 캐릭터 이미지 생성 (Grok 이미지 API, 구버전) |
+| `generate-character-images-v2.mjs` | 캐릭터 누끼 이미지 생성 v2 (현행 기준) |
 | `generate-card-images.ts` | 타로 카드 이미지 생성 |
 | `generate-skin-images.ts` | 카드 스킨 이미지 생성 |
 | `generate-backgrounds.ts` | 배경 이미지 생성 |

--- a/docs/workflow/unit-testing.md
+++ b/docs/workflow/unit-testing.md
@@ -44,11 +44,12 @@ import 방식:
 import { POST } from "@/app/api/tarot/reading/route";
 ```
 
-현재 `src/__tests__/api/` 파일 목록 (12개):
+현재 `src/__tests__/api/` 파일 목록 (13개):
 - `tarot-session.test.ts` (14개), `saju-session.test.ts` (12개), `shinjeom-session.test.ts` (13개)
 - `tarot-result.test.ts` (4개), `saju-result.test.ts` (4개), `shinjeom-result.test.ts` (5개)
 - `tarot-reading.test.ts` (23개), `saju-reading.test.ts` (19개), `shinjeom-message.test.ts` (19개)
 - `favorite-character.test.ts` (11개), `daily-card.test.ts` (10개), `locale-wiring.test.ts` (15개)
+- `daily-fortune.test.ts`
 
 ---
 

--- a/src/app/api/CLAUDE.md
+++ b/src/app/api/CLAUDE.md
@@ -16,10 +16,12 @@ api/
 │   └── result/[id]/route.ts
 ├── shinjeom/
 │   ├── session/route.ts
-│   └── reading/route.ts    # SSE 스트리밍 메시지 (POST)
+│   ├── message/route.ts    # SSE 스트리밍 메시지 (POST)
+│   └── result/[id]/route.ts
 ├── auth/
 │   └── [...nextauth]/      # NextAuth.js (DB_PROVIDER=postgres 모드)
 ├── daily-card/route.ts
+├── daily-fortune/route.ts
 ├── locale/route.ts
 └── profile/
     └── favorite-character/route.ts
@@ -62,7 +64,7 @@ export async function POST(request: NextRequest) {
 
 ## SSE 스트리밍 패턴
 
-`tarot/reading`, `saju/reading`, `shinjeom/reading`(message)은 SSE로 응답한다.
+`tarot/reading`, `saju/reading`, `shinjeom/message`은 SSE로 응답한다.
 
 ```ts
 import { SSE_HEADERS } from "@/lib/request-utils";

--- a/src/services/CLAUDE.md
+++ b/src/services/CLAUDE.md
@@ -48,7 +48,7 @@ interface DivinationService {
   startSession(topic: Topic): Omit<Session, "id" | "createdAt">;
   getSystemPrompt(characterId?: string, locale?: string): string;
   getReadingPrompt(context: SessionContext): string;
-  parseResult(aiResponse: string, expectedCardCount?: number): ReadingResult;
+  parseResult(aiResponse: string): ReadingResult;
 }
 ```
 


### PR DESCRIPTION
## Summary

4-에이전트 병렬 검사로 발견한 **30개 문서-코드 불일치** 항목을 수정합니다.

- **CLAUDE.md 파일**: `shinjeom/reading` → `shinjeom/message` 경로 오기재, `daily-fortune` route 누락, `parseResult` 인터페이스 시그니처 불일치
- **아키텍처 문서**: `getCardStyleImageUrl` 파라미터 순서 오기재(버그 유발 위험), `supabase-admin-adapter.ts` 누락, migration 017 누락, `DailyCard` → `DailyFortune` 컴포넌트명 오기재
- **워크플로우 문서**: CI artifact 보존 기간 90일→7일, E2E 스펙 파일 2개 누락, API 테스트 파일 수 12→13
- **컨벤션 문서**: namespace 수 5→16, Zod 스키마 목록 7→9종
- **`.env.example` 전면 재작성**: Verum 변수 제거, `GITHUB_*`→`GOOGLE_*`, `DATABASE_URL`→`POSTGRES_URL`, 기본값(`AI_TIMEOUT_MS`, `CLAUDE_MODEL`) 수정, Supabase 변수 추가

## Test Plan

- [x] `pnpm type-check` 통과 (문서·`.env.example` 변경만이므로 타입 오류 없음)
- [x] 수정된 16개 파일의 실제 코드 대조 완료
- [ ] `pnpm check:doc-links` CI 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)