### PR TITLE
docs: 문서 정합성 수정 — 코드 교차검증 반영

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@
 
 | 영역 | 현재 기준 |
 |---|---|
-| 언어/프레임워크 | TypeScript strict, Next.js 16.2.3 App Router, React 19.2.4 |
+| 언어/프레임워크 | TypeScript strict, Next.js 16.2.6 App Router, React 19.2.4 |
 | 스타일/애니메이션 | Tailwind CSS v4, Framer Motion v12.38 |
 | AI | Grok API 우선, Claude API 자동 fallback |
 | 인증/DB | Supabase Auth + Supabase PostgreSQL 기본, `DB_PROVIDER=postgres` 전환 시 NextAuth.js v5 + Drizzle |
@@ -37,11 +37,15 @@ src/
 │   ├── common/      # UserInfoForm (mode: "tarot"|"saju"|"shinjeom" — 신점은 전 필드 선택 입력)
 │   └── effects/     # ThemeEffectEngine, ThemeAtmosphereLayer, InteractionEffects,
 │                    # ServiceBackground, ParticleOverlay, MysticBackground, ScrollReveal
-├── data/            # cards, characters, home, saju, shinjeom, skins, spreads, topics
+├── data/            # cards, characters, home, saju, shinjeom/, skins, spreads, topics, mbti, topics-meta
 │   └── cardStyles.ts  # CardStyleId, 4가지 아트 스타일, THEME_TO_STYLE_MAP
 ├── hooks/           # Zustand store와 UI/streaming hooks
 │   ├── useCardStyleStore.ts   # 카드 스타일 persist 스토어 (arcana-card-style)
-│   └── useReadingReveal.ts    # 타로 카드 텍스트 reveal 타이밍 제어 스토어
+│   ├── useReadingReveal.ts    # 타로 카드 텍스트 reveal 타이밍 제어 스토어
+│   ├── useShinjeomSession.ts  # 신점 세션 상태 스토어 (UserInfo 포함)
+│   ├── useSajuSession.ts      # 사주 세션 상태 스토어
+│   ├── useSession.ts          # 타로 세션 상태 스토어
+│   └── (+ useLocaleStore, useGenderStore, useSkinStore, useFavoriteCharacter, useTheme, useSSEStream, useCardAnimation, useCharacter, useReducedMotionStore 등)
 ├── i18n/            # locale 감지, Provider, useT, translations
 ├── lib/             # env, auth, db, storage, validation, request/rate-limit 유틸
 │   └── storage/card-style.ts  # getCardStyleImageUrl, getCardStyleBackUrl

--- a/docs/architecture/data-model.md
+++ b/docs/architecture/data-model.md
@@ -219,6 +219,9 @@ export interface EffectTheme {
 | 출생시간(12시진) | `src/data/birth-hours.ts` |
 | 홈 페이지 정적 데이터 | `src/data/home/` (faq.ts) |
 | 에러 메시지 상수 | `src/data/error-messages.ts` |
+| MBTI 16타입 상수 | `src/data/mbti.ts` |
+| 토픽 메타 정보 | `src/data/topics-meta.ts` |
+| 신점 문화적 해석 데이터 | `src/data/shinjeom/cultural-readings.ts` |
 
 ## 다국어 데이터
 

--- a/docs/architecture/i18n.md
+++ b/docs/architecture/i18n.md
@@ -38,19 +38,30 @@ src/i18n/
 ├── useT.ts                   # 클라이언트 컴포넌트 훅
 └── translations/
     ├── index.ts              # buildDict + t(key, locale) + fallback chain
-    ├── shared/keys.ts        # SharedKeys 타입 (5 namespace) + flatten 헬퍼
+    ├── shared/keys.ts        # SharedKeys 타입 (17 namespace) + flatten 헬퍼
     ├── ko/index.ts           # SSOT
     ├── en/index.ts           # 영문 사전
     └── ja/index.ts           # 일본어 사전
 ```
 
-### namespace
+### namespace (17개)
 - `common` — skip-link, loading, retry, language 등 공유 키
 - `header` — nav, auth, theme 라벨
 - `footer` — tagline, section, link
-- `home` — hero, services, daily-card
-- `settings` — page, section, account
+- `home` — hero, services, daily-card, daily-fortune, gallery, faq, bottom-cta
+- `settings` — page, section, account, card-skin, gender-filter, animation, privacy, card-style
 - `locale` — confirm modal·toast 메시지
+- `tarot` — result, page, session 관련 키
+- `saju` — result, page, session, chart 관련 키
+- `mypage` — page, profile, stats, history, favorite
+- `character` — page, service 선택 관련 키
+- `user-info` — UserInfoForm 타이틀·서브타이틀·제출 버튼·플레이스홀더
+- `auth` — 로그인 페이지 키
+- `share` — 공유 버튼 라벨
+- `chat` — 채팅 기본 라벨
+- `api` — API 에러 메시지
+- `meta` — 사이트 메타 설명
+- `shinjeom` — result, page, topic, session 관련 키
 
 ### t(key, locale) fallback chain
 1. `dict[locale][key]` 존재 → 반환

--- a/docs/architecture/system-overview.md
+++ b/docs/architecture/system-overview.md
@@ -16,7 +16,9 @@ ArcanaInsight의 3개 운세 서비스(타로·사주·신점) 사용자 흐름 
        │    └─ chat/home/tarot/saju/shinjeom/...
        ├─ 상태 (src/hooks/)
        │    ├─ useCardStyleStore  — 카드 스타일 persist (arcana-card-style)
-       │    └─ useSkinStore, useTheme, ...
+       │    ├─ useSession / useSajuSession / useShinjeomSession  — 서비스별 세션 상태
+       │    ├─ useLocaleStore / useGenderStore / useSkinStore  — 전역 설정
+       │    └─ useReadingReveal, useFavoriteCharacter, ...
        ├─ API 라우트 (src/app/api/)  — SSE 스트리밍 + Zod 검증 + Auth
        └─ 서비스 레이어 (src/services/)
             ├─ core/FallbackProvider  — Grok 우선 → Claude API fallback
@@ -38,14 +40,14 @@ ArcanaInsight의 3개 운세 서비스(타로·사주·신점) 사용자 흐름 
 ### 타로 (4단계)
 
 1. **캐릭터 선택** → 12명 중 선택 (성별 필터 지원). 선호 상담사 설정 시 자동 스킵
-2. **개인정보 입력** → 생년월일, 출생시간(12시진), 성별, 혈액형 + 제3자 제공 동의
+2. **개인정보 입력** → 이름(선택), 생년월일, 출생시간, 성별, MBTI(선택)
 3. **주제 선택 + 카드 뽑기** → 주제 선택 → 스프레드 선택 → 카드 선택
 4. **AI 리딩 결과** → Grok AI가 SSE 스트리밍으로 해석 → 결과 공유(share_token URL)
 
 ### 사주 (4단계)
 
 1. **캐릭터 선택** → 12명 중 선택 (성별 필터 지원). 선호 상담사 설정 시 자동 스킵
-2. **개인정보 입력** → 생년월일, 출생시간(12시진), 성별, 혈액형 + 제3자 제공 동의
+2. **개인정보 입력** → 이름(선택), 생년월일, 출생시간, 성별, MBTI(선택)
 3. **시간단위 × 분석영역 선택** → 시간단위(7) + 분석영역(8) 동시 선택, 년단위 시 "월별 상세" 토글
 4. **AI 리딩 결과** → Grok AI가 SSE 스트리밍으로 해석 → 결과 공유
 
@@ -54,7 +56,7 @@ ArcanaInsight의 3개 운세 서비스(타로·사주·신점) 사용자 흐름 
 1. **캐릭터 선택** → 12명 중 선택. 선호 상담사 설정 시 자동 스킵
 2. **주제 선택** → 신수(종합운), 연애/궁합, 재물/사업운, 직장/이직, 건강/액막이, 택일
 3. **개인정보 입력 (선택)** → `UserInfoForm mode="shinjeom"` — 이름·생년월일·성별·MBTI 모두 선택 입력. "건너뛰기" 버튼으로 생략 가능. 입력 시 AI 프롬프트에 반영
-4. **대화형 상담** → 무제한 문답 → "신점 결과 받기" 버튼으로 종료 (1턴 이상 후 활성화)
+4. **대화형 상담** (`/shinjeom/session`) → 무제한 문답 → "신점 결과 받기" 버튼으로 종료 (1턴 이상 후 활성화)
 
 > 신점 결과 공유 페이지(`/shinjeom/result/[id]`) 구현 완료 (PR #142) — mypage 링크 활성화
 
@@ -141,7 +143,7 @@ ArcanaInsight의 3개 운세 서비스(타로·사주·신점) 사용자 흐름 
 1. **HeroSection** — 풀스크린 히어로 (캐릭터 + 카피 + CTA)
 2. **CharacterGallery** — 12캐릭터 갤러리 (카드형, 성별 필터 내장)
 3. **DailyFortune** — 캐릭터별 일일 운세 (5개 영역 1+4 레이아웃)
-4. **SkinGallery** — 카드 스킨 갤러리 (6종)
+4. **SkinGallery** — 카드 스킨 갤러리 (아트 스타일 4종 + 팔레트 스킨 6종 = 10종)
 5. **ServiceFlow** — 서비스 이용 흐름 소개
 6. **FAQ** — 아코디언 FAQ
 7. **BottomCTA** — 하단 행동 유도

--- a/docs/conventions/i18n-style.md
+++ b/docs/conventions/i18n-style.md
@@ -44,7 +44,7 @@ export async function POST(req: NextRequest) {
 ## 키 네이밍
 
 - 형식: `namespace.key` 또는 `namespace.section.key`
-- namespace: 16개 (`common`·`header`·`footer`·`home`·`settings`·`locale`·`tarot`·`saju`·`mypage`·`character`·`auth`·`share`·`chat`·`api`·`meta`·`shinjeom`) — 전체 목록은 `src/i18n/translations/shared/keys.ts` 참조
+- namespace: 17개 (`common`·`header`·`footer`·`home`·`settings`·`locale`·`tarot`·`saju`·`mypage`·`character`·`user-info`·`auth`·`share`·`chat`·`api`·`meta`·`shinjeom`) — 전체 목록은 `src/i18n/translations/shared/keys.ts` 참조
 - 케이스: dot-notation, kebab-case 단어 분리 (`skip-link`, `nav.daily-card`)
 - 예: `header.nav.tarot`, `footer.section.services`, `home.hero.title`, `locale.modal.confirm`
 

--- a/src/services/CLAUDE.md
+++ b/src/services/CLAUDE.md
@@ -11,7 +11,7 @@ services/
 │   ├── circuit-breaker.ts     # 쿨다운 상태 globalThis 공유 (서버리스 warm 인스턴스 대응)
 │   ├── grok-provider.ts       # Grok API 호출, RateLimitError / AuthError 정의
 │   ├── claude-provider.ts     # Claude API 호출 (fallback 전용)
-│   ├── prompt-builder.ts      # buildSystemPrompt / buildReadingPrompt / buildUserInfoPrompt
+│   ├── prompt-builder.ts      # buildCharacterHeader / buildSystemPrompt / buildReadingPrompt / buildUserInfoPrompt / buildFreeQuestionPrompt / buildCharacterMemoryPrompt / getLanguageFooter
 │   └── text-cleaner.ts        # cleanReadingText / parseJsonSafe / extractFallbackText
 ├── tarot/
 │   ├── tarot-service.ts       # DivinationService 구현체


### PR DESCRIPTION
## Summary

- **CLAUDE.md**: Next.js 버전 16.2.3 → 16.2.6, `data/` 트리에 `shinjeom/` 디렉터리 표기 및 `mbti`, `topics-meta` 추가, `hooks/` 목록에 `useShinjeomSession`, `useSajuSession`, `useSession` 등 실제 파일 반영
- **system-overview.md**: 개인정보 입력 항목에서 혈액형 제거 후 MBTI로 교체, 신점 4단계에 `/shinjeom/session` 라우트 명시, 상태 레이어 다이어그램 확장, `SkinGallery` 6종 → 10종(아트 스타일 4 + 팔레트 스킨 6)
- **i18n.md**: `SharedKeys` namespace 5개 → 17개로 정확히 업데이트, 각 namespace 설명 추가
- **i18n-style.md**: namespace 16개 → 17개(`user-info` 추가)로 i18n.md와 동기화
- **services/CLAUDE.md**: `prompt-builder.ts` export 함수 목록 완성 (`buildCharacterHeader`, `buildFreeQuestionPrompt`, `buildCharacterMemoryPrompt`, `getLanguageFooter` 추가)
- **data-model.md**: 정적 데이터 파일 표에 `mbti.ts`, `topics-meta.ts`, `shinjeom/cultural-readings.ts` 추가

## Test plan

- [ ] 소스 코드 파일은 일절 수정되지 않았음 (문서 전용 변경)
- [ ] 변경된 6개 문서 파일이 실제 코드와 일치하는지 교차 검증 완료
- [ ] `pnpm check:doc-links`로 문서 링크 유효성 확인 권장

🤖 Generated with [Claude Code](https://claude.com/claude-code)