### PR TITLE
docs: Doc Audit + Plan B — 역할 표기 및 아키텍처 문서 재작성

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,9 +96,6 @@ pnpm upload:assets:skip   # 이미 존재하는 이미지 건너뛰고 업로드
 
 전체 목록과 전환 절차는 [`docs/operations/env-variables.md`](docs/operations/env-variables.md)가 정본이다.
 
-- Supabase 기본 필수: `GROK_API_KEY`, `NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_ANON_KEY`, `SUPABASE_SERVICE_ROLE_KEY`, `NEXT_PUBLIC_SITE_URL`
-- PostgreSQL 모드 추가: `DB_PROVIDER=postgres`, `POSTGRES_URL`, `NEXTAUTH_SECRET`, `NEXTAUTH_URL`, `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`
-
 ## 변경 프로세스
 
 상세 절차는 [`docs/workflow/code-change-process.md`](docs/workflow/code-change-process.md)를 따른다.

--- a/docs/architecture/data-model.md
+++ b/docs/architecture/data-model.md
@@ -1,5 +1,8 @@
 # 데이터 모델 — 캐릭터·카드·스킨
 
+> **담당**: Claude (데이터 구조·타입 계약 설계) | Codex (데이터 파일 작성·검증)
+> 협업 프로토콜 정본: [`../workflow/claude-codex-collaboration.md`](../workflow/claude-codex-collaboration.md)
+
 ArcanaInsight의 정적 데이터(캐릭터, 카드, 스프레드, 스킨) 모델을 정의합니다.
 
 ---

--- a/docs/architecture/system-overview.md
+++ b/docs/architecture/system-overview.md
@@ -4,6 +4,35 @@ ArcanaInsight의 3개 운세 서비스(타로·사주·신점) 사용자 흐름 
 
 ---
 
+## 개요 — 레이어 다이어그램
+
+```
+사용자 브라우저
+  └─ Next.js App Router (src/app/)
+       ├─ UI 레이어 (src/components/)
+       │    ├─ card/         — CardFace, CardBack, CardItem, CardStyleSelector
+       │    ├─ character/    — 캐릭터 등장 컴포넌트
+       │    ├─ effects/      — ThemeEffectEngine, ParticleOverlay, MysticBackground 등 5-레이어 이펙트
+       │    └─ chat/home/tarot/saju/shinjeom/...
+       ├─ 상태 (src/hooks/)
+       │    ├─ useCardStyleStore  — 카드 스타일 persist (arcana-card-style)
+       │    └─ useSkinStore, useTheme, ...
+       ├─ API 라우트 (src/app/api/)  — SSE 스트리밍 + Zod 검증 + Auth
+       └─ 서비스 레이어 (src/services/)
+            ├─ core/FallbackProvider  — Grok 우선 → Claude API fallback
+            ├─ tarot/, saju/, shinjeom/
+            └─ core/prompt-builder, text-cleaner, circuit-breaker
+
+데이터 레이어
+  ├─ Supabase (기본)     — Auth + PostgreSQL + Storage(card-styles 버킷)
+  └─ PostgreSQL 모드     — NextAuth.js v5 + Drizzle (DB_PROVIDER=postgres 시)
+```
+
+**API 보안 순서** (변경 금지): Rate Limit → Zod `safeParse` → Auth → 소유권 검증
+
+---
+
+
 ## 1. 서비스별 사용자 흐름
 
 ### 타로 (4단계)

--- a/docs/operations/known-issues.md
+++ b/docs/operations/known-issues.md
@@ -43,6 +43,20 @@ Quality Gate: **PASSED** | Bugs: 0 | Vulnerabilities: 0 | CRITICAL: **0건**
 
 ---
 
+## Visual Overhaul 진행 현황
+
+카드 아트 스타일 시스템(Visual Overhaul) Phase별 상태:
+
+| Phase | 내용 | 상태 | 비고 |
+|-------|------|------|------|
+| Phase 1 | AI 생성 카드 이미지 (Replicate API) — 4종 스타일 × 78장 앞면 + 뒷면 | ⚠️ 이미지 미생성 | `pnpm generate:assets` + `pnpm upload:assets` 실행 필요. `REPLICATE_API_KEY` 환경변수 필요 |
+| Phase 2 | `CardStyleSelector` UI, `useCardStyleStore`, `CardFace`/`CardBack` styleId 지원 | ✅ 완료 | 코드 구현 완료. 이미지 없으면 SVG fallback 렌더링 |
+| Phase 3 | 설정 페이지 CardStyleSelector 통합, SkinGallery 연동, 테마 자동 매핑 표시 | ✅ 완료 | `/settings` 카드 스킨 섹션에 11개 버튼 통합 |
+
+> Phase 1 이미지 미생성 상태에서도 서비스는 SVG 스킨으로 정상 동작함.
+
+---
+
 ## Verum 침투적 통합 제거 이력
 
 비침투적 재도입 준비를 위해 `src/lib/verum/` SDK 및 모든 관련 코드를 제거한 작업 (2026-04-25).

--- a/docs/workflow/claude-codex-collaboration.md
+++ b/docs/workflow/claude-codex-collaboration.md
@@ -25,7 +25,7 @@
 |---|-----------|--------|
 | C1 | 기능 요구사항 분석 및 스펙 문서 작성 | `docs/superpowers/specs/*.md` |
 | C2 | 아키텍처 설계·기술 결정 문서 | `docs/architecture/*.md` 갱신 |
-| C3 | 에이전트 정의 및 Task Playbook | `.claude/agents/*.md`, `docs/workflow/task-playbooks.md` |
+| C3 | 에이전트 정의 및 Task Playbook | `.claude/agents/*.md`, `docs/workflow/task-playbooks.md` — 현재 6종: `character-add`, `divination-scaffold`, `page-builder`, `skin-manager`, `theme-creator`, `quality-gate` |
 | C4 | DB 스키마 설계 및 마이그레이션 계획 | SQL 초안, Drizzle 스키마 구조 명세 |
 | C5 | 새 서비스·페이지 뼈대 스캐폴딩 | 파일 구조, 인터페이스, 타입 정의, 빈 함수 시그니처 |
 | C6 | `CLAUDE.md` / `AGENTS.md` 최신화 | 구조 트리, 아키텍처 섹션 갱신 |

--- a/docs/workflow/task-playbooks.md
+++ b/docs/workflow/task-playbooks.md
@@ -62,6 +62,20 @@
 
 ---
 
+## 카드 아트 스타일 이미지 생성·업로드 `[Codex]`
+
+1. `src/data/cardStyles.ts` — `CardStyleId` 4종 및 `THEME_TO_STYLE_MAP` 확인
+2. `src/hooks/useCardStyleStore.ts` — `styleOverride`, `useSkinMode`, `resolvedStyle()` 스토어 확인
+3. `src/lib/storage/card-style.ts` — `getCardStyleImageUrl()` / `getCardStyleBackUrl()` 헬퍼
+4. `src/components/card/CardStyleSelector.tsx` — 스타일 선택 UI (설정 페이지)
+5. `scripts/generate-assets/` — Replicate API 생성 오케스트레이터
+6. 생성: `pnpm generate:assets` 또는 `pnpm generate:assets:skip`
+7. 업로드: `pnpm upload:assets` 또는 `pnpm upload:assets:skip`
+
+이미지 경로 규칙: [`docs/conventions/image-assets.md`](../conventions/image-assets.md) §5
+
+---
+
 ## AI 프롬프트 수정 `[Claude → Codex]`
 
 1. `src/services/core/prompt-builder.ts` — 공통 프롬프트 빌더


### PR DESCRIPTION
## Summary

- **CLAUDE.md** — 환경변수 섹션 상세 목록 제거 → 링크 단일화 (148행, 200행 이하 유지)
- **docs/architecture/system-overview.md** — UI 레이어 다이어그램에 `effects/` 5-레이어 이펙트 반영
- **docs/architecture/data-model.md** — Claude/Codex 담당 메타 블록 추가
- **docs/workflow/claude-codex-collaboration.md** — 에이전트 6종(character-add, divination-scaffold, page-builder, skin-manager, theme-creator, quality-gate) 명시
- **docs/workflow/task-playbooks.md** — CardStyleSelector + Replicate API 이미지 생성 플레이북 추가
- **docs/operations/known-issues.md** — Visual Overhaul Phase 1/2/3 현황 표 추가

## Already Complete (Skipped)

- AGENTS.md 경량화: 이미 완료
- CLAUDE.md 역할 분담 압축: 이미 완료
- workflow/ conventions/ operations/ 메타 블록: 이미 완료

## Test plan

- [x] `pnpm check:doc-links` — 신규 링크 오류 0개 (기존 plan 파일 경고 36개는 pre-existing)
- [x] CLAUDE.md 148행 (200행 이하)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)