### PR TITLE
fix(reading): 카드 리딩 텍스트 깊이 개선 + 멀티 에이전트 문서 정합성 전면 수정

### DIFF
--- a/.claude/WORKFLOW.md
+++ b/.claude/WORKFLOW.md
@@ -86,6 +86,7 @@
    - 새 캐릭터: character-add 에이전트
    - 새 DivinationService: divination-scaffold 에이전트
    - 새 카드 스킨: skin-manager 에이전트
+   - 새 테마 추가/색상 수정: theme-creator 에이전트
 
 4. 구현 (Codex 위임 가능)
    Claude = 설계·뼈대·PR 검토
@@ -236,6 +237,7 @@ PR 머지 완료 후 반드시 수행:
 |---------|---------|
 | `character-add` | 새 캐릭터 추가 (backup-v2/ 백업 포함) |
 | `skin-manager` | 카드 스킨 추가·이미지 생성 (backup-v2/ 백업 포함) |
+| `theme-creator` | 새 테마 추가 또는 기존 테마 색상 수정 |
 | `divination-scaffold` | 새 운세 서비스 추가 (sonar exclusions 동기화 포함) |
 | `page-builder` | 새 페이지 생성 |
 | `quality-gate` | 전체 코드 품질 검증 (sonar 동기화 포함) |

--- a/.claude/agents/character-add.md
+++ b/.claude/agents/character-add.md
@@ -43,12 +43,12 @@ ArcanaInsight에 새 캐릭터를 추가할 때 사용한다.
   id: "{id}", name: "{name}", nameJp: "{nameJp}", gender: "{gender}",
   greeting: "{greeting}",
   expressions: {
-    default: "/images/characters/{id}/nukki/default.png",
-    smile: "/images/characters/{id}/nukki/smile.png",
-    serious: "/images/characters/{id}/nukki/serious.png",
-    surprised: "/images/characters/{id}/nukki/surprised.png",
-    wink: "/images/characters/{id}/nukki/wink.png",
-    mystical: "/images/characters/{id}/nukki/mystical.png",
+    default: "/images/characters/{id}/nukki-enhanced/default.png",
+    smile: "/images/characters/{id}/nukki-enhanced/smile.png",
+    serious: "/images/characters/{id}/nukki-enhanced/serious.png",
+    surprised: "/images/characters/{id}/nukki-enhanced/surprised.png",
+    wink: "/images/characters/{id}/nukki-enhanced/wink.png",
+    mystical: "/images/characters/{id}/nukki-enhanced/mystical.png",
   },
   idleAnimation: "float",
   personality: "{personality}",
@@ -87,25 +87,25 @@ ArcanaInsight에 새 캐릭터를 추가할 때 사용한다.
 ```bash
 # 기존 이미지가 있는 경우 backup-v2/에 백업
 mkdir -p public/images/characters/{id}/backup-v2
-cp -r public/images/characters/{id}/nukki/* public/images/characters/{id}/backup-v2/ 2>/dev/null || true
+cp -r public/images/characters/{id}/nukki-enhanced/* public/images/characters/{id}/backup-v2/ 2>/dev/null || true
 ```
 
 백업 없이 이미지를 덮어쓰면 복구 불가 → 재생성 비용 발생.
 
 ### 5. 이미지 디렉토리 생성
 ```bash
-mkdir -p public/images/characters/{id}/nukki
+mkdir -p public/images/characters/{id}/nukki-enhanced
 ```
 
-필요한 파일 (6개 고유 이미지):
-- `nukki/default.png`
-- `nukki/smile.png`
-- `nukki/serious.png`
-- `nukki/surprised.png`
-- `nukki/wink.png`
-- `nukki/mystical.png`
+필요한 파일 (7개 — 6개 고유 표정 + idle):
+- `nukki-enhanced/default.png`
+- `nukki-enhanced/smile.png`
+- `nukki-enhanced/serious.png`
+- `nukki-enhanced/surprised.png`
+- `nukki-enhanced/wink.png`
+- `nukki-enhanced/mystical.png`
 
-> `idle.png`은 `default.png`과 동일한 이미지이므로, 필요 시 복사하거나 동일 파일을 사용한다.
+> `idle.png`은 `SpriteAnimator`가 `default` 무드에 사용하는 파일명이다. `default.png`을 복사해 `idle.png`으로 저장한다.
 
 **이미지 생성**: `scripts/generate-character-images-v2.mjs` 스크립트 사용.
 
@@ -123,7 +123,7 @@ node scripts/generate-character-images-v2.mjs {id} smile
 > ```bash
 > python3 -c "
 > from PIL import Image; import glob
-> files = sorted(glob.glob('public/images/characters/{id}/nukki/*.png'))
+> files = sorted(glob.glob('public/images/characters/{id}/nukki-enhanced/*.png'))
 > bad = [(f, Image.open(f).size) for f in files if Image.open(f).size != (1408, 768)]
 > print('비표준 파일:', bad if bad else '없음 (모두 1408x768)')
 > "
@@ -189,9 +189,9 @@ sonar.coverage.exclusions=\
 - [ ] `expressions` 경로가 실제 파일과 일치
 - [ ] `waitingLines`에 대사 추가됨
 - [ ] `buildCardPreviewLine`의 `cardPreviewTemplates`에 항목 추가됨
-- [ ] 누끼 이미지 6개(default/smile/serious/surprised/wink/mystical) 존재
-- [ ] **모든 nukki 이미지가 1408×768 사이즈** (python3 사이즈 검증 명령으로 확인)
+- [ ] nukki-enhanced 이미지 7개(default/idle/smile/serious/surprised/wink/mystical) 존재
+- [ ] **모든 nukki-enhanced 이미지가 1408×768 사이즈** (python3 사이즈 검증 명령으로 확인)
 - [ ] **캐릭터 이미지 표시 시 표준 mask 스타일 적용** (CharacterDisplay 사용 또는 직접 스타일 명시)
-- [ ] SpriteAnimator의 MOOD_TO_FILE 매핑과 파일명 일치
+- [ ] SpriteAnimator의 MOOD_TO_FILE 매핑과 파일명 일치 (default→idle.png)
 - [ ] **이미지 생성 전 backup-v2/ 백업 완료**
 - [ ] **신규 .ts 파일 추가 시 sonar-project.properties exclusions 동기화 완료**

--- a/.claude/agents/quality-gate.md
+++ b/.claude/agents/quality-gate.md
@@ -55,7 +55,7 @@ pnpm lint              # ESLint (0 error 필수, warning 기록)
 1. **사주 계산 엔진** (5개) — 알려진 사주, 윤년, 십성, 12운성, 대운
 2. **상수 데이터 무결성** (4개) — 천간 10개, 지지 12개, 오행 5개, 12시진
 3. **카드 데이터** (2개) — 메이저 22장, 스프레드 10종
-4. **캐릭터 데이터** (2개) — 전체 캐릭터 수 12명, 모든 expressions가 nukki PNG 경로(`/nukki/*.png`) 형식
+4. **캐릭터 데이터** (2개) — 전체 캐릭터 수 12명, 모든 expressions가 nukki-enhanced PNG 경로(`/nukki-enhanced/*.png`) 형식
 5. **API 입력 검증** (2개) — 유효 토픽(15개 / 사주 8개+타로 7개), 스프레드 타입(10종)
 6. **SSE 패턴** (4개) — 버퍼링, error 처리, done+break, 사주 동일 패턴
 7. **타입 안전성** (4개) — spreadType nullable, cardInterpretations optional, 타임아웃, 플레이스홀더
@@ -65,7 +65,7 @@ pnpm lint              # ESLint (0 error 필수, warning 기록)
 ### Phase 4: 이미지 에셋 검증
 
 모든 캐릭터 디렉토리를 확인:
-- **모든 12캐릭터**: PNG 누끼 경로 (`/images/characters/{id}/nukki/default.png` 형식)
+- **모든 12캐릭터**: PNG 누끼 경로 (`/images/characters/{id}/nukki-enhanced/default.png` 형식)
 - 필수 표정 6종: `default`, `smile`, `serious`, `surprised`, `wink`, `mystical`
 - SpriteAnimator MOOD_TO_FILE 매핑과 파일명 일치
 - expressions 경로가 실제 파일과 일치
@@ -73,7 +73,7 @@ pnpm lint              # ESLint (0 error 필수, warning 기록)
   ```bash
   python3 -c "
   from PIL import Image; import glob
-  files = glob.glob('public/images/characters/*/nukki/*.png')
+  files = glob.glob('public/images/characters/*/nukki-enhanced/*.png')
   bad = [f for f in files if Image.open(f).size != (1408, 768)]
   print(f'전체 {len(files)}개 | 비표준: {len(bad)}개')
   for f in bad: print(' !!', f, Image.open(f).size)
@@ -84,7 +84,7 @@ pnpm lint              # ESLint (0 error 필수, warning 기록)
 - **[필수] 캐릭터 이미지 테두리 투명도 — 표준 mask 값 일치 확인**:
   캐릭터 이미지를 직접 표시하는 모든 컴포넌트/페이지에서 아래 표준값이 그대로 사용되는지 grep으로 확인:
   ```bash
-  grep -rn "black 14%\|black 18%\|black 10%" src/ --include="*.tsx"
+  grep -rn "black 14%\|black 18%\|black 10%" src/ --include="*.tsx" --include="*.ts"
   ```
   `CharacterDisplay.tsx` 외에 캐릭터 이미지를 직접 렌더링하는 곳(예: `character/[id]/page.tsx`)도 동일한 수치를 사용해야 한다.
   수치가 다르면 표준값(`top: 14%, bottom: 18%, left/right: 10%`)으로 수정한다.

--- a/.claude/agents/skin-manager.md
+++ b/.claude/agents/skin-manager.md
@@ -22,12 +22,12 @@ ArcanaInsight의 카드 스킨 시스템을 관리한다.
 
 | ID | 이름 | 설명 |
 |----|------|------|
-| gold-luxury | 골드 럭셔리 | 금박 + 다크 톤 |
-| dark-gothic | 다크 고딕 | 고딕 + 블랙 |
-| celestial-mystic | 천상 미스틱 | 우주/천체 테마 |
-| pastel-dream | 파스텔 드림 | 파스텔톤 |
-| neon-cyberpunk | 네온 사이버 | 사이버펑크 |
-| emerald-enchant | 에메랄드 인챈트 | 에메랄드/자연 |
+| gold-luxury | 골드 럭셔리 | 미드나잇 블루와 금박의 최고급 아르데코 |
+| dark-gothic | 다크 고딕 | 핏빛 악센트의 어둡고 강렬한 중세 오컬트 |
+| celestial-mystic | 셀레스티얼 미스틱 | 별자리와 달빛의 천상 세계 |
+| pastel-dream | 파스텔 드림 | 수채화처럼 번지는 몽환적 라벤더 세계 |
+| neon-cyberpunk | 네온 사이버펑크 | 홀로그램 회로와 네온의 미래적 디지털 오라클 |
+| emerald-enchant | 에메랄드 인챈트 | 에메랄드 보석과 숲의 자연 마법 |
 
 ## 스킨 이미지 구조
 
@@ -52,7 +52,7 @@ card-skins/
 - `nameKo` — 한국어 이름
 - `description` — 설명 (1줄)
 - `previewColor` — 미리보기 색상 (hex)
-- `stylePrompt` — Grok 이미지 생성 API(`grok-2-image` 모델) 스타일 프롬프트
+- `stylePrompt` — Grok 이미지 생성 API(`grok-imagine-image-pro` 모델) 스타일 프롬프트
 
 ### 2. 수정 파일
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -7,6 +7,7 @@
       "Bash(pnpm type-check)",
       "Bash(pnpm test)",
       "Bash(pnpm test:coverage)",
+      "Bash(pnpm test:e2e*)",
       "Bash(pnpm tsc*)",
       "Bash(pnpm install*)",
       "Bash(pnpm add*)",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,7 @@ src/
 │   ├── effects/     # ThemeEffectEngine, ThemeAtmosphereLayer, InteractionEffects,
 │   │                # ServiceBackground, ParticleOverlay, MysticBackground, ScrollReveal
 │   │                # mysticUtils.ts — particleStyle·particleMotion 순수 함수
+│   │                # themeAtmosphere.ts — ThemeAtmosphereLayer 전용 파티클 종류·설정
 │   ├── session/     # ResultTextCard, SessionActionButtons, ReadingErrorState (3서비스 공통)
 │   └── tarot/       # CardInterpretationList (카드별 해석 목록), TarotResultPanel (결과 패널),
 │                    # ShuffleCeremony, CardFlipEffect, ReadingProgressIndicator, CardSpreadEffects

--- a/docs/architecture/ai-infrastructure.md
+++ b/docs/architecture/ai-infrastructure.md
@@ -132,6 +132,26 @@ for (let i = start; i < text.length; i++) {
 `shinjeom-service.ts`가 이 정규식을 사용하다가 `parseJsonSafe()`로 교체됨.
 
 
+## 4. max_tokens 정책 (`computeReadingMaxTokens`)
+
+`src/app/api/tarot/reading/route.ts` — 카드 수 비례 동적 산정
+
+| 카드 수 | max_tokens |
+|---------|-----------|
+| 1장 | 6,000 |
+| 2–3장 | 10,000 |
+| 4–5장 | 14,000 |
+| 6–7장 | 18,000 |
+| 8–9장 | 22,000 |
+| 10장+ | `min(4000 + n×2500 + 5000, 60000)` |
+
+- 모델 cap 60,000: Claude Sonnet 4.6 / Haiku 4.5 max output 64K 안전마진
+- `perCard 2500`: 한국어 토큰 비율(영어 대비 ×1.3) + JSON 구조 오버헤드 반영
+- `reasoningBuffer 5000`: Grok-3 reasoning 토큰을 max_tokens 예산에서 함께 소비하는 특성 대응
+- `base 4000`: system prompt + overallReading + advice 고정 오버헤드
+
+---
+
 ## 클라이언트 타임아웃 패턴 (tarot/saju 세션 공통)
 
 타로·사주 세션 페이지는 240s 하드 타임아웃 + `AbortController` + `finished` 가드 패턴을 공통 적용합니다:

--- a/docs/architecture/db-abstraction.md
+++ b/docs/architecture/db-abstraction.md
@@ -65,7 +65,9 @@ src/lib/db/
 | `010_share_token_default_fix.sql` | readings share_token NULL 백필 |
 | `011_saju_shinjeom_share_token_defaults.sql` | saju/shinjeom share_token NULL 백필 |
 | `012_spread_type_expand.sql` | sessions.spread_type CHECK 제약 확장 (10개 스프레드, PR #216) |
-| `013_*` ~ `015_fix_sessions_rls.sql` | RLS 보강 (PR #219·#221 — share_token USING(true), 익명 세션 SELECT 허용 등) |
+| `013_shinjeom_rls.sql` | shinjeom_messages RLS 추가 (008에서 누락) |
+| `014_fix_share_token_rls.sql` | readings/saju_readings share_token 전체 공개 정책 제거 — service_role 서버 레이어로 대체 |
+| `015_fix_sessions_rls.sql` | sessions SELECT: 익명 세션(user_id IS NULL) 조회 허용 (assertSessionOwnership 지원) |
 | `016_locale_columns.sql` | 5개 테이블 locale 컬럼 + idx_sessions_user_locale (PR #223) |
 | `017_daily_fortune_areas.sql` | daily_cards.area 컬럼 추가 + UNIQUE(date, character_id, area) 재구성 (DailyFortune 5영역) |
 | `018_birthtime_mbti.sql` | profiles.birth_hour HH:MM 형식 외 NULL 처리 + profiles.mbti 컬럼 추가 |

--- a/docs/conventions/i18n-style.md
+++ b/docs/conventions/i18n-style.md
@@ -44,7 +44,7 @@ export async function POST(req: NextRequest) {
 ## 키 네이밍
 
 - 형식: `namespace.key` 또는 `namespace.section.key`
-- namespace: 17개 (`common`·`header`·`footer`·`home`·`settings`·`locale`·`tarot`·`saju`·`mypage`·`character`·`user-info`·`auth`·`share`·`chat`·`api`·`meta`·`shinjeom`) — 전체 목록은 `src/i18n/translations/shared/keys.ts` 참조
+- namespace: 19개 (`common`·`header`·`footer`·`home`·`settings`·`locale`·`tarot`·`saju`·`mypage`·`character`·`user-info`·`birth-time`·`privacy-consent`·`auth`·`share`·`chat`·`api`·`meta`·`shinjeom`) — 전체 목록은 `src/i18n/translations/shared/keys.ts` 참조
 - 케이스: dot-notation, kebab-case 단어 분리 (`skip-link`, `nav.daily-card`)
 - 예: `header.nav.tarot`, `footer.section.services`, `home.hero.title`, `locale.modal.confirm`
 

--- a/docs/conventions/layout-rules.md
+++ b/docs/conventions/layout-rules.md
@@ -12,7 +12,7 @@
 
 | 화면 | 구조 |
 |------|------|
-| **데스크탑(md 이상)** | 좌측 캐릭터 `md:w-1/2` + 우측 콘텐츠 `md:w-1/2` — 가로 5:5 flex |
+| **데스크탑(md 이상)** | 좌측 캐릭터 `md:w-[50%]` + 우측 콘텐츠 `md:w-[50%]` — 가로 5:5 flex |
 | **모바일(md 미만)** | `flex-col` 세로 배치 — 캐릭터 → 콘텐츠 순서 |
 
 ---
@@ -70,12 +70,12 @@ style={{
 
 ```tsx
 // 모바일 캐릭터 영역
-<div className="h-[25%] md:h-auto md:w-1/2">
+<div className="h-[25%] md:h-auto md:w-[50%]">
   <CharacterDisplay ... />
 </div>
 
 // 콘텐츠 영역
-<div className="flex-1 overflow-y-auto md:w-1/2">
+<div className="flex-1 overflow-y-auto md:w-[50%]">
   {/* 콘텐츠 */}
 </div>
 ```

--- a/docs/conventions/zod-schemas.md
+++ b/docs/conventions/zod-schemas.md
@@ -48,10 +48,11 @@ const body = await request.json() as { field1: string };
 
 ## 3. 기존 스키마 목록
 
-`src/lib/validation/api-schemas.ts` — 9종:
+`src/lib/validation/api-schemas.ts` — 10종:
 
 | 스키마 | 용도 |
 |--------|------|
+| `LocaleSchema` | locale 설정 요청 |
 | `TarotReadingSchema` | 타로 리딩 요청 |
 | `SajuReadingSchema` | 사주 리딩 요청 |
 | `ShinjeomMessageSchema` | 신점 메시지 요청 |

--- a/docs/operations/operation-guide.md
+++ b/docs/operations/operation-guide.md
@@ -245,7 +245,7 @@ flowchart TB
 3. **DB locale 동기화 확인** — 인증 사용자: `profiles.locale` SELECT로 확인. 쿠키와 불일치하면 `/api/locale` POST가 한 번 실패한 케이스.
 4. **`<html lang>` 검증** — DevTools Elements 탭에서 `<html lang="en">` 등 확인. `ko`로 표시되면 쿠키가 SSR에 도달하지 못한 상태 (middleware 동작 의심).
 
-### locale별 카드·캐릭터 표시가 한국어로 나오는 경우 (PR-3·4·5 진행 중 정상)
-- 카드 데이터 영문화는 PR-3, 캐릭터 페르소나는 PR-4, 일본어 전체 채움은 PR-5에서 진행. 현재는 ko fallback이 의도된 동작.
+### locale별 카드·캐릭터 표시가 한국어로 나오는 경우
+- i18n 다국어 PR (#230~#235 포함 9건) 전체 머지 완료 (2026-05-14). 현재 ko fallback은 의도된 동작 — 외부 번역가 미사용, 직역 사전으로 운영 지속 (사용자 확정).
 
 상세: [`../architecture/i18n.md`](../architecture/i18n.md)

--- a/docs/workflow/claude-codex-collaboration.md
+++ b/docs/workflow/claude-codex-collaboration.md
@@ -25,7 +25,7 @@
 |---|-----------|--------|
 | C1 | 기능 요구사항 분석 및 스펙 문서 작성 | `docs/superpowers/specs/*.md` |
 | C2 | 아키텍처 설계·기술 결정 문서 | `docs/architecture/*.md` 갱신 |
-| C3 | 에이전트 정의 및 Task Playbook | `.claude/agents/*.md`, `docs/workflow/task-playbooks.md` — 현재 6종: `character-add`, `divination-scaffold`, `page-builder`, `skin-manager`, `theme-creator`, `quality-gate` |
+| C3 | 에이전트 정의 및 Task Playbook | `.claude/agents/*.md`, `docs/workflow/task-playbooks.md` — 현재 8종: `character-add`, `divination-scaffold`, `page-builder`, `skin-manager`, `theme-creator`, `quality-gate`, `i18n-manager`, `post-merge-doc-refresher` |
 | C4 | DB 스키마 설계 및 마이그레이션 계획 | SQL 초안, Drizzle 스키마 구조 명세 |
 | C5 | 새 서비스·페이지 뼈대 스캐폴딩 | 파일 구조, 인터페이스, 타입 정의, 빈 함수 시그니처 |
 | C6 | `CLAUDE.md` / `AGENTS.md` 최신화 | 구조 트리, 아키텍처 섹션 갱신 |
@@ -82,7 +82,7 @@ Codex에게 작업을 전달할 때 **아래 항목을 모두 포함**해야 한
 ### 완료 조건 (Definition of Done)
 - [ ] pnpm type-check — 0 error
 - [ ] pnpm lint       — 0 error
-- [ ] pnpm test:coverage — branches≥92 / functions≥98 / lines≥98
+- [ ] pnpm test:coverage — branches≥92 / functions≥98 / lines≥98 / statements≥98
 - [ ] [기능별 추가 조건]
 
 ### 재진입 조건 (아래 상황이면 구현 중단 후 Claude에게 반환)

--- a/docs/workflow/code-change-process.md
+++ b/docs/workflow/code-change-process.md
@@ -20,7 +20,7 @@
 ```bash
 pnpm type-check        # TypeScript 타입 체크
 pnpm lint              # ESLint 코드 품질 검사
-pnpm test:coverage     # 단위 테스트 + 커버리지 임계값 확인 (statements 98%)
+pnpm test:coverage     # 단위 테스트 + 커버리지 임계값 확인 (branches 92 / functions·lines·statements 98)
 pnpm build             # 프로덕션 빌드 확인
 ```
 

--- a/docs/workflow/e2e-testing.md
+++ b/docs/workflow/e2e-testing.md
@@ -6,7 +6,7 @@
 > **담당**: Codex (spec 작성·수정·실행) | Claude (테스트 시나리오 기획·셀렉터 전략 결정)
 > 협업 프로토콜 정본: [`claude-codex-collaboration.md`](claude-codex-collaboration.md)
 
-- **23개 spec 파일** / **182개 테스트** (Desktop Chrome 기준)
+- **25개 spec 파일** (Desktop Chrome 기준; 실제 테스트 수는 `npx playwright test --list --project="Desktop Chrome"` 기준)
 - **3개 디바이스 프로필**: Desktop Chrome · Mobile Android (Pixel 7) · Mobile iOS (iPhone 14)
 - **Playwright 버전**: `v1.59.1` — CI Docker 이미지와 버전 고정, 임의 변경 금지
 
@@ -99,6 +99,8 @@ docker run --rm \
 
 **문서 변경(*.md, docs/, n8n/)만의 PR/push는 E2E를 자동 스킵합니다.**
 
+> ⚠️ **CI 재현성 필수**: `playwright.config.ts`의 `use.locale: "ko"` 절대 제거 금지. CI 브라우저 기본값은 en-US이므로 제거 시 SSR이 영어로 렌더링되어 한국어 단언이 전부 실패합니다 (PR #243, 25개 실패 사례).
+
 ### QA 자동 루프
 
 ```
@@ -139,6 +141,8 @@ docker run --rm \
 | `theme.spec.ts` | 테마 드롭다운 · 7종 테마 전환 · 3개 디바이스 | — | 없음 |
 | `i18n-matrix.spec.ts` | ko/en/ja 3개 locale 전환 · UI 텍스트 렌더링 검증 | — | 없음 |
 | `theme-atmosphere.spec.ts` | 7종 테마 분위기 이펙트 · 파티클·배경 렌더링 | — | 없음 |
+| `tarot-text-reveal.spec.ts` | 타로 showLabel 제어 동작 — result phase 진입 전 카드명 텍스트 미노출 검증 | — | 없음 |
+| `theme-effects.spec.ts` | ThemeAtmosphereLayer 렌더링 검증 — 테마별 레이어 DOM 존재 확인 | — | 없음 |
 | `smart-ci.spec.ts` | 실 Supabase 세션 기반 플로우 검증 (CI `testIgnore` 대상) — 파일 상단 `// ⚠️ 실 Supabase 인증 세션 필요 — CI testIgnore 대상` 주석 필수 | — | ⚠️ 실 세션 필요 |
 
 ---
@@ -232,7 +236,30 @@ Mobile iOS 프로젝트(WebKit)는 `page.mouse.wheel()`을 지원하지 않는�
 
 ## 5. Helper 사용 가이드
 
-> 참조: [`e2e/helpers/sse-mock.ts`](../../e2e/helpers/sse-mock.ts)
+> 참조: [`e2e/helpers/sse-mock.ts`](../../e2e/helpers/sse-mock.ts), [`e2e/helpers/service-navigation.ts`](../../e2e/helpers/service-navigation.ts)
+
+### service-navigation.ts
+
+서비스 진입 로직(캐릭터 선택, 타로/사주/신점 페이지 이동, 폼 입력)을 집중 관리합니다.
+UI 변경 시 이 파일을 **먼저** 수정하면 이 파일을 import하는 모든 spec 파일이 자동 대응됩니다.
+
+```ts
+import {
+  selectFirstCharacter,        // 캐릭터 목록에서 첫 번째 캐릭터 클릭
+  navigateToSajuForm,          // /saju 이동 후 캐릭터 선택 → 사주 폼 진입
+  fillSajuForm,                // 생년월일·성별·시간 입력
+  submitSajuForm,              // 사주 폼 제출
+  enterSajuSession,            // 사주 세션까지 전체 진입
+  navigateToShinjeomSession,   // /shinjeom 이동 후 캐릭터·주제 선택
+  enterShinjeomSession,        // 신점 세션 진입 (주제 선택 + 첫 메시지 전송)
+  enterTarotSession,           // /tarot 이동 후 캐릭터·주제·스프레드 선택까지
+} from "../helpers/service-navigation";
+```
+
+**변경 전 영향 파일 확인 필수**:
+```bash
+grep -rn "service-navigation" e2e/ --include="*.ts"
+```
 
 AI 응답 렌더링 테스트(`ai-response-rendering.spec.ts`)에서 실제 API 호출 없이 SSE 스트리밍을 mock합니다.
 
@@ -454,7 +481,7 @@ await enterShinjeomSession(page);
 
 ```bash
 # 재검증 커맨드
-ls e2e/*.spec.ts | wc -l                              # spec 파일 수
+ls e2e/*.spec.ts | wc -l                                         # spec 파일 수 (현재 25개)
 npx playwright test --list --project="Desktop Chrome" | tail -1  # 테스트 수
 ```
 

--- a/docs/workflow/scripts.md
+++ b/docs/workflow/scripts.md
@@ -29,6 +29,10 @@
 | `pnpm upload:assets:skip` | `generate-assets/upload-to-supabase.ts --skip-existing` | 이미 존재하는 이미지를 건너뛰고 업로드 |
 | `pnpm test:e2e:full` | `e2e-full/orchestrator.ts --mode=full --workers=6` | 전수 E2E (실서버 + 실 API 키 필요) |
 | `pnpm test:e2e:full:ci` | `e2e-full/orchestrator.ts --mode=ci` | CI 대표 12 조합 |
+| `pnpm enhance:images` | `enhance-character-images.mjs` | 캐릭터 이미지 보정 (Node.js) |
+| `pnpm polish:images` | `polish-character-images.py` | 캐릭터 이미지 후처리 (Python) |
+| `pnpm remove:bg:pilot` | `remove-character-bg.mjs --pilot` | 배경 제거 파일럿 (1장 테스트) |
+| `pnpm remove:bg:full` | `remove-character-bg.mjs --full` | 전체 캐릭터 배경 제거 |
 
 ## 3. 수동 자산 생성 (`tsx scripts/<name>.ts` 직접 실행)
 

--- a/docs/workflow/unit-testing.md
+++ b/docs/workflow/unit-testing.md
@@ -31,7 +31,7 @@ src/lib/env.test.ts       ← 같은 디렉토리
 
 ### API 라우트 테스트 ⚠️ 중요
 
-`vitest.config.ts`의 `exclude: ["src/app/**"]` 설정이 테스트 파일도 제외합니다.
+`vitest.config.ts`의 `exclude: ["src/app/**", "src/components/**"]` 설정이 테스트 파일도 제외합니다.
 
 ```
 src/app/api/tarot/reading/route.test.ts  ← ❌ 수집 불가


### PR DESCRIPTION
## Summary

- **카드 리딩 텍스트 깊이 개선**: Grok-3 reasoning 토큰 소비를 고려해 `computeReadingMaxTokens` 전 구간 ~2배 상향, `depthGuide` 카드 수 무관 균일 3~4문단으로 통일
- **멀티 에이전트 분석 기반 Claude 운영 체계 구축**: 4개 병렬 에이전트가 코드베이스를 분석해 스킬·훅·규칙·에이전트 파일 14종 신규 생성
- **4-에이전트 교차검증 문서 정합성 전면 수정**: 전체 문서를 코드 정본과 교차검증, 17개 파일 불일치 수정

## 변경 내용

### 🔧 카드 리딩 깊이 개선 (`src/`)
- `src/app/api/tarot/reading/route.ts`: `computeReadingMaxTokens` 전 구간 ~2배 상향
  - 1장: 2600 → 6000 / 3장: 4500 → 10000 / 5장: 6500 → 14000
  - 7장: 8500 → 18000 / 9장: 10500 → 22000 / 10장+: 공식 변경
- `src/services/core/prompt-builder.ts`: `depthGuide` 3단계 분기 → 카드 수 무관 균일 3~4문단
- 관련 테스트 업데이트 (prompt-builder.test.ts, tarot-reading.test.ts)

### 🤖 Claude 운영 체계 신규 구축 (`.claude/`)
- **신규 에이전트 2종**: `i18n-manager.md`, `post-merge-doc-refresher.md`
- **신규 rules 4종**: `api-routes.md`, `services.md`, `e2e-testing.md`, `i18n.md`
- **신규 스크립트 1종**: `scripts/pre-pr-checks.sh` (7단계 PR 전 검증 게이트)
- **hooks 추가**: `pre-push-checks.sh` + `gh pr create` 트리거 사전 검증
- 기존 에이전트 강화: `character-add`, `skin-manager`, `divination-scaffold`, `quality-gate`
- `WORKFLOW.md`: post-merge 워크플로우(8번), 에이전트 가이드(9번) 추가

### 📚 문서 정합성 수정 (17개 파일)
| 파일 | 수정 내용 |
|------|---------|
| `character-add.md`, `quality-gate.md` | 이미지 경로 `nukki` → `nukki-enhanced` 전면 수정 🔴 |
| `ai-infrastructure.md` | `computeReadingMaxTokens` 값 테이블 신규 추가 |
| `layout-rules.md` | `md:w-1/2` → `md:w-[50%]` (실제 코드 일치) |
| `i18n-style.md` | namespace 17개 → 19개 |
| `e2e-testing.md` | spec 25개, `locale:"ko"` 필수 경고, helper 문서화 |
| `db-abstraction.md` | 마이그레이션 013~015 파일명 명시 |
| `.claude/settings.json` | `pnpm test:e2e*` 권한 추가 |

## Test plan

- [ ] `pnpm type-check` — 0 error
- [ ] `pnpm lint` — 0 error
- [ ] `pnpm test:coverage` — branches 92 / functions·lines·statements 98% 충족
- [ ] `pnpm check:doc-links` — 문서 링크 유효
- [ ] `pnpm check:env-docs` — env.ts ↔ env-variables.md 정합성
- [ ] `pnpm i18n:check` — 번역 키 drift 없음
- [ ] 타로 1장 리딩 실행 → 각 카드 해석이 3~4문단으로 충분히 깊은지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)