### PR TITLE
fix(security): Rate Limit 누락 엔드포인트 보완 + daily upsert getAdminDb 전환

### DIFF
--- a/src/__tests__/api/daily-card.test.ts
+++ b/src/__tests__/api/daily-card.test.ts
@@ -26,7 +26,10 @@ async function setup(options: {
     mockAiModule.FallbackProvider.mockImplementation(() => provider);
   }
 
-  vi.doMock("@/lib/db", () => ({ getDb: vi.fn().mockReturnValue(mockDb) }));
+  vi.doMock("@/lib/db", () => ({
+    getDb: vi.fn().mockReturnValue(mockDb),
+    getAdminDb: vi.fn().mockReturnValue(mockDb),
+  }));
   vi.doMock("@/services/core/fallback-provider", () => mockAiModule);
   vi.doMock("@/lib/rate-limit", () => ({
     checkRateLimit: vi.fn().mockResolvedValue(!options.rateLimited),

--- a/src/__tests__/api/daily-fortune.test.ts
+++ b/src/__tests__/api/daily-fortune.test.ts
@@ -41,7 +41,10 @@ async function setup(options: {
     mockAiModule.FallbackProvider.mockImplementation(() => provider);
   }
 
-  vi.doMock("@/lib/db", () => ({ getDb: vi.fn().mockReturnValue(mockDb) }));
+  vi.doMock("@/lib/db", () => ({
+    getDb: vi.fn().mockReturnValue(mockDb),
+    getAdminDb: vi.fn().mockReturnValue(mockDb),
+  }));
   vi.doMock("@/services/core/fallback-provider", () => mockAiModule);
   vi.doMock("@/lib/rate-limit", () => ({
     checkRateLimit: vi.fn().mockResolvedValue(!options.rateLimited),

--- a/src/__tests__/api/favorite-character.test.ts
+++ b/src/__tests__/api/favorite-character.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
+import { NextRequest } from "next/server";
 import { setupDoMock } from "@/test-helpers/reset-modules";
 import { makeMockDb } from "@/test-helpers/mock-db";
 import { makeAuthMock, MOCK_USER } from "@/test-helpers/mock-auth";
@@ -6,23 +7,36 @@ import { makePostRequest } from "@/test-helpers/mock-request";
 
 setupDoMock();
 
+function makeGetRequest(url = "http://localhost/api/profile/favorite-character"): NextRequest {
+  return new NextRequest(url);
+}
+
 async function setup(options: { user?: typeof MOCK_USER | null } = {}) {
   const mockDb = makeMockDb();
+  const mockAdminDb = makeMockDb();
   mockDb.update.mockResolvedValue({ id: MOCK_USER.id, favorite_character_id: "arcana" });
+  mockAdminDb.update.mockResolvedValue({ id: MOCK_USER.id, favorite_character_id: "arcana" });
   mockDb.findOne.mockResolvedValue({ favorite_character_id: "arcana" });
 
   const user = "user" in options ? options.user : MOCK_USER;
-  vi.doMock("@/lib/db", () => ({ getDb: vi.fn().mockReturnValue(mockDb) }));
+  vi.doMock("@/lib/db", () => ({
+    getDb: vi.fn().mockReturnValue(mockDb),
+    getAdminDb: vi.fn().mockReturnValue(mockAdminDb),
+  }));
   vi.doMock("@/lib/auth", () => makeAuthMock(user));
+  vi.doMock("@/lib/rate-limit", () => ({
+    checkRateLimit: vi.fn().mockResolvedValue(true),
+    rateLimitResponse: vi.fn(),
+  }));
 
   const { GET, POST } = await import("@/app/api/profile/favorite-character/route");
-  return { GET, POST, mockDb };
+  return { GET, POST, mockDb, mockAdminDb };
 }
 
 describe("GET /api/profile/favorite-character", () => {
   it("선호 상담사 있음 → characterId 반환", async () => {
     const { GET } = await setup();
-    const res = await GET();
+    const res = await GET(makeGetRequest());
     expect(res.status).toBe(200);
     expect((await res.json()).characterId).toBe("arcana");
   });
@@ -30,7 +44,7 @@ describe("GET /api/profile/favorite-character", () => {
   it("선호 상담사 없음 → characterId: null", async () => {
     const { GET, mockDb } = await setup();
     mockDb.findOne.mockResolvedValue({ favorite_character_id: null });
-    const res = await GET();
+    const res = await GET(makeGetRequest());
     expect(res.status).toBe(200);
     expect((await res.json()).characterId).toBeNull();
   });
@@ -38,21 +52,21 @@ describe("GET /api/profile/favorite-character", () => {
   it("프로필 없음 → characterId: null", async () => {
     const { GET, mockDb } = await setup();
     mockDb.findOne.mockResolvedValue(null);
-    const res = await GET();
+    const res = await GET(makeGetRequest());
     expect(res.status).toBe(200);
     expect((await res.json()).characterId).toBeNull();
   });
 
   it("미인증 사용자 → 401", async () => {
     const { GET } = await setup({ user: null });
-    const res = await GET();
+    const res = await GET(makeGetRequest());
     expect(res.status).toBe(401);
   });
 
   it("DB 조회 실패 → 500", async () => {
     const { GET, mockDb } = await setup();
     mockDb.findOne.mockRejectedValue(new Error("DB error"));
-    const res = await GET();
+    const res = await GET(makeGetRequest());
     expect(res.status).toBe(500);
   });
 });
@@ -66,12 +80,12 @@ describe("POST /api/profile/favorite-character", () => {
   });
 
   it("characterId: null → 선호 상담사 해제 (success)", async () => {
-    const { POST, mockDb } = await setup();
-    mockDb.update.mockResolvedValue({ id: MOCK_USER.id, favorite_character_id: null });
+    const { POST, mockAdminDb } = await setup();
+    mockAdminDb.update.mockResolvedValue({ id: MOCK_USER.id, favorite_character_id: null });
     const res = await POST(makePostRequest({ characterId: null }));
     expect(res.status).toBe(200);
     expect((await res.json()).success).toBe(true);
-    expect(mockDb.update).toHaveBeenCalledWith("profiles", { id: MOCK_USER.id }, { favorite_character_id: null });
+    expect(mockAdminDb.update).toHaveBeenCalledWith("profiles", { id: MOCK_USER.id }, { favorite_character_id: null });
   });
 
   it("존재하지 않는 characterId → 400", async () => {
@@ -89,8 +103,8 @@ describe("POST /api/profile/favorite-character", () => {
   });
 
   it("DB update 실패 → 500", async () => {
-    const { POST, mockDb } = await setup();
-    mockDb.update.mockRejectedValue(new Error("DB error"));
+    const { POST, mockAdminDb } = await setup();
+    mockAdminDb.update.mockRejectedValue(new Error("DB error"));
     const res = await POST(makePostRequest({ characterId: "arcana" }));
     expect(res.status).toBe(500);
   });

--- a/src/app/api/daily-card/route.ts
+++ b/src/app/api/daily-card/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getDb } from "@/lib/db";
+import { getDb, getAdminDb } from "@/lib/db";
 import { FallbackProvider } from "@/services/core/fallback-provider";
 import { DeckManager } from "@/services/tarot/deck-manager";
 import { getCharacterById } from "@/data/characters";
@@ -85,7 +85,7 @@ export async function POST(request: NextRequest) {
     const keywords = meanings.keywords.slice(0, 3);
 
     // 캐시 저장 (동시 요청 시 중복 방지 — 충돌 무시)
-    await db.upsert("daily_cards", {
+    await getAdminDb().upsert("daily_cards", {
       date,
       character_id: characterId,
       area: "general",

--- a/src/app/api/daily-fortune/route.ts
+++ b/src/app/api/daily-fortune/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getDb } from "@/lib/db";
+import { getDb, getAdminDb } from "@/lib/db";
 import { FallbackProvider } from "@/services/core/fallback-provider";
 import { DeckManager } from "@/services/tarot/deck-manager";
 import { getCharacterById } from "@/data/characters";
@@ -81,7 +81,7 @@ export async function POST(request: NextRequest) {
 
       for (const ac of missingCards) {
         const interpretation = interpretations[ac.area] ?? "";
-        await db.upsert("daily_cards", {
+        await getAdminDb().upsert("daily_cards", {
           date, character_id: characterId, area: ac.area,
           card_id: ac.cardId, is_reversed: ac.isReversed, interpretation, keywords: ac.keywords,
         }, "date,character_id,area");

--- a/src/app/api/locale/route.ts
+++ b/src/app/api/locale/route.ts
@@ -1,11 +1,20 @@
 import { NextRequest, NextResponse } from "next/server";
-import { LOCALE_COOKIE, LOCALE_COOKIE_MAX_AGE } from "@/i18n/config";
+import { LOCALE_COOKIE, LOCALE_COOKIE_MAX_AGE, DEFAULT_LOCALE, isLocale, type Locale } from "@/i18n/config";
 import { LocaleSchema } from "@/lib/validation/api-schemas";
 import { getCurrentUser } from "@/lib/auth";
 import { getDb } from "@/lib/db";
+import { checkRateLimit, rateLimitResponse } from "@/lib/rate-limit";
+import { getClientIp } from "@/lib/request-utils";
+import { getRequestLocale } from "@/i18n/server-locale";
 
 export async function POST(request: NextRequest) {
+  let reqLocaleForRateLimit: Locale = DEFAULT_LOCALE;
   try {
+    const detectedLocale = await getRequestLocale();
+    if (isLocale(detectedLocale)) reqLocaleForRateLimit = detectedLocale;
+    const ip = getClientIp(request.headers);
+    if (!(await checkRateLimit(`locale:${ip}`, 30, 60_000))) return rateLimitResponse(reqLocaleForRateLimit);
+
     const parsed = LocaleSchema.safeParse(await request.json());
     if (!parsed.success) {
       return NextResponse.json({ error: "Invalid locale" }, { status: 400 });

--- a/src/app/api/profile/favorite-character/route.ts
+++ b/src/app/api/profile/favorite-character/route.ts
@@ -1,11 +1,21 @@
 import { NextRequest, NextResponse } from "next/server"
-import { getDb } from "@/lib/db"
+import { getDb, getAdminDb } from "@/lib/db"
 import { requireUser } from "@/lib/auth"
 import { getCharacterById } from "@/data/characters"
 import { FavoriteCharacterSchema } from "@/lib/validation/api-schemas"
+import { checkRateLimit, rateLimitResponse } from "@/lib/rate-limit"
+import { getClientIp } from "@/lib/request-utils"
+import { getRequestLocale } from "@/i18n/server-locale"
+import { DEFAULT_LOCALE, isLocale, type Locale } from "@/i18n/config"
 
-export async function GET() {
+export async function GET(request: NextRequest) {
+  let locale: Locale = DEFAULT_LOCALE
   try {
+    const reqLocale = await getRequestLocale()
+    if (isLocale(reqLocale)) locale = reqLocale
+    const ip = getClientIp(request.headers)
+    if (!(await checkRateLimit(`favorite-character:${ip}`, 30, 60_000))) return rateLimitResponse(locale)
+
     const user = await requireUser()
     const db = getDb()
     const profile = await db.findOne<{ favorite_character_id: string | null }>(
@@ -22,7 +32,13 @@ export async function GET() {
 }
 
 export async function POST(request: NextRequest) {
+  let locale: Locale = DEFAULT_LOCALE
   try {
+    const reqLocale = await getRequestLocale()
+    if (isLocale(reqLocale)) locale = reqLocale
+    const ip = getClientIp(request.headers)
+    if (!(await checkRateLimit(`favorite-character:${ip}`, 10, 60_000))) return rateLimitResponse(locale)
+
     const user = await requireUser()
     const parsed = FavoriteCharacterSchema.safeParse(await request.json())
     if (!parsed.success) return NextResponse.json({ error: "Invalid request body" }, { status: 400 })
@@ -30,7 +46,7 @@ export async function POST(request: NextRequest) {
     if (characterId !== null && !getCharacterById(characterId)) {
       return NextResponse.json({ error: "Invalid character" }, { status: 400 })
     }
-    const db = getDb()
+    const db = getAdminDb()
     await db.update("profiles", { id: user.id }, { favorite_character_id: characterId })
     return NextResponse.json({ success: true })
   } catch (e) {

--- a/src/app/api/saju/result/[id]/route.ts
+++ b/src/app/api/saju/result/[id]/route.ts
@@ -1,6 +1,9 @@
 import { NextRequest, NextResponse } from "next/server"
 import { getAdminDb } from "@/lib/db"
-import { pickFields } from "@/lib/request-utils"
+import { pickFields, getClientIp } from "@/lib/request-utils"
+import { checkRateLimit, rateLimitResponse } from "@/lib/rate-limit"
+import { getRequestLocale } from "@/i18n/server-locale"
+import { DEFAULT_LOCALE, isLocale, type Locale } from "@/i18n/config"
 
 const SAFE_KEYS = [
   "id", "birth_date", "birth_hour", "gender", "birth_name", "mbti",
@@ -10,8 +13,14 @@ const SAFE_KEYS = [
   "overall_reading", "topic_reading", "advice", "share_token", "created_at",
 ] as const
 
-export async function GET(_request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+export async function GET(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  let locale: Locale = DEFAULT_LOCALE
   try {
+    const reqLocale = await getRequestLocale()
+    if (isLocale(reqLocale)) locale = reqLocale
+    const ip = getClientIp(request.headers)
+    if (!(await checkRateLimit(`result:${ip}`, 60, 60_000))) return rateLimitResponse(locale)
+
     const { id } = await params
     const db = getAdminDb()
     const reading = await db.findOne<Record<string, unknown>>("saju_readings", { share_token: id })

--- a/src/app/api/shinjeom/result/[id]/route.ts
+++ b/src/app/api/shinjeom/result/[id]/route.ts
@@ -1,11 +1,20 @@
 import { NextRequest, NextResponse } from "next/server"
 import { getAdminDb } from "@/lib/db"
-import { pickFields } from "@/lib/request-utils"
+import { pickFields, getClientIp } from "@/lib/request-utils"
+import { checkRateLimit, rateLimitResponse } from "@/lib/rate-limit"
+import { getRequestLocale } from "@/i18n/server-locale"
+import { DEFAULT_LOCALE, isLocale, type Locale } from "@/i18n/config"
 
 const SAFE_KEYS = ["id", "overall_reading", "topic_reading", "advice", "share_token", "created_at"] as const
 
-export async function GET(_request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+export async function GET(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  let locale: Locale = DEFAULT_LOCALE
   try {
+    const reqLocale = await getRequestLocale()
+    if (isLocale(reqLocale)) locale = reqLocale
+    const ip = getClientIp(request.headers)
+    if (!(await checkRateLimit(`result:${ip}`, 60, 60_000))) return rateLimitResponse(locale)
+
     const { id } = await params
     const db = getAdminDb()
     const reading = await db.findOne<Record<string, unknown>>("shinjeom_readings", { share_token: id })

--- a/src/app/api/tarot/result/[id]/route.ts
+++ b/src/app/api/tarot/result/[id]/route.ts
@@ -1,11 +1,20 @@
 import { NextRequest, NextResponse } from "next/server"
 import { getAdminDb } from "@/lib/db"
-import { pickFields } from "@/lib/request-utils"
+import { pickFields, getClientIp } from "@/lib/request-utils"
+import { checkRateLimit, rateLimitResponse } from "@/lib/rate-limit"
+import { getRequestLocale } from "@/i18n/server-locale"
+import { DEFAULT_LOCALE, isLocale, type Locale } from "@/i18n/config"
 
 const SAFE_KEYS = ["id", "card_interpretation", "overall_reading", "advice", "share_token", "created_at"] as const
 
-export async function GET(_request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+export async function GET(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  let locale: Locale = DEFAULT_LOCALE
   try {
+    const reqLocale = await getRequestLocale()
+    if (isLocale(reqLocale)) locale = reqLocale
+    const ip = getClientIp(request.headers)
+    if (!(await checkRateLimit(`result:${ip}`, 60, 60_000))) return rateLimitResponse(locale)
+
     const { id } = await params
     const db = getAdminDb()
     const reading = await db.findOne<Record<string, unknown>>("readings", { share_token: id })

--- a/src/test-helpers/api-route-setup.ts
+++ b/src/test-helpers/api-route-setup.ts
@@ -45,6 +45,10 @@ export async function makeResultRouteSetup(
 }> {
   const mockDb = makeMockDb()
   const mockAdminDb = makeMockDb()
+  vi.doMock("@/lib/rate-limit", () => ({
+    checkRateLimit: vi.fn().mockResolvedValue(true),
+    rateLimitResponse: vi.fn(),
+  }))
   vi.doMock("@/lib/db", () => ({
     getDb: vi.fn().mockReturnValue(mockDb),
     getAdminDb: vi.fn().mockReturnValue(mockAdminDb),


### PR DESCRIPTION
## Summary

- result GET 3개 (tarot/saju/shinjeom/result/[id]): 토큰 열거 공격 방지용 Rate Limit 추가 (60 req/min/IP)
- profile/favorite-character GET/POST: IP별 Rate Limit 추가 (GET 30, POST 10 req/min)
- locale POST: IP별 Rate Limit 추가 (30 req/min)
- daily-card/daily-fortune: upsert 연산을 `getAdminDb()`로 전환 — RLS 정책과 무관하게 캐시 저장 보장
- favorite-character POST: `db.update()`도 `getAdminDb()` 사용으로 통일

## Test plan

- [x] `pnpm type-check` — 에러 없음
- [x] 관련 테스트 6개 파일 통과 (44 tests)
- [x] 전체 테스트 스위트 통과 (934 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)