### PR TITLE
chore(ci): CI 병목 개선 — 빌드 캐시·artifact 최적화·e2e matrix

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
+        with:
+          version: "10.33.0"
       - uses: actions/setup-node@v4
         with:
           node-version: 20
@@ -41,6 +43,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
+        with:
+          version: "10.33.0"
       - uses: actions/setup-node@v4
         with:
           node-version: 20
@@ -54,7 +58,7 @@ jobs:
           path: coverage/
           retention-days: 7
 
-  # ── 3단계: 프로덕션 빌드 + 아티팩트 업로드 (E2E가 pnpm start로 재사용) ──
+  # ── 3단계: 프로덕션 빌드 (static 통과 후 시작, .next/cache GHA 캐시 재사용) ──
   build:
     name: Production Build
     runs-on: ubuntu-latest
@@ -62,11 +66,24 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
+        with:
+          version: "10.33.0"
       - uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: pnpm
       - run: pnpm install --frozen-lockfile
+
+      # Next.js 증분 빌드 캐시 — 의존성 미변경 PR에서 warm build로 30-70% 단축
+      - name: Next.js 빌드 캐시 복원
+        uses: actions/cache@v4
+        with:
+          path: ${{ github.workspace }}/.next/cache
+          key: nextjs-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}-${{ hashFiles('src/**/*.ts', 'src/**/*.tsx', 'src/**/*.css') }}
+          restore-keys: |
+            nextjs-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}-
+            nextjs-${{ runner.os }}-
+
       - run: pnpm build
         env:
           NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL || 'https://placeholder.supabase.co' }}
@@ -75,23 +92,38 @@ jobs:
           GROK_API_KEY: ${{ secrets.GROK_API_KEY || 'placeholder-grok-key' }}
           GROK_MODEL: grok-3
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY || 'placeholder-service-key' }}
+
+      # .next/cache/** 제외 — E2E가 런타임 서빙에 불필요한 캐시 디렉터리 전송 방지
       - uses: actions/upload-artifact@v4
         with:
           name: next-build
-          path: .next/
+          path: |
+            .next/
+            !.next/cache/**
           include-hidden-files: true
           if-no-files-found: error
           retention-days: 1
 
-  # ── 4단계: E2E (build 아티팩트 다운로드 → pnpm start 서빙) ─────────────
+  # ── 4단계: E2E (build 완료 즉시 시작, unit과 독립 병렬 실행) ─────────────
   # playwright.config.ts webServer.command: process.env.CI ? "pnpm start" : "pnpm dev"
-  e2e-desktop:
-    name: E2E — Desktop Chrome
+  # unit 테스트는 E2E 정확성과 무관 — E2E는 build 산출물만 있으면 시작 가능
+  e2e:
+    name: E2E — ${{ matrix.project }}
     runs-on: ubuntu-latest
-    needs: [static, unit, build]
+    needs: [build]
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - project: "Desktop Chrome"
+            report-name: playwright-report-desktop
+          - project: "Mobile Android"
+            report-name: playwright-report-android
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
+        with:
+          version: "10.33.0"
       - uses: actions/setup-node@v4
         with:
           node-version: 20
@@ -117,7 +149,7 @@ jobs:
         if: steps.pw-cache.outputs.cache-hit == 'true'
         run: npx playwright install-deps chromium
 
-      - run: pnpm test:e2e --project="Desktop Chrome"
+      - run: pnpm test:e2e --project="${{ matrix.project }}"
         env:
           CI: "true"
           NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL || 'https://placeholder.supabase.co' }}
@@ -130,55 +162,6 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: failure()
         with:
-          name: playwright-report-desktop
-          path: playwright-report/
-          retention-days: 7
-
-  e2e-android:
-    name: E2E — Mobile Android
-    runs-on: ubuntu-latest
-    needs: [static, unit, build]
-    steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: pnpm
-      - run: pnpm install --frozen-lockfile
-
-      - uses: actions/download-artifact@v4
-        with:
-          name: next-build
-          path: .next/
-
-      - uses: actions/cache@v4
-        id: pw-cache
-        with:
-          path: ~/.cache/ms-playwright
-          key: pw-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
-
-      - name: Playwright 설치 (캐시 미스)
-        if: steps.pw-cache.outputs.cache-hit != 'true'
-        run: npx playwright install --with-deps chromium
-
-      - name: Playwright 시스템 의존성 설치 (캐시 히트)
-        if: steps.pw-cache.outputs.cache-hit == 'true'
-        run: npx playwright install-deps chromium
-
-      - run: pnpm test:e2e --project="Mobile Android"
-        env:
-          CI: "true"
-          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL || 'https://placeholder.supabase.co' }}
-          NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY || 'placeholder-anon-key' }}
-          NEXT_PUBLIC_SITE_URL: http://localhost:3000
-          GROK_API_KEY: ${{ secrets.GROK_API_KEY || 'placeholder-grok-key' }}
-          GROK_MODEL: grok-3
-          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY || 'placeholder-service-key' }}
-
-      - uses: actions/upload-artifact@v4
-        if: failure()
-        with:
-          name: playwright-report-android
+          name: ${{ matrix.report-name }}
           path: playwright-report/
           retention-days: 7

--- a/.github/workflows/docs-sync.yml
+++ b/.github/workflows/docs-sync.yml
@@ -18,6 +18,8 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: pnpm/action-setup@v4
+        with:
+          version: "10.33.0"
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -33,6 +33,8 @@ jobs:
           fetch-depth: 0   # SonarCloud는 전체 git 히스토리 필요 (blame, 새 코드 감지)
 
       - uses: pnpm/action-setup@v4
+        with:
+          version: "10.33.0"
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/weekly-qa.yml
+++ b/.github/workflows/weekly-qa.yml
@@ -22,6 +22,8 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: pnpm/action-setup@v4
+        with:
+          version: "10.33.0"
 
       - uses: actions/setup-node@v4
         with:
@@ -36,6 +38,16 @@ jobs:
       - name: ESLint 코드 품질
         run: pnpm lint
 
+      # Next.js 증분 빌드 캐시 — 주간 QA에서도 warm build 재사용
+      - name: Next.js 빌드 캐시 복원
+        uses: actions/cache@v4
+        with:
+          path: ${{ github.workspace }}/.next/cache
+          key: nextjs-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}-${{ hashFiles('src/**/*.ts', 'src/**/*.tsx', 'src/**/*.css') }}
+          restore-keys: |
+            nextjs-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}-
+            nextjs-${{ runner.os }}-
+
       - name: 프로덕션 빌드
         run: pnpm build
         env:
@@ -46,21 +58,42 @@ jobs:
           GROK_MODEL: grok-3
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY || 'placeholder-service-key' }}
 
+      # .next/cache/** 제외 — E2E가 불필요한 캐시 디렉터리 전송 방지
       - uses: actions/upload-artifact@v4
         with:
           name: next-build-weekly
-          path: .next/
+          path: |
+            .next/
+            !.next/cache/**
           include-hidden-files: true
           if-no-files-found: error
           retention-days: 1
 
-  e2e-desktop:
-    name: E2E — Desktop Chrome
+  e2e:
+    name: E2E — ${{ matrix.project }}
     runs-on: ubuntu-latest
     needs: quality-check
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - project: "Desktop Chrome"
+            report-name: report-desktop
+            browser: chromium
+            pw-cache-suffix: ""
+          - project: "Mobile Android"
+            report-name: report-android
+            browser: chromium
+            pw-cache-suffix: ""
+          - project: "Mobile iOS"
+            report-name: report-ios
+            browser: webkit
+            pw-cache-suffix: "-webkit"
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
+        with:
+          version: "10.33.0"
       - uses: actions/setup-node@v4
         with:
           node-version: 20
@@ -76,18 +109,18 @@ jobs:
         id: pw-cache
         with:
           path: ~/.cache/ms-playwright
-          key: pw-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
+          key: pw-${{ runner.os }}${{ matrix.pw-cache-suffix }}-${{ hashFiles('**/pnpm-lock.yaml') }}
 
       - name: Playwright 설치 (캐시 미스)
         if: steps.pw-cache.outputs.cache-hit != 'true'
-        run: npx playwright install --with-deps chromium
+        run: npx playwright install --with-deps ${{ matrix.browser }}
 
       - name: Playwright 시스템 의존성 설치 (캐시 히트)
         if: steps.pw-cache.outputs.cache-hit == 'true'
-        run: npx playwright install-deps chromium
+        run: npx playwright install-deps ${{ matrix.browser }}
 
-      - name: E2E 테스트 (Desktop Chrome)
-        run: pnpm test:e2e --project="Desktop Chrome"
+      - name: E2E 테스트 (${{ matrix.project }})
+        run: pnpm test:e2e --project="${{ matrix.project }}"
         env:
           CI: "true"
           NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL || 'https://placeholder.supabase.co' }}
@@ -100,114 +133,14 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: ${{ !cancelled() }}
         with:
-          name: report-desktop
-          path: playwright-report/
-          retention-days: 30
-
-  e2e-mobile-android:
-    name: E2E — Mobile Android
-    runs-on: ubuntu-latest
-    needs: quality-check
-    steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: pnpm
-      - run: pnpm install --frozen-lockfile
-
-      - uses: actions/download-artifact@v4
-        with:
-          name: next-build-weekly
-          path: .next/
-
-      - uses: actions/cache@v4
-        id: pw-cache
-        with:
-          path: ~/.cache/ms-playwright
-          key: pw-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
-
-      - name: Playwright 설치 (캐시 미스)
-        if: steps.pw-cache.outputs.cache-hit != 'true'
-        run: npx playwright install --with-deps chromium
-
-      - name: Playwright 시스템 의존성 설치 (캐시 히트)
-        if: steps.pw-cache.outputs.cache-hit == 'true'
-        run: npx playwright install-deps chromium
-
-      - name: E2E 테스트 (Mobile Android — Pixel 7)
-        run: pnpm test:e2e --project="Mobile Android"
-        env:
-          CI: "true"
-          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL || 'https://placeholder.supabase.co' }}
-          NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY || 'placeholder-anon-key' }}
-          NEXT_PUBLIC_SITE_URL: http://localhost:3000
-          GROK_API_KEY: ${{ secrets.GROK_API_KEY || 'placeholder-grok-key' }}
-          GROK_MODEL: grok-3
-          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY || 'placeholder-service-key' }}
-
-      - uses: actions/upload-artifact@v4
-        if: ${{ !cancelled() }}
-        with:
-          name: report-android
-          path: playwright-report/
-          retention-days: 30
-
-  e2e-mobile-ios:
-    name: E2E — Mobile iOS
-    runs-on: ubuntu-latest
-    needs: quality-check
-    steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: pnpm
-      - run: pnpm install --frozen-lockfile
-
-      - uses: actions/download-artifact@v4
-        with:
-          name: next-build-weekly
-          path: .next/
-
-      - uses: actions/cache@v4
-        id: pw-cache
-        with:
-          path: ~/.cache/ms-playwright
-          key: pw-${{ runner.os }}-webkit-${{ hashFiles('**/pnpm-lock.yaml') }}
-
-      - name: Playwright 설치 (캐시 미스)
-        if: steps.pw-cache.outputs.cache-hit != 'true'
-        run: npx playwright install --with-deps webkit
-
-      - name: Playwright 시스템 의존성 설치 (캐시 히트)
-        if: steps.pw-cache.outputs.cache-hit == 'true'
-        run: npx playwright install-deps webkit
-
-      - name: E2E 테스트 (Mobile iOS — iPhone 14)
-        run: pnpm test:e2e --project="Mobile iOS"
-        env:
-          CI: "true"
-          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL || 'https://placeholder.supabase.co' }}
-          NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY || 'placeholder-anon-key' }}
-          NEXT_PUBLIC_SITE_URL: http://localhost:3000
-          GROK_API_KEY: ${{ secrets.GROK_API_KEY || 'placeholder-grok-key' }}
-          GROK_MODEL: grok-3
-          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY || 'placeholder-service-key' }}
-
-      - uses: actions/upload-artifact@v4
-        if: ${{ !cancelled() }}
-        with:
-          name: report-ios
+          name: ${{ matrix.report-name }}
           path: playwright-report/
           retention-days: 30
 
   notify-on-failure:
     name: 실패 시 Issue 생성
     runs-on: ubuntu-latest
-    needs: [quality-check, e2e-desktop, e2e-mobile-android, e2e-mobile-ios]
+    needs: [quality-check, e2e]
     if: failure()
     steps:
       - uses: actions/checkout@v4
@@ -264,7 +197,7 @@ jobs:
   close-resolved-issues:
     name: 통과 시 QA Issue 닫기
     runs-on: ubuntu-latest
-    needs: [quality-check, e2e-desktop, e2e-mobile-android, e2e-mobile-ios]
+    needs: [quality-check, e2e]
     if: success()
     steps:
       - uses: actions/github-script@v7


### PR DESCRIPTION
## 배경

PR CI가 느리다는 피드백을 받아 3-에이전트 병렬 심층 분석을 수행했습니다.
분석 후 위험도 낮고 효과가 확실한 항목만 선별하여 적용했습니다.

## 분석 결과 (3-에이전트)

| 병목 | 예상 낭비 | 조치 |
|---|---|---|
| `.next/cache` 미캐시 — cold build 매번 수행 | 빌드 30-70% 느림 | `actions/cache@v4`로 증분 빌드 재사용 |
| `.next/cache/**` artifact에 포함 — e2e 2개 job이 불필요한 캐시 전송 | 60-120초 낭비 | `!.next/cache/**` 제외 |
| e2e가 `unit` 완료를 불필요하게 대기 | unit 지연만큼 E2E 지연 | `needs: [build]`로 단순화 |
| e2e-desktop / e2e-android 완전 중복 코드 80줄 | 유지보수 비용 | matrix 통합 |

## 변경 내용

### [deploy.yml](.github/workflows/deploy.yml)
- **Next.js 빌드 캐시**: `build` job에 `.next/cache` GHA 캐시 추가
  - 의존성 미변경 PR → warm build로 **30-70% 빌드 단축** 기대
  - key: `pnpm-lock.yaml` + `src/**/*.{ts,tsx,css}` 해시, restore-keys로 부분 캐시 히트
- **artifact 최적화**: `.next/cache/**` 제외 → upload 1회 + download 2회 불필요 용량 감소
- **e2e matrix 통합**: `e2e-desktop` + `e2e-android` → `e2e (matrix)` 단일 job
- **e2e `needs` 단순화**: `[static, unit, build]` → `[build]`
  - `static`은 build가 이미 depends (암묵적 포함)
  - `unit` coverage는 E2E 정확성과 무관 → 병렬 독립 실행
- **pnpm version 명시**: 모든 job `pnpm/action-setup@v4 version: "10.33.0"`

### [weekly-qa.yml](.github/workflows/weekly-qa.yml)
- 동일 패턴 적용: `.next/cache` 캐시, artifact 최적화, pnpm version
- e2e 3개 job(Desktop / Android / iOS) → matrix 통합
  - browser(chromium/webkit), pw-cache-suffix, report-name을 matrix 변수로 분리

### [sonar.yml](.github/workflows/sonar.yml), [docs-sync.yml](.github/workflows/docs-sync.yml)
- pnpm version: "10.33.0" 명시

## 미적용 항목 (위험도 또는 복잡도 높아 별도 PR 권고)

| 항목 | 이유 |
|---|---|
| `output: standalone` 채택 | E2E `pnpm start` → `node .next/standalone/server.js` 변경 필요 |
| sonar.yml `pnpm test:coverage` 중복 제거 | 크로스-워크플로우 artifact 공유 복잡 (별도 워크플로우 통합 시 push-to-main 트리거 처리 필요) |
| `next build --turbopack` | Tailwind v4 + framer-motion + Supabase 호환성 검증 필요 |
| `tsconfig.json target: ES2022` 상향 | 번들 크기 영향 검증 필요 |

## 테스트 계획

- [ ] PR CI (`deploy.yml`) 실행 확인 — e2e matrix 2개 job 병렬 실행 확인
- [ ] build job `.next/cache` 캐시 히트 확인 (2번째 실행부터)
- [ ] artifact 크기가 이전보다 감소했는지 확인
- [ ] weekly-qa.yml 수동 dispatch로 iOS 포함 matrix 3개 job 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)