### PR TITLE
fix(types): 타입 안전성 강화 및 설정 정합성 수정

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "dotenv": "^17.4.0",
     "drizzle-kit": "^0.31.10",
     "eslint": "^9",
-    "eslint-config-next": "16.2.3",
+    "eslint-config-next": "16.2.6",
     "replicate": "^1.4.0",
     "tailwindcss": "^4",
     "tsx": "^4.21.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -76,8 +76,8 @@ importers:
         specifier: ^9
         version: 9.39.4(jiti@2.6.1)
       eslint-config-next:
-        specifier: 16.2.3
-        version: 16.2.3(@typescript-eslint/parser@8.57.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+        specifier: 16.2.6
+        version: 16.2.6(@typescript-eslint/parser@8.57.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       replicate:
         specifier: ^1.4.0
         version: 1.4.0
@@ -1040,8 +1040,8 @@ packages:
   '@next/env@16.2.6':
     resolution: {integrity: sha512-gd8HoHN4ufj73WmR3JmVolrpJR47ILK6LouP5xElPglaVxir6e1a7VzvTvDWkOoPXT9rkkTzyCxBu4yeZfZwcw==}
 
-  '@next/eslint-plugin-next@16.2.3':
-    resolution: {integrity: sha512-nE/b9mht28XJxjTwKs/yk7w4XTaU3t40UHVAky6cjiijdP/SEy3hGsnQMPxmXPTpC7W4/97okm6fngKnvCqVaA==}
+  '@next/eslint-plugin-next@16.2.6':
+    resolution: {integrity: sha512-Z8l6o4JWKUl755x4R+wogD86KPeU+Ckw4K+SYG4kHeOJtRenDeK+OSbGcqZpDtbwn9DsJVdir2UxmwXuinUbUw==}
 
   '@next/swc-darwin-arm64@16.2.6':
     resolution: {integrity: sha512-ZJGkkcNfYgrrMkqOdZ7zoLa1TOy0qpcMfk/z4Mh/FKUz40gVO+HNQWqmLxf67Z5WB64DRp0dhEbyHfel+6sJUg==}
@@ -2052,8 +2052,8 @@ packages:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
 
-  eslint-config-next@16.2.3:
-    resolution: {integrity: sha512-Dnkrylzjof/Az7iNoIQJqD18zTxQZcngir19KJaiRsMnnjpQSVoa6aEg/1Q4hQC+cW90uTlgQYadwL1CYNwFWA==}
+  eslint-config-next@16.2.6:
+    resolution: {integrity: sha512-z2ELYSkyrrJ6cuunTU8vhsT/RpouPkjaSah06nVW6Rg2Hpg0Vs8s497/e5s8G8qtdp4ccsiovz5P1rv+5VSW2Q==}
     peerDependencies:
       eslint: '>=9.0.0'
       typescript: '>=3.3.1'
@@ -4059,7 +4059,7 @@ snapshots:
 
   '@next/env@16.2.6': {}
 
-  '@next/eslint-plugin-next@16.2.3':
+  '@next/eslint-plugin-next@16.2.6':
     dependencies:
       fast-glob: 3.3.1
 
@@ -5054,9 +5054,9 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
-  eslint-config-next@16.2.3(@typescript-eslint/parser@8.57.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3):
+  eslint-config-next@16.2.6(@typescript-eslint/parser@8.57.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3):
     dependencies:
-      '@next/eslint-plugin-next': 16.2.3
+      '@next/eslint-plugin-next': 16.2.6
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1))

--- a/src/__tests__/api/daily-card.test.ts
+++ b/src/__tests__/api/daily-card.test.ts
@@ -6,7 +6,7 @@ import { makeMockAiModule } from "@/test-helpers/mock-ai";
 
 setupDoMock();
 
-const TODAY = "2026-04-24";
+const TODAY = new Date().toISOString().split("T")[0];
 const CACHED_CARD = { card_id: "major-00", is_reversed: false, interpretation: "캐시된 해석", keywords: ["새로운 시작"] };
 const VALID_BODY = { characterId: "arcana", date: TODAY };
 

--- a/src/__tests__/api/daily-fortune.test.ts
+++ b/src/__tests__/api/daily-fortune.test.ts
@@ -6,7 +6,7 @@ import { makeMockAiModule } from "@/test-helpers/mock-ai";
 
 setupDoMock();
 
-const TODAY = "2026-05-11";
+const TODAY = new Date().toISOString().split("T")[0];
 const VALID_BODY = { characterId: "arcana", date: TODAY };
 
 const CACHED_ROWS = [

--- a/src/__tests__/components/card/CardFace.showLabel.test.ts
+++ b/src/__tests__/components/card/CardFace.showLabel.test.ts
@@ -9,11 +9,14 @@ import { describe, it, expect } from "vitest";
 // CardFace 컴포넌트 소스의 showLabel 기본값 동작을 타입 레벨에서 검증
 // (실제 DOM 렌더링은 E2E / Playwright로 검증)
 describe("CardFace showLabel prop 계약", () => {
-  it("showLabel이 true일 때 텍스트 블록이 렌더링되어야 함 (규칙 문서화)", () => {
-    // 이 테스트는 showLabel prop의 계약을 문서화한다:
-    // - showLabel=true (기본값): SVG text 요소(카드명·문구) 렌더링
-    // - showLabel=false: SVG text 요소 비렌더링 (숫자 제외)
-    expect(true).toBe(true); // 계약 문서화 — 렌더링 검증은 E2E에서 수행
+  it("showLabel 조건부 렌더링 패턴이 소스에 존재한다 (규칙 문서화)", async () => {
+    const fs = await import("node:fs/promises");
+    const path = await import("node:path");
+    const filePath = path.resolve(process.cwd(), "src/components/card/CardFace.tsx");
+    const source = await fs.readFile(filePath, "utf-8");
+    // showLabel=true(기본값): SVG text 요소 렌더링 / showLabel=false: 비렌더링
+    expect(source).toContain("showLabel = true");
+    expect(source).toContain("{showLabel && (");
   });
 
   it("showLabel 기본값은 true이다 (소스 코드 확인)", async () => {

--- a/src/app/api/saju/session/route.ts
+++ b/src/app/api/saju/session/route.ts
@@ -3,7 +3,7 @@ import { getAdminDb } from "@/lib/db"
 import { getCurrentUser } from "@/lib/auth"
 import { getCharacterById } from "@/data/characters"
 import { Topic } from "@/types/session"
-import { SAJU_TOPICS } from "@/data/topics"
+import { isSajuTopic } from "@/data/topics"
 import { SajuSessionSchema } from "@/lib/validation/api-schemas"
 import { checkRateLimit, rateLimitResponse } from "@/lib/rate-limit"
 import { getClientIp } from "@/lib/request-utils"
@@ -21,10 +21,10 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "Invalid request" }, { status: 400 })
     }
     const { topic: rawTopic, characterId } = parsed.data
-    if (!SAJU_TOPICS.includes(rawTopic as Topic)) {
+    if (!isSajuTopic(rawTopic)) {
       return NextResponse.json({ error: "Invalid topic" }, { status: 400 })
     }
-    const topic = rawTopic as Topic
+    const topic: Topic = rawTopic
     const validCharId = characterId && getCharacterById(characterId) ? characterId : null
     const user = await getCurrentUser()
     const db = getAdminDb()

--- a/src/app/api/shinjeom/message/route.ts
+++ b/src/app/api/shinjeom/message/route.ts
@@ -11,7 +11,7 @@ import { getClientIp, jsonError, SSE_HEADERS } from "@/lib/request-utils"
 import { saveShinjeomFinalReading, saveShinjeomMessages } from "@/lib/db/reading-saver";
 import { getRequestLocale } from "@/i18n/server-locale";
 import { t as translate } from "@/i18n/translations";
-import { SHINJEOM_TOPICS } from "@/data/topics";
+import { isShinjeomTopic } from "@/data/topics";
 
 const shinjeomService = new ShinjeomService();
 const aiProvider = new FallbackProvider();
@@ -33,8 +33,8 @@ export async function POST(request: NextRequest) {
     const parsed = ShinjeomMessageSchema.safeParse(rawBody);
     if (!parsed.success) return jsonError("Invalid request");
     const { sessionId, characterId, userInfo, currentMessage, isFinalTurn, messageIndex, topic: rawTopic } = parsed.data;
-    if (!SHINJEOM_TOPICS.includes(rawTopic)) return jsonError("Invalid topic");
-    const topic = rawTopic as Topic;
+    if (!isShinjeomTopic(rawTopic)) return jsonError("Invalid topic");
+    const topic: Topic = rawTopic;
     // timestamp는 네트워크 전송 시 문자열/숫자로 직렬화되므로 Date로 복원
     const chatHistory: ChatMessage[] = parsed.data.chatHistory.map((m) => ({
       ...m,

--- a/src/app/api/shinjeom/session/route.ts
+++ b/src/app/api/shinjeom/session/route.ts
@@ -5,7 +5,7 @@ import { ShinjeomSessionSchema } from "@/lib/validation/api-schemas"
 import { checkRateLimit, rateLimitResponse } from "@/lib/rate-limit"
 import { getClientIp } from "@/lib/request-utils"
 import { getRequestLocale } from "@/i18n/server-locale"
-import { SHINJEOM_TOPICS } from "@/data/topics"
+import { isShinjeomTopic } from "@/data/topics"
 
 export async function POST(request: NextRequest) {
   try {
@@ -19,7 +19,7 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "Invalid request" }, { status: 400 })
     }
     const { topic, characterId } = parsed.data
-    if (!SHINJEOM_TOPICS.includes(topic)) {
+    if (!isShinjeomTopic(topic)) {
       return NextResponse.json({ error: "Invalid topic" }, { status: 400 })
     }
 

--- a/src/app/api/tarot/reading/route.ts
+++ b/src/app/api/tarot/reading/route.ts
@@ -9,7 +9,7 @@ import { buildUserInfoPrompt, buildFreeQuestionPrompt } from "@/services/core/pr
 import { assertSessionOwnership } from "@/lib/auth";
 import { fetchMemoryPrompt } from "@/lib/db/character-context";
 import { getAdminDb } from "@/lib/db";
-import { TAROT_TOPICS } from "@/data/topics";
+import { isTarotTopic } from "@/data/topics";
 import { TarotReadingSchema } from "@/lib/validation/api-schemas";
 import { checkRateLimit, rateLimitResponse } from "@/lib/rate-limit"
 import { getClientIp, jsonError, SSE_HEADERS } from "@/lib/request-utils";
@@ -61,8 +61,8 @@ export async function POST(request: NextRequest) {
     const { sessionId, topic: rawTopic, spreadType, characterId, userInfo, freeQuestion, cards } = parsed.data;
 
     // 입력 검증
-    if (!TAROT_TOPICS.includes(rawTopic as Topic)) return jsonError("Invalid topic");
-    const topic = rawTopic as Topic;
+    if (!isTarotTopic(rawTopic)) return jsonError("Invalid topic");
+    const topic: Topic = rawTopic;
 
     // 세션 소유권 검증 (sessionId 있을 때만 — 익명 리딩은 허용)
     if (sessionId) {

--- a/src/app/api/tarot/session/route.ts
+++ b/src/app/api/tarot/session/route.ts
@@ -5,7 +5,7 @@ import { TarotService } from "@/services/tarot/tarot-service"
 import { SpreadResolver } from "@/services/tarot/spread-resolver"
 import { getCharacterById } from "@/data/characters"
 import { Topic } from "@/types/session"
-import { TAROT_TOPICS } from "@/data/topics"
+import { isTarotTopic } from "@/data/topics"
 import { TarotSessionSchema } from "@/lib/validation/api-schemas"
 import { checkRateLimit, rateLimitResponse } from "@/lib/rate-limit"
 import { getClientIp } from "@/lib/request-utils"
@@ -26,10 +26,10 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "Invalid request" }, { status: 400 })
     }
     const { topic: rawTopic, characterId, spreadType } = parsed.data
-    if (!TAROT_TOPICS.includes(rawTopic as Topic)) {
+    if (!isTarotTopic(rawTopic)) {
       return NextResponse.json({ error: "Invalid topic" }, { status: 400 })
     }
-    const topic = rawTopic as Topic
+    const topic: Topic = rawTopic
     const validCharId = characterId && getCharacterById(characterId) ? characterId : null
     const user = await getCurrentUser()
     const sessionData = tarotService.startSession(topic)

--- a/src/data/topics.test.ts
+++ b/src/data/topics.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { TAROT_TOPICS, SAJU_TOPICS, SHINJEOM_TOPICS, ALL_TOPICS } from "./topics";
+import { TAROT_TOPICS, SAJU_TOPICS, SHINJEOM_TOPICS, ALL_TOPICS, isTopic } from "./topics";
 
 describe("TAROT_TOPICS", () => {
   it("7개 항목이 있다", () => {
@@ -118,16 +118,16 @@ describe("ALL_TOPICS", () => {
   });
 
   it("유효한 토픽 값이 포함된다", () => {
-    expect(ALL_TOPICS.includes("love")).toBe(true);
-    expect(ALL_TOPICS.includes("saju-general")).toBe(true);
-    expect(ALL_TOPICS.includes("shinjeom-general")).toBe(true);
+    expect(isTopic("love")).toBe(true);
+    expect(isTopic("saju-general")).toBe(true);
+    expect(isTopic("shinjeom-general")).toBe(true);
   });
 
   it("존재하지 않는 값은 포함되지 않는다", () => {
-    expect(ALL_TOPICS.includes("invalid")).toBe(false);
-    expect(ALL_TOPICS.includes("")).toBe(false);
-    expect(ALL_TOPICS.includes("saju")).toBe(false);
-    expect(ALL_TOPICS.includes("shinjeom")).toBe(false);
+    expect(isTopic("invalid")).toBe(false);
+    expect(isTopic("")).toBe(false);
+    expect(isTopic("saju")).toBe(false);
+    expect(isTopic("shinjeom")).toBe(false);
   });
 
   it("모든 요소가 string 타입이다", () => {

--- a/src/data/topics.ts
+++ b/src/data/topics.ts
@@ -1,5 +1,7 @@
+import type { Topic } from "@/types/session";
+
 /** 타로 유효 토픽 목록 */
-export const TAROT_TOPICS: string[] = [
+export const TAROT_TOPICS: Topic[] = [
   "love",
   "love-single",
   "love-couple",
@@ -10,7 +12,7 @@ export const TAROT_TOPICS: string[] = [
 ]
 
 /** 사주 유효 토픽 목록 */
-export const SAJU_TOPICS: string[] = [
+export const SAJU_TOPICS: Topic[] = [
   "saju-general",
   "saju-love-single",
   "saju-love-couple",
@@ -22,7 +24,7 @@ export const SAJU_TOPICS: string[] = [
 ]
 
 /** 신점 유효 토픽 목록 */
-export const SHINJEOM_TOPICS: string[] = [
+export const SHINJEOM_TOPICS: Topic[] = [
   "shinjeom-general",
   "shinjeom-love",
   "shinjeom-wealth",
@@ -32,4 +34,14 @@ export const SHINJEOM_TOPICS: string[] = [
 ]
 
 /** 전체 유효 토픽 목록 (타로 + 사주 + 신점) */
-export const ALL_TOPICS: string[] = [...TAROT_TOPICS, ...SAJU_TOPICS, ...SHINJEOM_TOPICS]
+export const ALL_TOPICS: Topic[] = [...TAROT_TOPICS, ...SAJU_TOPICS, ...SHINJEOM_TOPICS]
+
+const ALL_TOPICS_SET: ReadonlySet<string> = new Set(ALL_TOPICS);
+const SHINJEOM_TOPICS_SET: ReadonlySet<string> = new Set(SHINJEOM_TOPICS);
+const TAROT_TOPICS_SET: ReadonlySet<string> = new Set(TAROT_TOPICS);
+const SAJU_TOPICS_SET: ReadonlySet<string> = new Set(SAJU_TOPICS);
+
+export function isTopic(v: string): v is Topic { return ALL_TOPICS_SET.has(v); }
+export function isShinjeomTopic(v: string): v is Topic { return SHINJEOM_TOPICS_SET.has(v); }
+export function isTarotTopic(v: string): v is Topic { return TAROT_TOPICS_SET.has(v); }
+export function isSajuTopic(v: string): v is Topic { return SAJU_TOPICS_SET.has(v); }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -36,6 +36,7 @@ export default defineConfig({
         "src/app/api/saju/result/[id]/route.ts",      // PR C
         "src/app/api/profile/favorite-character/route.ts", // PR C
         "src/app/api/daily-card/route.ts",            // PR C
+        "src/app/api/daily-fortune/route.ts",         // PR C
         "src/app/api/tarot/reading/route.ts",         // PR C
         "src/app/api/saju/reading/route.ts",          // PR C
         "src/app/api/shinjeom/message/route.ts",      // PR C


### PR DESCRIPTION
## Summary

- **topics.ts**: `string[]` → `Topic[]` 타입 강화 + `isTopic` / `isTarotTopic` / `isSajuTopic` / `isShinjeomTopic` 타입 가드 함수 추가
- **API routes**: `rawTopic as Topic` 캐스트 → 타입 가드로 교체 (5개 라우트)
- **package.json**: `eslint-config-next` 16.2.3 → 16.2.6 (`next` 버전과 동기화)
- **test dates**: `daily-card` / `daily-fortune` 테스트 하드코딩 날짜 → `new Date().toISOString()` 동적 처리
- **CardFace.showLabel.test**: `expect(true).toBe(true)` 무의미 어서션 제거 → 소스 코드 검증으로 교체
- **vitest.config.ts**: `daily-fortune/route.ts` `coverage.include` 추가

## Test plan
- [x] `pnpm type-check` 통과
- [x] `pnpm test` 934개 전부 통과
- [ ] `pnpm install` lockfile 정합성 확인
- [ ] 신규 타입 가드 함수 런타임 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)