### PR TITLE
fix(tarot): 선택 카드 뒤 회전 아크 이펙트 제거

### DIFF
--- a/src/components/card/CardItem.tsx
+++ b/src/components/card/CardItem.tsx
@@ -82,53 +82,24 @@ export function CardItem({ card, isFlipped, isSelected, isReversed = false, onCl
         />
       )}
 
-      {/* 스프레드 선택 카드 글로우: 펄스 링 + 회전 빛 아크 (positionIndex별 페이즈 다름) */}
+      {/* 스프레드 선택 카드 글로우: 펄스 링 */}
       {showSelectionGlow && (
-        <>
-          <motion.div
-            className="absolute inset-0 rounded-lg pointer-events-none"
-            animate={{
-              boxShadow: [
-                `0 0 0 1.5px rgba(${rgb},0.65), 0 0 8px rgba(${rgb},0.25), 0 0 18px rgba(${rgb},0.1)`,
-                `0 0 0 2.5px rgba(${rgb},1), 0 0 16px rgba(${rgb},0.55), 0 0 32px rgba(${rgb},0.22)`,
-                `0 0 0 1.5px rgba(${rgb},0.65), 0 0 8px rgba(${rgb},0.25), 0 0 18px rgba(${rgb},0.1)`,
-              ],
-            }}
-            transition={{
-              duration: 1.8 + pIdx * 0.4,
-              repeat: Infinity,
-              ease: "easeInOut",
-              delay: pIdx * 0.55,
-            }}
-          />
-          <motion.div
-            className="absolute pointer-events-none"
-            style={{
-              top: -2, right: -2, bottom: -2, left: -2,
-              borderRadius: "0.625rem",
-              padding: "2px",
-              background: `conic-gradient(
-                from 0deg,
-                transparent 0deg,
-                transparent 252deg,
-                rgba(${rgb},0.45) 290deg,
-                rgba(255,255,255,0.92) 312deg,
-                rgba(${rgb},0.45) 334deg,
-                transparent 360deg
-              )`,
-              WebkitMask: "linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0)",
-              WebkitMaskComposite: "xor",
-              maskComposite: "exclude",
-            }}
-            animate={{ rotate: [0, 360] }}
-            transition={{
-              duration: 2.5 + pIdx * 0.5,
-              repeat: Infinity,
-              ease: "linear",
-              delay: pIdx * 0.75,
-            }}
-          />
-        </>
+        <motion.div
+          className="absolute inset-0 rounded-lg pointer-events-none"
+          animate={{
+            boxShadow: [
+              `0 0 0 1.5px rgba(${rgb},0.65), 0 0 8px rgba(${rgb},0.25), 0 0 18px rgba(${rgb},0.1)`,
+              `0 0 0 2.5px rgba(${rgb},1), 0 0 16px rgba(${rgb},0.55), 0 0 32px rgba(${rgb},0.22)`,
+              `0 0 0 1.5px rgba(${rgb},0.65), 0 0 8px rgba(${rgb},0.25), 0 0 18px rgba(${rgb},0.1)`,
+            ],
+          }}
+          transition={{
+            duration: 1.8 + pIdx * 0.4,
+            repeat: Infinity,
+            ease: "easeInOut",
+            delay: pIdx * 0.55,
+          }}
+        />
       )}
 
       <motion.div


### PR DESCRIPTION
## Summary

- 타로 스프레드에서 선택된 카드 주변을 회전하는 conic-gradient 아크 이펙트 제거
- PR #419에서 ShuffleCeremony는 제거했으나 CardItem의 `showSelectionGlow` 블록 안 회전 arc(`animate={{ rotate: [0, 360] }}`)가 남아 있었음
- 펄스 링 글로우(boxShadow 애니메이션)는 유지

## Changed Files

- `src/components/card/CardItem.tsx` — 회전 conic-gradient motion.div 제거, Fragment → 단일 motion.div로 단순화

## Test plan

- [ ] 타로 카드 선택 후 선택된 카드 주변에 회전 효과 없는지 확인
- [ ] 펄스 글로우(반짝이는 테두리)는 유지되는지 확인
- [ ] CI 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)