### PR TITLE
test(saju): birthTime=null·mbti 저장 회귀 방지 테스트 추가

### DIFF
--- a/src/__tests__/api/saju-reading.test.ts
+++ b/src/__tests__/api/saju-reading.test.ts
@@ -161,6 +161,71 @@ describe("POST /api/saju/reading", () => {
     expect(mockSave).toHaveBeenCalledWith(mockDb, "sess-saju", expect.any(Object), expect.any(String));
   });
 
+  it("birthTime=null → birth_hour: null 로 저장 (NOT NULL 위반 방지)", async () => {
+    const mockSave = vi.fn().mockResolvedValue(undefined);
+    vi.doMock("@/lib/db/reading-saver", () => ({ saveSajuReading: mockSave }));
+    vi.doMock("@/lib/rate-limit", () => ({
+      checkRateLimit: vi.fn().mockReturnValue(true),
+      rateLimitResponse: vi.fn(),
+    }));
+    const mockDb = makeMockDb();
+    vi.doMock("@/lib/db", () => ({ getDb: vi.fn().mockReturnValue(mockDb), getAdminDb: vi.fn().mockReturnValue(mockDb) }));
+    vi.doMock("@/lib/auth", () => makeAuthMock());
+    vi.doMock("@/services/core/fallback-provider", () => makeMockAiModule());
+    const { POST } = await import("@/app/api/saju/reading/route");
+    const res = await POST(makePostRequest({
+      ...VALID_BODY,
+      sessionId: "sess-no-time",
+      userInfo: { ...VALID_BODY.userInfo, birthTime: null },
+    }));
+    await readSSEStream(res);
+    await Promise.resolve();
+    const savedData = mockSave.mock.calls[0]?.[2] as Record<string, unknown>;
+    expect(savedData?.birth_hour).toBeNull();
+  });
+
+  it("mbti 입력 시 saju_readings에 저장", async () => {
+    const mockSave = vi.fn().mockResolvedValue(undefined);
+    vi.doMock("@/lib/db/reading-saver", () => ({ saveSajuReading: mockSave }));
+    vi.doMock("@/lib/rate-limit", () => ({
+      checkRateLimit: vi.fn().mockReturnValue(true),
+      rateLimitResponse: vi.fn(),
+    }));
+    const mockDb = makeMockDb();
+    vi.doMock("@/lib/db", () => ({ getDb: vi.fn().mockReturnValue(mockDb), getAdminDb: vi.fn().mockReturnValue(mockDb) }));
+    vi.doMock("@/lib/auth", () => makeAuthMock());
+    vi.doMock("@/services/core/fallback-provider", () => makeMockAiModule());
+    const { POST } = await import("@/app/api/saju/reading/route");
+    const res = await POST(makePostRequest({
+      ...VALID_BODY,
+      sessionId: "sess-mbti",
+      userInfo: { ...VALID_BODY.userInfo, mbti: "INFP" },
+    }));
+    await readSSEStream(res);
+    await Promise.resolve();
+    const savedData = mockSave.mock.calls[0]?.[2] as Record<string, unknown>;
+    expect(savedData?.mbti).toBe("INFP");
+  });
+
+  it("mbti 미입력 시 mbti: null 로 저장", async () => {
+    const mockSave = vi.fn().mockResolvedValue(undefined);
+    vi.doMock("@/lib/db/reading-saver", () => ({ saveSajuReading: mockSave }));
+    vi.doMock("@/lib/rate-limit", () => ({
+      checkRateLimit: vi.fn().mockReturnValue(true),
+      rateLimitResponse: vi.fn(),
+    }));
+    const mockDb = makeMockDb();
+    vi.doMock("@/lib/db", () => ({ getDb: vi.fn().mockReturnValue(mockDb), getAdminDb: vi.fn().mockReturnValue(mockDb) }));
+    vi.doMock("@/lib/auth", () => makeAuthMock());
+    vi.doMock("@/services/core/fallback-provider", () => makeMockAiModule());
+    const { POST } = await import("@/app/api/saju/reading/route");
+    const res = await POST(makePostRequest({ ...VALID_BODY, sessionId: "sess-no-mbti" }));
+    await readSSEStream(res);
+    await Promise.resolve();
+    const savedData = mockSave.mock.calls[0]?.[2] as Record<string, unknown>;
+    expect(savedData?.mbti).toBeNull();
+  });
+
   it("topicReading 없는 AI 응답 → topic_reading || '' 분기 커버", async () => {
     const mockSave = vi.fn().mockResolvedValue(undefined);
     const noTopicReading = JSON.stringify({ overallReading: "전반 결과", advice: "조언" });


### PR DESCRIPTION
## 배경

PR #354에서 사주 개인정보 저장 버그(birth_hour NOT NULL 위반, mbti 미저장)를 수정했으나, 해당 버그 케이스를 검증하는 테스트가 누락되어 있었습니다.

## 추가된 테스트 (3개)

| 테스트 | 검증 내용 |
|---|---|
| `birthTime=null → birth_hour: null 로 저장` | "시간을 모릅니다" 선택 시 `saveSajuReading()` 페이로드에 `birth_hour: null`이 전달되는지 확인 (NOT NULL 위반 방지) |
| `mbti 입력 시 saju_readings에 저장` | mbti="INFP" 입력 시 DB 저장 페이로드에 `mbti: "INFP"`가 포함되는지 확인 |
| `mbti 미입력 시 mbti: null 로 저장` | mbti 미입력 시 `mbti: null`이 명시적으로 전달되는지 확인 |

## 검증

- `pnpm vitest run src/__tests__/api/saju-reading.test.ts` → 22/22 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)