### PR TITLE
fix(schema): daily_cards area 컬럼 Drizzle 동기화 + session_cards selected_at 전달

### DIFF
--- a/src/app/api/shinjeom/session/route.ts
+++ b/src/app/api/shinjeom/session/route.ts
@@ -30,6 +30,7 @@ export async function POST(request: NextRequest) {
       session = await db.insert("sessions", {
         service_type: "shinjeom",
         topic,
+        spread_type: null,
         character_id: characterId,
         user_id: user?.id ?? null,
         status: "in_progress",

--- a/src/app/api/tarot/reading/route.ts
+++ b/src/app/api/tarot/reading/route.ts
@@ -126,7 +126,9 @@ export async function POST(request: NextRequest) {
           // DB 저장 — fire-and-forget. parseError 있는 부분 결과는 영구 저장하지 않는다
           // (result/[id] 진입 시 빈 화면 방지). 클라이언트는 in_progress 세션을 재시도 가능.
           if (db && sessionId && !result.parseError) {
-            void saveTarotReading(db, sessionId, result, cards, locale).catch(
+            void saveTarotReading(db, sessionId, result, selectedCards.map((c) => ({
+              cardId: c.card.id, position: c.position, isReversed: c.isReversed, selectedAt: c.selectedAt,
+            })), locale).catch(
               (e) => console.error("타로 DB 저장 최종 실패:", e)
             )
           }

--- a/src/lib/db/reading-saver.ts
+++ b/src/lib/db/reading-saver.ts
@@ -35,7 +35,7 @@ export async function saveTarotReading(
   db: DbClient,
   sessionId: string,
   reading: { cardInterpretations?: unknown; overallReading: string; advice: string },
-  cards: { cardId: string; position: number; isReversed: boolean }[],
+  cards: { cardId: string; position: number; isReversed: boolean; selectedAt?: Date }[],
   locale: string = "ko"
 ): Promise<void> {
   const lc = safeLocale(locale);
@@ -58,6 +58,7 @@ export async function saveTarotReading(
           card_id: c.cardId,
           position: c.position,
           is_reversed: c.isReversed,
+          ...(c.selectedAt ? { selected_at: c.selectedAt.toISOString() } : {}),
         }))
       ),
     ])

--- a/src/lib/db/schema/index.ts
+++ b/src/lib/db/schema/index.ts
@@ -73,8 +73,9 @@ export const dailyCards = pgTable("daily_cards", {
   interpretation: text("interpretation").notNull(),
   keywords: text("keywords").array().default([]),
   createdAt: timestamp("created_at", { withTimezone: true }).defaultNow(),
+  area: text("area").notNull().default("general"),
 }, (t) => [
-  uniqueIndex("daily_cards_date_character_id_key").on(t.date, t.characterId),
+  uniqueIndex("daily_cards_date_character_area_key").on(t.date, t.characterId, t.area),
 ])
 
 export const sajuReadings = pgTable("saju_readings", {


### PR DESCRIPTION
## Summary

- **daily_cards.area Drizzle 미반영 수정**: migration 017이 추가한 `area text NOT NULL DEFAULT 'general'` 컬럼과 UNIQUE 인덱스 `(date, character_id, area)` 3-컬럼을 `schema/index.ts`에 반영. `DB_PROVIDER=postgres` 전환 시 `/api/daily-fortune`·`/api/daily-card`가 즉시 500 에러를 내는 문제 방지.
- **session_cards.selected_at 전달**: 타로 카드 선택 시각(`selectedAt`)을 `saveTarotReading` 호출 시 전달하여 AI 생성 완료 시각 대신 요청 수신 시각이 기록되도록 수정.
- **shinjeom session spread_type 일관성**: 신점 세션 INSERT에 `spread_type: null` 명시 추가.

## 변경 파일

| 파일 | 변경 내용 |
|---|---|
| `src/lib/db/schema/index.ts` | `dailyCards` — `area` 컬럼 추가, uniqueIndex 3-컬럼으로 교체 |
| `src/lib/db/reading-saver.ts` | `saveTarotReading` — cards 파라미터에 `selectedAt?` 추가, INSERT에 `selected_at` 전달 |
| `src/app/api/tarot/reading/route.ts` | `saveTarotReading` 호출 시 `cards` → `selectedCards` 매핑으로 교체 |
| `src/app/api/shinjeom/session/route.ts` | `spread_type: null` 명시 추가 |

## DB 관련 (이미 적용 완료)

아래 3개 마이그레이션은 이미 Supabase DB에 직접 적용됨 (이 PR과 별개):
- migration 007: `profiles.selected_skin` 추가
- migration 018: `profiles.mbti` 추가
- migration 019: `saju_readings.birth_hour` NOT NULL 해제 + `saju_readings.mbti` 추가

## Test plan

- [ ] `pnpm type-check` 통과 확인
- [ ] `pnpm build` 통과 확인
- [ ] Unit Tests 통과 확인
- [ ] E2E daily-fortune, daily-card 관련 테스트 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)