### PR TITLE
feat(shinjeom): UserInfoForm + MBTI 연동 — 신점 상담 개인화

### DIFF
--- a/docs/operations/known-issues.md
+++ b/docs/operations/known-issues.md
@@ -71,14 +71,15 @@ Quality Gate: **PASSED** | Bugs: 0 | Vulnerabilities: 0 | CRITICAL: **0건**
 
 ---
 
-## i18n 다국어 — 미해결·후속 PR 의존 (2026-05-06 multi-agent 감사)
+## i18n 다국어 — 잔여 항목 (2026-05-14 기준)
+
+모든 PR (#230~#235 포함 9건) 머지 완료. 아래는 의도적으로 보류 중인 항목이다.
 
 | 항목 | 영역 | 상태·근거 |
 |------|------|-----------|
-| **AuthUser 타입 locale 필드 미포함** | `src/lib/auth/index.ts` | PR-4 예정. 현재는 쿠키(`ai_locale`)가 SSOT, `profiles.locale`은 보조 동기화. cross-locale 쿼리 필요 시 PR-4에서 `getCurrentUser()` 반환 타입 확장. |
-| **`daily_cards` 테이블 locale 컬럼 의도적 미포함** | `supabase/migrations/003_daily_cards.sql` | 옵션 B 확정 — `(date, character_id)` UNIQUE 단일 사전 정책. locale 분리 시 4×용량 폭증. 표시 시점 locale 분리는 PR-3·PR-5에서 처리. |
-| **PR-2 사전 정의됨, 페이지 미적용 i18n 키 19개** | `src/i18n/translations/ko/index.ts` (`home.*` 8 + `settings.*` 11) | PR-2에서 사전만 정의됨 (정의 자체는 정상). 페이지 코드(`src/app/page.tsx`·`src/app/settings/page.tsx`) `t()` 적용은 PR-3 영역. SharedKeys 타입은 모든 locale 강제하므로 정의됨 미사용 키도 타입 안전 유지. |
-| **translations 사전 SonarCloud 중복도 모니터링** | `src/i18n/translations/{ko,en,ja}/index.ts` | 현재 4 파일(인덱스+공유키+3 locale). PR-3·PR-5에서 카드·캐릭터 데이터가 추가되면 중복도 누적 위험. `shared/keys.ts` 공통 베이스 + `flatten()` 헬퍼로 1차 방어 중. SonarCloud `new_duplicated_lines_density` 3% 임계 모니터링 필요. |
-| **외부 번역가 발주 시점 미결정** | `docs/i18n/glossary.md`·`character-voice-guide.md` | PR-3 진입 시점에 발주 권장 (사용자 결정). 발주 자료는 PR-3·PR-4 시 작성될 예정. 현재 영어 사전은 1차 임시 직역 placeholder. |
+| **AuthUser 타입 locale 필드 미포함** | `src/lib/auth/index.ts` | 현재 쿠키(`ai_locale`)가 SSOT, `profiles.locale`은 보조 동기화로 충분. cross-locale 쿼리 필요 시 별도 PR에서 `getCurrentUser()` 반환 타입 확장. |
+| **`daily_cards` 테이블 locale 컬럼 의도적 미포함** | `supabase/migrations/003_daily_cards.sql` | 옵션 B 확정 — `(date, character_id)` UNIQUE 단일 사전 정책. locale 분리 시 4×용량 폭증 우려. |
+| **translations 사전 SonarCloud 중복도 모니터링** | `src/i18n/translations/{ko,en,ja}/index.ts` | `shared/keys.ts` 공통 베이스로 1차 방어 중. SonarCloud `new_duplicated_lines_density` 3% 임계 모니터링 필요. |
+| **외부 번역가 미사용** | — | **사용자 확정(2026-05-14)**: 외부 번역 발주 계획 없음. 현행 직역 사전으로 운영 지속. |
 
 상세 인프라: [`../architecture/i18n.md`](../architecture/i18n.md) / 컨벤션: [`../conventions/i18n-style.md`](../conventions/i18n-style.md)

--- a/e2e/helpers/service-navigation.ts
+++ b/e2e/helpers/service-navigation.ts
@@ -78,6 +78,8 @@ export async function navigateToShinjeomSession(page: Page) {
   await page.goto("/shinjeom");
   await selectFirstCharacter(page);
   await page.locator("text=신수").first().click();
+  // user-info 스텝: 건너뛰기로 즉시 세션 진입
+  await page.locator("button:has-text('건너뛰기')").click();
   await page.waitForURL("**/shinjeom/session**", { timeout: 10_000 });
 }
 
@@ -86,6 +88,8 @@ export async function enterShinjeomSession(page: Page) {
   await page.waitForLoadState("networkidle");
   await selectFirstCharacter(page);
   await page.locator("text=신수").first().click();
+  // user-info 스텝: 건너뛰기로 즉시 세션 진입
+  await page.locator("button:has-text('건너뛰기')").click();
   await page.waitForURL("**/shinjeom/session**", { timeout: 10_000 });
   await expect(page.locator("text=고민").first()).toBeVisible({ timeout: 10_000 });
 }

--- a/e2e/shinjeom-flow.spec.ts
+++ b/e2e/shinjeom-flow.spec.ts
@@ -33,6 +33,9 @@ test.describe("신점 서비스 플로우", () => {
     // 주제 선택 (신수)
     await page.locator("text=신수").first().click();
 
+    // user-info 스텝: 건너뛰기로 즉시 세션 진입
+    await page.locator("button:has-text('건너뛰기')").click();
+
     // 세션 페이지 이동
     await page.waitForURL("**/shinjeom/session**", { timeout: 10_000 });
     expect(page.url()).toContain("/shinjeom/session");
@@ -45,6 +48,8 @@ test.describe("신점 서비스 플로우", () => {
     await expect(characterCards.first()).toBeVisible({ timeout: 10_000 });
     await characterCards.first().click();
     await page.locator("text=신수").first().click();
+    // user-info 스텝: 건너뛰기
+    await page.locator("button:has-text('건너뛰기')").click();
     await page.waitForURL("**/shinjeom/session**", { timeout: 10_000 });
 
     // 인사말 메시지 존재
@@ -93,7 +98,7 @@ test.describe("신점 서비스 플로우", () => {
 
 test.describe("신점 세션 — 메시지 전송 플로우", () => {
   test.beforeEach(async ({ page }) => {
-    // 신점 세션 진입: 첫 번째 캐릭터 선택 → 첫 번째 주제 선택
+    // 신점 세션 진입: 첫 번째 캐릭터 선택 → 첫 번째 주제 선택 → user-info 건너뛰기
     await page.setViewportSize({ width: 390, height: 844 });
     await page.goto("/shinjeom");
     await page.waitForLoadState("domcontentloaded");
@@ -105,6 +110,8 @@ test.describe("신점 세션 — 메시지 전송 플로우", () => {
     const firstTopic = page.locator("[data-testid^='shinjeom-topic-btn-']").first();
     await expect(firstTopic).toBeVisible({ timeout: 5000 });
     await firstTopic.click();
+    // user-info 스텝: 건너뛰기
+    await page.locator("button:has-text('건너뛰기')").click();
     await page.waitForURL("**/shinjeom/session", { timeout: 10000 });
   });
 

--- a/src/app/api/shinjeom/message/route.ts
+++ b/src/app/api/shinjeom/message/route.ts
@@ -32,7 +32,7 @@ export async function POST(request: NextRequest) {
     // Zod 입력 검증 (chatHistory 100개 상한으로 토큰 과소비 방어)
     const parsed = ShinjeomMessageSchema.safeParse(rawBody);
     if (!parsed.success) return jsonError("Invalid request");
-    const { sessionId, characterId, currentMessage, isFinalTurn, messageIndex, topic: rawTopic } = parsed.data;
+    const { sessionId, characterId, userInfo, currentMessage, isFinalTurn, messageIndex, topic: rawTopic } = parsed.data;
     if (!SHINJEOM_TOPICS.includes(rawTopic)) return jsonError("Invalid topic");
     const topic = rawTopic as Topic;
     // timestamp는 네트워크 전송 시 문자열/숫자로 직렬화되므로 Date로 복원
@@ -50,7 +50,7 @@ export async function POST(request: NextRequest) {
     }
 
     const systemPrompt = shinjeomService.getSystemPrompt(characterId ?? undefined, locale);
-    const userPrompt = shinjeomService.buildConversationPrompt(topic, currentMessage, chatHistory, isFinalTurn);
+    const userPrompt = shinjeomService.buildConversationPrompt(topic, currentMessage, chatHistory, isFinalTurn, userInfo);
 
     const db = sessionId ? getAdminDb() : null;
 

--- a/src/app/shinjeom/page.tsx
+++ b/src/app/shinjeom/page.tsx
@@ -10,9 +10,11 @@ import { getCharactersByGender, getCharacterById } from "@/data/characters";
 import { CharacterConfig } from "@/types/character";
 import { useGenderStore } from "@/hooks/useGenderStore";
 import { Topic } from "@/types/session";
+import { UserInfo } from "@/types/user-info";
 import { Icon } from "@/components/common/Icon";
 import { useFavoriteCharacter } from "@/hooks/useFavoriteCharacter";
 import { ServiceBackground } from "@/components/effects/ServiceBackground";
+import { UserInfoForm } from "@/components/common/UserInfoForm";
 import { useT } from "@/i18n/useT";
 import { useLocaleStore } from "@/hooks/useLocaleStore";
 import { CulturalReadingDisplay } from "@/components/shinjeom/CulturalReadingDisplay";
@@ -26,7 +28,7 @@ const TOPIC_CONFIGS: { id: Topic; iconId: string }[] = [
   { id: "shinjeom-auspicious", iconId: "shinjeom-auspicious" },
 ];
 
-type PageStep = "character-select" | "topic-select";
+type PageStep = "character-select" | "topic-select" | "user-info";
 
 // ─── Step sub-components ────────────────────────────────────────────────────
 
@@ -116,12 +118,41 @@ function TopicSelectStep({ selectedCharacter, onBack, onTopicSelect }: Readonly<
   );
 }
 
+// ─── UserInfo step ──────────────────────────────────────────────────────────
+
+function UserInfoStep({ selectedCharacter, onBack, onSubmit, onSkip }: Readonly<{
+  selectedCharacter: CharacterConfig | null;
+  onBack: () => void;
+  onSubmit: (data: UserInfo) => void;
+  onSkip: () => void;
+}>) {
+  const { t } = useT();
+  return (
+    <motion.div key="user-info" initial={{ opacity: 0, x: 50 }} animate={{ opacity: 1, x: 0 }} exit={{ opacity: 0, x: -50 }}
+      className="relative z-20 max-w-lg mx-auto px-4 py-8">
+      <UserInfoForm
+        mode="shinjeom"
+        onSubmit={onSubmit}
+        onBack={onBack}
+        characterName={selectedCharacter?.name}
+      />
+      <button
+        type="button"
+        onClick={onSkip}
+        className="mt-4 w-full text-arcana-muted text-sm hover:text-arcana-purple transition-colors text-center py-2"
+      >
+        {t("common.skip")}
+      </button>
+    </motion.div>
+  );
+}
+
 // ─── Page state + routing ───────────────────────────────────────────────────
 
 function ShinjeomPageContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
-  const { setCharacterId, setTopic, setPhase } = useShinjeomSessionStore();
+  const { setCharacterId, setTopic, setPhase, setUserInfo } = useShinjeomSessionStore();
   const { genderFilter, setGenderFilter } = useGenderStore();
   const characters = getCharactersByGender(genderFilter);
 
@@ -174,6 +205,18 @@ function ShinjeomPageContent() {
 
   const handleTopicSelect = (topic: Topic) => {
     setTopic(topic);
+    setStep("user-info");
+  };
+
+  const handleUserInfoSubmit = (data: UserInfo) => {
+    const hasData = data.name.trim() || data.birthDate;
+    setUserInfo(hasData ? data : null);
+    setPhase("conversation");
+    router.push("/shinjeom/session");
+  };
+
+  const handleUserInfoSkip = () => {
+    setUserInfo(null);
     setPhase("conversation");
     router.push("/shinjeom/session");
   };
@@ -181,6 +224,10 @@ function ShinjeomPageContent() {
   const handleBack = () => {
     setStep("character-select");
     setSelectedCharacter(null);
+  };
+
+  const handleUserInfoBack = () => {
+    setStep("topic-select");
   };
 
   return (
@@ -194,6 +241,10 @@ function ShinjeomPageContent() {
         )}
         {step === "topic-select" && (
           <TopicSelectStep selectedCharacter={selectedCharacter} onBack={handleBack} onTopicSelect={handleTopicSelect} />
+        )}
+        {step === "user-info" && (
+          <UserInfoStep selectedCharacter={selectedCharacter} onBack={handleUserInfoBack}
+            onSubmit={handleUserInfoSubmit} onSkip={handleUserInfoSkip} />
         )}
       </AnimatePresence>
     </div>

--- a/src/app/shinjeom/session/page.tsx
+++ b/src/app/shinjeom/session/page.tsx
@@ -142,6 +142,7 @@ export default function ShinjeomSessionPage() {
       body: {
         sessionId: useShinjeomSessionStore.getState().sessionId,
         topic, characterId,
+        userInfo: useShinjeomSessionStore.getState().userInfo,
         currentMessage: message,
         chatHistory: useShinjeomSessionStore.getState().chatMessages,
         isFinalTurn: false,
@@ -203,6 +204,7 @@ export default function ShinjeomSessionPage() {
       body: {
         sessionId: useShinjeomSessionStore.getState().sessionId,
         topic, characterId,
+        userInfo: useShinjeomSessionStore.getState().userInfo,
         currentMessage: undefined,
         chatHistory: currentChatMessages,
         isFinalTurn: true,

--- a/src/components/common/UserInfoForm.tsx
+++ b/src/components/common/UserInfoForm.tsx
@@ -13,7 +13,7 @@ const STORAGE_KEY = "arcana_user_info";
 const CONSENT_KEY = "arcana_privacy_agreed";
 
 interface UserInfoFormProps {
-  readonly mode: "tarot" | "saju";
+  readonly mode: "tarot" | "saju" | "shinjeom";
   readonly onSubmit: (data: UserInfo) => void;
   readonly onBack: () => void;
   readonly characterName?: string;
@@ -181,6 +181,8 @@ export function UserInfoForm({ mode, onSubmit, onBack, characterName }: UserInfo
   const timeProvided = timeUnknown || birthTime !== null;
   const isValid = mode === "saju"
     ? !!(birthDate && gender && timeProvided)
+    : mode === "shinjeom"
+    ? true
     : !!(name.trim() && birthDate && gender);
 
   const handleSubmit = async () => {
@@ -189,7 +191,7 @@ export function UserInfoForm({ mode, onSubmit, onBack, characterName }: UserInfo
     const data: UserInfo = {
       name: name.trim(),
       birthDate,
-      gender: gender as "male" | "female" | "other",
+      gender: (gender || "other") as "male" | "female" | "other",
       birthTime,
       mbti: mbti || undefined,
     };
@@ -228,14 +230,15 @@ export function UserInfoForm({ mode, onSubmit, onBack, characterName }: UserInfo
     "w-full bg-arcana-card/70 border border-arcana-border rounded-xl px-3 py-2.5 text-arcana-text text-sm focus:border-arcana-purple focus:outline-none";
 
   const backLabel = mode === "saju" ? t("common.back-arrow") : t("tarot.page.spread-select.back");
-  const title = mode === "saju" ? t("user-info.title.saju") : t("user-info.title.tarot");
+  const title = mode === "saju" ? t("user-info.title.saju") : mode === "shinjeom" ? t("user-info.title.shinjeom") : t("user-info.title.tarot");
   const computeSubtitle = (): string => {
     if (mode === "saju") return t("user-info.subtitle.saju");
+    if (mode === "shinjeom") return t("user-info.subtitle.shinjeom");
     if (characterName) return t("user-info.subtitle.tarot.with-name").replace("{name}", characterName);
     return t("user-info.subtitle.tarot.default");
   };
   const subtitle = computeSubtitle();
-  const submitLabel = mode === "saju" ? t("user-info.submit.saju") : t("user-info.submit.tarot");
+  const submitLabel = mode === "saju" ? t("user-info.submit.saju") : mode === "shinjeom" ? t("user-info.submit.shinjeom") : t("user-info.submit.tarot");
 
   return (
     <div className="space-y-5">
@@ -277,7 +280,7 @@ export function UserInfoForm({ mode, onSubmit, onBack, characterName }: UserInfo
 
       {/* 생년월일 — 단일 date input */}
       <div>
-        <label htmlFor="userinfo-birthdate" className="text-arcana-muted text-xs font-serif mb-1.5 block">생년월일 *</label>
+        <label htmlFor="userinfo-birthdate" className="text-arcana-muted text-xs font-serif mb-1.5 block">생년월일 {mode === "shinjeom" ? "(선택)" : "*"}</label>
         <input
           id="userinfo-birthdate"
           type="date"
@@ -291,7 +294,7 @@ export function UserInfoForm({ mode, onSubmit, onBack, characterName }: UserInfo
 
       {/* 성별 */}
       <div>
-        <label className="text-arcana-muted text-xs font-serif mb-1.5 block">성별 *</label>
+        <label className="text-arcana-muted text-xs font-serif mb-1.5 block">성별 {mode === "shinjeom" ? "(선택)" : "*"}</label>
         <div className="grid grid-cols-3 gap-2">
           {(["male", "female", "other"] as const).map((val) => (
             <button

--- a/src/hooks/useShinjeomSession.ts
+++ b/src/hooks/useShinjeomSession.ts
@@ -1,6 +1,7 @@
 import { create } from "zustand";
 import { Topic, ChatMessage } from "@/types/session";
 import { ReadingResult } from "@/types/service";
+import { UserInfo } from "@/types/user-info";
 
 export type ShinjeomPhase = "character-select" | "topic-select" | "conversation" | "result";
 
@@ -9,7 +10,7 @@ interface ShinjeomSessionState {
   sessionId: string | null;
   characterId: string | null;
   topic: Topic | null;
-  userInfo: { name?: string; birthDate?: string; gender?: string } | null;
+  userInfo: UserInfo | null;
   chatMessages: ChatMessage[];
   turnCount: number; // 사용자 메시지 횟수
   readingResult: ReadingResult | null;

--- a/src/i18n/translations/en/index.ts
+++ b/src/i18n/translations/en/index.ts
@@ -20,6 +20,7 @@ export const en: Partial<SharedKeys> = {
     "modal.close-aria": "Close modal",
     "card.back-alt": "Card back",
     "skin.preview-alt": "{name} card preview",
+    "skip": "Skip",
   },
   header: {
     "logo.alt": "ArcanaInsight",
@@ -286,11 +287,14 @@ export const en: Partial<SharedKeys> = {
   "user-info": {
     "title.saju": "Birth Information",
     "title.tarot": "Consultation Information",
+    "title.shinjeom": "Spiritual Reading Information",
     "subtitle.saju": "Required for accurate Saju analysis",
     "subtitle.tarot.with-name": "Share your details for a more personal reading with {name}",
     "subtitle.tarot.default": "Share your details for a more accurate reading",
+    "subtitle.shinjeom": "Enter your details for a more accurate spiritual reading",
     "submit.saju": "Begin Saju analysis",
     "submit.tarot": "Begin consultation",
+    "submit.shinjeom": "Begin consultation",
     "name-placeholder": "Enter your name",
     "gender.male": "Male",
     "gender.female": "Female",

--- a/src/i18n/translations/ja/index.ts
+++ b/src/i18n/translations/ja/index.ts
@@ -143,6 +143,7 @@ export const ja: Partial<SharedKeys> = {
     "modal.close-aria": "モーダルを閉じる",
     "card.back-alt": "カード裏面",
     "skin.preview-alt": "{name} カードプレビュー",
+    "skip": "スキップ",
   },
   locale: {
     "modal.title": "言語を選択してください",
@@ -288,11 +289,14 @@ export const ja: Partial<SharedKeys> = {
   "user-info": {
     "title.saju": "生年月日情報入力",
     "title.tarot": "相談情報入力",
+    "title.shinjeom": "霊視相談情報入力",
     "subtitle.saju": "正確な四柱分析のため必須情報です",
     "subtitle.tarot.with-name": "{name}様とより正確な鑑定のため情報を入力してください",
     "subtitle.tarot.default": "より正確な鑑定のため情報を入力してください",
+    "subtitle.shinjeom": "より正確な霊視相談のため情報を入力してください",
     "submit.saju": "四柱分析を開始",
     "submit.tarot": "相談を開始",
+    "submit.shinjeom": "相談を開始",
     "name-placeholder": "お名前を入力してください",
     "gender.male": "男性",
     "gender.female": "女性",

--- a/src/i18n/translations/ko/index.ts
+++ b/src/i18n/translations/ko/index.ts
@@ -15,6 +15,7 @@ export const ko: SharedKeys = {
     "modal.close-aria": "모달 닫기",
     "card.back-alt": "카드 뒷면",
     "skin.preview-alt": "{name} 카드 미리보기",
+    "skip": "건너뛰기",
   },
   header: {
     "logo.alt": "ArcanaInsight",
@@ -281,11 +282,14 @@ export const ko: SharedKeys = {
   "user-info": {
     "title.saju": "생년월일 정보 입력",
     "title.tarot": "상담 정보 입력",
+    "title.shinjeom": "신점 상담 정보 입력",
     "subtitle.saju": "정확한 사주 분석을 위해 필수 정보입니다",
     "subtitle.tarot.with-name": "{name}가 더 정확한 리딩을 위해 필요한 정보예요",
     "subtitle.tarot.default": "더 정확한 리딩을 위해 정보를 입력해주세요",
+    "subtitle.shinjeom": "더 정확한 신점 상담을 위해 정보를 입력해주세요",
     "submit.saju": "사주 분석 시작",
     "submit.tarot": "상담 시작하기",
+    "submit.shinjeom": "상담 시작하기",
     "name-placeholder": "이름을 입력하세요",
     "gender.male": "남성",
     "gender.female": "여성",

--- a/src/i18n/translations/shared/keys.ts
+++ b/src/i18n/translations/shared/keys.ts
@@ -19,6 +19,7 @@ export interface SharedKeys {
     "card.back-alt": string;
     // PR 11
     "skin.preview-alt": string;
+    "skip": string;
   };
   header: {
     "logo.alt": string;
@@ -295,11 +296,14 @@ export interface SharedKeys {
   "user-info": {
     "title.saju": string;
     "title.tarot": string;
+    "title.shinjeom": string;
     "subtitle.saju": string;
     "subtitle.tarot.with-name": string;
     "subtitle.tarot.default": string;
+    "subtitle.shinjeom": string;
     "submit.saju": string;
     "submit.tarot": string;
+    "submit.shinjeom": string;
     "name-placeholder": string;
     "gender.male": string;
     "gender.female": string;

--- a/src/lib/validation/api-schemas.ts
+++ b/src/lib/validation/api-schemas.ts
@@ -134,6 +134,13 @@ export const ShinjeomMessageSchema = z.object({
   sessionId: uuidOrNull,
   topic: topicStr,
   characterId: charIdStr,
+  userInfo: z.object({
+    name: z.string().max(50),
+    birthDate: dateStr,
+    gender: z.string().max(10),
+    birthTime: z.string().regex(/^\d{2}:\d{2}$/).nullable(),
+    mbti: z.string().max(10).optional(),
+  }).nullish(),
   currentMessage: z.string().max(2000).optional(),
   chatHistory: z.array(z.object({
     id: z.string().max(100),

--- a/src/services/shinjeom/shinjeom-service.ts
+++ b/src/services/shinjeom/shinjeom-service.ts
@@ -3,7 +3,7 @@ import { CharacterConfig } from "@/types/character";
 import { Session, Topic, ChatMessage } from "@/types/session";
 import { getCharacterById } from "@/data/characters";
 import { cleanReadingText, parseJsonSafe } from "@/services/core/text-cleaner";
-import { buildCharacterHeader, getLanguageFooter } from "@/services/core/prompt-builder";
+import { buildCharacterHeader, buildUserInfoPrompt, getLanguageFooter } from "@/services/core/prompt-builder";
 
 const topicLabels: Record<string, string> = {
   "shinjeom-general": "신수 (종합운)",
@@ -68,15 +68,17 @@ export class ShinjeomService implements DivinationService {
     currentMessage: string | undefined,
     chatHistory: ChatMessage[],
     isFinalTurn: boolean,
+    userInfo?: { name: string; birthDate: string; gender: string; birthTime: string | null; mbti?: string } | null,
   ): string {
     const topicLabel = topicLabels[topic] || topic;
+    const userInfoText = buildUserInfoPrompt(userInfo);
     const historyText = chatHistory
       .filter((m) => m.role === "user" || m.role === "character")
       .map((m) => `${m.role === "user" ? "사용자" : "상담사"}: ${m.content}`)
       .join("\n\n");
 
     if (!isFinalTurn) {
-      return `상담 주제: ${topicLabel}
+      return `상담 주제: ${topicLabel}${userInfoText}
 
 이전 대화:
 ${historyText}
@@ -91,7 +93,7 @@ ${historyText}
     }
 
     // 사용자 종료 요청 → 전체 대화 종합하여 최종 결과
-    return `상담 주제: ${topicLabel}
+    return `상담 주제: ${topicLabel}${userInfoText}
 
 전체 대화:
 ${historyText}


### PR DESCRIPTION
## Summary

- 신점 서비스 플로우에 user-info 스텝 추가 (topic-select → user-info → session)
- `UserInfoForm`에 `shinjeom` 모드 추가 — 모든 필드 선택 사항, 건너뛰기 버튼 제공
- 수집한 정보(이름·생년월일·성별·태어난 시각·MBTI)를 AI 프롬프트에 반영
- `ShinjeomMessageSchema`에 `userInfo` 필드 추가 (nullish)
- i18n: `user-info.title/subtitle/submit.shinjeom`, `common.skip` 3개 locale 추가
- `known-issues.md`: i18n 섹션 현행화, 외부 번역가 미사용 확정 기록

## Test plan

- [x] `pnpm type-check` — 오류 없음
- [x] `pnpm lint` — 에러 없음
- [x] `pnpm test:coverage` — 54 files, 915 tests 전부 통과
- [ ] 신점 페이지 접속 → 캐릭터 선택 → 주제 선택 → 정보 입력 폼 표시 확인
- [ ] 정보 입력 후 상담 시작 → AI 응답에 개인 정보 반영 확인
- [ ] 건너뛰기 클릭 → 정보 없이 상담 진행 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)