### PR TITLE
docs: 전체 문서 최신화 — Visual Overhaul Effect Phase 2+3 반영

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,15 +33,19 @@
 src/
 ├── app/             # App Router 페이지와 API
 ├── components/      # card, character, chat, common, effects, home, layout, saju, shinjeom, skin, tarot
-│   └── card/        # CardFace, CardBack, CardItem, CardStyleSelector (스타일 선택 UI)
+│   ├── card/        # CardFace, CardBack, CardItem, CardStyleSelector (스타일 선택 UI)
+│   └── effects/     # ThemeEffectEngine, ThemeAtmosphereLayer, InteractionEffects,
+│                    # ServiceBackground, ParticleOverlay, MysticBackground, ScrollReveal
 ├── data/            # cards, characters, home, saju, shinjeom, skins, spreads, topics
 │   └── cardStyles.ts  # CardStyleId, 4가지 아트 스타일, THEME_TO_STYLE_MAP
 ├── hooks/           # Zustand store와 UI/streaming hooks
-│   └── useCardStyleStore.ts  # 카드 스타일 persist 스토어 (arcana-card-style)
+│   ├── useCardStyleStore.ts   # 카드 스타일 persist 스토어 (arcana-card-style)
+│   └── useReadingReveal.ts    # 타로 카드 텍스트 reveal 타이밍 제어 스토어
 ├── i18n/            # locale 감지, Provider, useT, translations
 ├── lib/             # env, auth, db, storage, validation, request/rate-limit 유틸
 │   └── storage/card-style.ts  # getCardStyleImageUrl, getCardStyleBackUrl
 ├── services/        # core AI provider/fallback + tarot/saju/shinjeom 서비스
+├── styles/          # theme-effects.css — CSS variable 기반 5-레이어 이펙트 정의
 ├── test-helpers/    # Vitest 공통 mock/setup
 └── types/           # 공유 타입
 
@@ -61,6 +65,8 @@ supabase/migrations/ # Supabase SQL migrations
 - SSE 스트리밍: 타로/사주/신점 리딩은 `SSE_HEADERS`, `fetchSSEStream()`, `AbortController` 패턴을 사용. 상세는 [`docs/architecture/ai-infrastructure.md`](docs/architecture/ai-infrastructure.md).
 - i18n: `middleware`가 locale을 결정하고 `x-locale` 헤더와 쿠키를 유지. 상세는 [`docs/architecture/i18n.md`](docs/architecture/i18n.md), [`docs/conventions/i18n-style.md`](docs/conventions/i18n-style.md).
 - 카드 아트 스타일: `CardStyleId`(dark-fantasy·art-nouveau·anime-mystical·modern-digital), `THEME_TO_STYLE_MAP`으로 테마 자동 매핑. `useCardStyleStore`가 사용자 override를 persist. `CardFace`/`CardBack`/`CardItem`은 styleId → skinId → SVG 순으로 이미지 우선순위 처리.
+- 테마 이펙트: `ThemeEffectEngine`이 CSS 변수(`--theme-glow-color`, `--theme-particle-color` 등)를 주입. `ThemeAtmosphereLayer`(글로우·파티클 5-레이어), `InteractionEffects`(`InteractionClickParticles` — `document.addEventListener` 방식, pointer-events-none), `ServiceBackground`, `src/styles/theme-effects.css` 로 구성.
+- 타로 텍스트 reveal: `useReadingReveal` 스토어가 `showLabel` 플래그를 관리. `CardFace` → `CardItem` → `CardSpread` → 타로 세션 페이지로 prop 체인 전달. result phase 진입 시에만 카드명 텍스트 노출.
 
 ## 캐릭터/데이터 기준
 

--- a/docs/operations/known-issues.md
+++ b/docs/operations/known-issues.md
@@ -50,8 +50,10 @@ Quality Gate: **PASSED** | Bugs: 0 | Vulnerabilities: 0 | CRITICAL: **0건**
 | Phase | 내용 | 상태 | 비고 |
 |-------|------|------|------|
 | Phase 1 | AI 생성 카드 이미지 (Replicate API) — 4종 스타일 × 78장 앞면 + 뒷면 | ⚠️ 이미지 미생성 | `pnpm generate:assets` + `pnpm upload:assets` 실행 필요. `REPLICATE_API_KEY` 환경변수 필요 |
-| Phase 2 | `CardStyleSelector` UI, `useCardStyleStore`, `CardFace`/`CardBack` styleId 지원 | ✅ 완료 | 코드 구현 완료. 이미지 없으면 SVG fallback 렌더링 |
-| Phase 3 | 설정 페이지 CardStyleSelector 통합, SkinGallery 연동, 테마 자동 매핑 표시 | ✅ 완료 | `/settings` 카드 스킨 섹션에 11개 버튼 통합 |
+| Phase 2 (카드 스타일) | `CardStyleSelector` UI, `useCardStyleStore`, `CardFace`/`CardBack` styleId 지원 | ✅ 완료 | 코드 구현 완료. 이미지 없으면 SVG fallback 렌더링 |
+| Phase 3 (카드 스타일) | 설정 페이지 CardStyleSelector 통합, SkinGallery 연동, 테마 자동 매핑 표시 | ✅ 완료 | `/settings` 카드 스킨 섹션에 11개 버튼 통합 |
+| Effect Phase 2 | 5-레이어 테마 이펙트 시스템 — `ThemeEffectEngine`, `ThemeAtmosphereLayer`, `InteractionClickParticles`, `theme-effects.css`, CSS variable 주입 | ✅ 완료 (PR #361) | 글로우·파티클·대기층·클릭 이펙트. `document.addEventListener` 방식으로 pointer-events 충돌 없음. PR #362(Phase 3)는 phase2 브랜치에 스택 후 PR #361로 main 통합 |
+| Effect Phase 3 | 서비스 이펙트 + 타로 카드 텍스트 reveal — `showLabel` prop chain, `useReadingReveal`, `ShuffleCeremony` motion trail, `ServiceBackground` | ✅ 완료 (PR #361 포함) | result phase 진입 시에만 카드명 텍스트 노출. `useSession` 스토어는 persist 없는 인메모리 스토어. `useReadingReveal` hook이 `showLabel` 플래그 관리 |
 
 > Phase 1 이미지 미생성 상태에서도 서비스는 SVG 스킨으로 정상 동작함.
 


### PR DESCRIPTION
## Summary

- `CLAUDE.md` 프로젝트 구조 갱신: `src/styles/`, `components/effects/` 전체 컴포넌트 목록, `useReadingReveal` 훅 추가
- `CLAUDE.md` 핵심 아키텍처에 테마 이펙트 시스템 및 타로 텍스트 reveal 설명 추가
- `docs/operations/known-issues.md` Visual Overhaul 표에 Effect Phase 2+3 완료 항목 추가

## Background

PRs #361 (Effect Phase 2 — 5-layer theme effects), #362 (Effect Phase 3 — service effects + card text reveal), #363 (docs rewrite) 머지 완료 후 전역 CLAUDE.md 규칙에 따른 의무 문서 최신화.

## Test plan

- [ ] 문서 링크 검증: `pnpm check:doc-links`

🤖 Generated with [Claude Code](https://claude.com/claude-code)