### PR TITLE
fix(type-safety): session store characterId → CharacterId | null, arcana 하드코딩 제거

### DIFF
--- a/src/hooks/useSajuSession.ts
+++ b/src/hooks/useSajuSession.ts
@@ -3,6 +3,7 @@ import { ChatMessage, Topic, SajuTimeRange } from "@/types/session";
 import { ReadingResult } from "@/types/service";
 import { SajuResult } from "@/services/saju/saju-types";
 import { UserInfo } from "@/types/user-info";
+import type { CharacterId } from "@/types/character";
 
 export type { UserInfo };
 
@@ -11,7 +12,7 @@ type SajuPhase = "info-input" | "topic-select" | "reading" | "result";
 interface SajuSessionState {
   phase: SajuPhase;
   sessionId: string | null;
-  characterId: string | null;
+  characterId: CharacterId | null;
   topic: Topic | null;
   timeRange: SajuTimeRange | null;
   includeMonthly: boolean;
@@ -24,7 +25,7 @@ interface SajuSessionState {
 
   setPhase: (phase: SajuPhase) => void;
   setSessionId: (id: string) => void;
-  setCharacterId: (id: string) => void;
+  setCharacterId: (id: CharacterId) => void;
   setTopic: (topic: Topic) => void;
   setTimeRange: (range: SajuTimeRange) => void;
   setIncludeMonthly: (v: boolean) => void;

--- a/src/hooks/useSession.ts
+++ b/src/hooks/useSession.ts
@@ -4,6 +4,7 @@ import { SelectedCard, TarotCard } from "@/types/card";
 import { ReadingResult } from "@/types/service";
 import { Topic } from "@/types/session";
 import { UserInfo } from "@/types/user-info";
+import type { CharacterId } from "@/types/character";
 
 export type { UserInfo };
 
@@ -12,7 +13,7 @@ type SessionPhase = "topic-select" | "card-shuffle" | "card-select" | "reading" 
 interface SessionState {
   phase: SessionPhase;
   sessionId: string | null;
-  characterId: string | null;
+  characterId: CharacterId | null;
   topic: Topic | null;
   spreadType: SpreadType | null;
   requiredCards: number;
@@ -27,7 +28,7 @@ interface SessionState {
   setTopic: (topic: Topic) => void;
   setSpreadType: (type: SpreadType, required: number) => void;
   setSessionId: (id: string) => void;
-  setCharacterId: (id: string) => void;
+  setCharacterId: (id: CharacterId) => void;
   setAvailableCards: (cards: TarotCard[]) => void;
   selectCard: (card: SelectedCard) => boolean;
   addChatMessage: (message: ChatMessage) => void;

--- a/src/hooks/useShinjeomSession.ts
+++ b/src/hooks/useShinjeomSession.ts
@@ -2,13 +2,14 @@ import { create } from "zustand";
 import { Topic, ChatMessage } from "@/types/session";
 import { ReadingResult } from "@/types/service";
 import { UserInfo } from "@/types/user-info";
+import type { CharacterId } from "@/types/character";
 
 export type ShinjeomPhase = "character-select" | "conversation" | "result";
 
 interface ShinjeomSessionState {
   phase: ShinjeomPhase;
   sessionId: string | null;
-  characterId: string | null;
+  characterId: CharacterId | null;
   topic: Topic | null;
   userInfo: UserInfo | null;
   chatMessages: ChatMessage[];
@@ -18,7 +19,7 @@ interface ShinjeomSessionState {
 
   setPhase: (phase: ShinjeomPhase) => void;
   setSessionId: (id: string) => void;
-  setCharacterId: (id: string) => void;
+  setCharacterId: (id: CharacterId) => void;
   setTopic: (topic: Topic) => void;
   setUserInfo: (info: ShinjeomSessionState["userInfo"]) => void;
   addChatMessage: (message: ChatMessage) => void;

--- a/src/hooks/useTarotReading.ts
+++ b/src/hooks/useTarotReading.ts
@@ -40,7 +40,7 @@ function buildRevealStep(
 function getReadingErrorText(msg: string, charId: string | null | undefined): string {
   const wl = getWaitingLinesData(useLocaleStore.getState().locale);
   const lines = (charId && wl.characterErrorLines[charId]) ? wl.characterErrorLines[charId] : wl.defaultErrorLines;
-  if (msg.includes("GROK_API_KEY")) return lines.api;
+  if (msg.includes("API_KEY")) return lines.api;
   return lines.reading;
 }
 
@@ -160,7 +160,7 @@ export function useTarotReading({ setRevealedPositions, setPendingConfirm }: Use
     setRevealedPositions([]);
     addChatMessage({ id: crypto.randomUUID(), role: "character", content: translate("tarot.session.msg.cards-gathered", locale), mood: "mystical", timestamp: new Date() });
 
-    const stopSequence = startWaitingSequence(cards, characterId || "arcana");
+    const stopSequence = startWaitingSequence(cards, characterId ?? "");
 
     // sessionId 확보 대기 (최대 3초) — race condition 방지
     let sessionId = storeSessionId;
@@ -176,7 +176,7 @@ export function useTarotReading({ setRevealedPositions, setPendingConfirm }: Use
       stopSequence();
       addChatMessage({
         id: crypto.randomUUID(), role: "character",
-        content: getReadingErrorText(translate("tarot.session.msg.connection-failed", locale), characterId ?? "arcana"),
+        content: getReadingErrorText(translate("tarot.session.msg.connection-failed", locale), characterId),
         mood: "default", timestamp: new Date(),
       });
       setMood("default");


### PR DESCRIPTION
## Summary

- `useSession` / `useSajuSession` / `useShinjeomSession`: `characterId` 타입 `string | null` → `CharacterId | null` 강화 — 12개 캐릭터 외의 ID는 컴파일 타임에 차단
- `useTarotReading` line 163: `characterId || "arcana"` → `characterId ?? ""` — arcana 하드코딩 제거. 캐릭터 없는 경우 `defaultWaitingLines`로 자동 폴백
- `useTarotReading` line 43: `msg.includes("GROK_API_KEY")` → `msg.includes("API_KEY")` — `daily-card/route.ts` 패턴과 통일, 에러 메시지 형식 변화에 강인

## Test plan

- [x] `pnpm type-check` — 에러 없음
- [x] 전체 테스트 스위트 통과 (934 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)