### PR TITLE
docs: vitest 4 업그레이드(PR #423) 반영 — 문서 최신화

### DIFF
--- a/docs/operations/monitoring.md
+++ b/docs/operations/monitoring.md
@@ -89,7 +89,7 @@ PR 및 main push 시 자동 실행 (`sonar.yml`):
 
 - PR마다 커버리지 변화 코멘트 자동 게시
 - `unit` flag로 단위 테스트 커버리지만 추적
-- 임계값: branches 92% / lines·statements·functions 98%
+- 임계값: branches 90% / functions 97% / lines·statements 98%
 
 ---
 

--- a/docs/workflow/ci-cd.md
+++ b/docs/workflow/ci-cd.md
@@ -117,6 +117,10 @@ Railway 환경변수: DB_PROVIDER=supabase (즉시 적용)
 
 → CI 실패 시 main 머지 자체가 차단되어 Railway 배포도 자동으로 방어됨
 
+### Dependabot PR의 시크릿 제한 ⚠️
+
+Dependabot이 만든 PR의 워크플로는 **저장소 Secrets에 접근하지 못한다**(GitHub 보안 정책). 따라서 Grok/Supabase 키가 플레이스홀더(`pl***ey`)로 주입되어 AI·DB 호출이 실패하고, 이로 인해 `E2E — Mobile Android` 같은 레이아웃·스크롤 타이밍 민감 테스트가 **실제 코드 문제 없이도 실패**할 수 있다(Desktop Chrome은 통과). 이때는 시크릿이 포함된 로컬 Docker E2E([`e2e-testing.md`](e2e-testing.md))로 해당 테스트 통과를 확인한 뒤 수동 머지한다. (2026-06-02 vitest 4 업그레이드 PR #423 사례)
+
 ---
 
 ## E2E 상세 실행 가이드

--- a/docs/workflow/code-change-process.md
+++ b/docs/workflow/code-change-process.md
@@ -20,7 +20,7 @@
 ```bash
 pnpm type-check        # TypeScript 타입 체크
 pnpm lint              # ESLint 코드 품질 검사
-pnpm test:coverage     # 단위 테스트 + 커버리지 임계값 확인 (branches 92 / functions·lines·statements 98)
+pnpm test:coverage     # 단위 테스트 + 커버리지 임계값 확인 (branches 90 / functions 97 / lines·statements 98)
 pnpm build             # 프로덕션 빌드 확인
 ```
 

--- a/docs/workflow/unit-testing.md
+++ b/docs/workflow/unit-testing.md
@@ -9,9 +9,9 @@ Vitest 기반 단위 테스트 작성 패턴과 주의사항입니다.
 
 ## 1. 테스트 현황
 
-- **Vitest 2.0** (node env, v8 coverage)
+- **Vitest 4.1** (node env, v8 coverage / `@vitest/coverage-v8` 4.x, vite 7)
 - 실제 테스트 수는 변경이 잦으므로 `pnpm test:coverage` 출력과 coverage 리포트를 기준으로 확인한다.
-- 임계값: `branches 92 / functions 98 / lines 98 / statements 98`
+- 임계값: `branches 90 / functions 97 / lines 98 / statements 98`
 
 ```bash
 pnpm test:coverage    # 테스트 실행 + 커버리지 리포트
@@ -145,6 +145,26 @@ describe("API 테스트", () => {
 });
 ```
 
+### 생성자 mock은 화살표 함수 금지 ⚠️ (vitest 4)
+
+라우트가 `new FallbackProvider()`처럼 **생성자로 호출**하는 클래스를 mock할 때는,
+vitest 4부터 mock 구현이 생성자로 실행되므로 **화살표 함수를 쓸 수 없다**(화살표는 생성자 불가).
+일반 `function` 표현식으로 인스턴스를 반환해야 한다.
+
+```ts
+// ❌ vitest 4에서 "() => provider is not a constructor"
+FallbackProvider: vi.fn().mockImplementation(() => provider)
+
+// ✅ 일반 함수로 인스턴스 반환
+FallbackProvider: vi.fn().mockImplementation(function () { return provider; })
+```
+
+### `makeMockDb()` 타입 (vitest 4)
+
+`MockDbClient`는 각 메서드를 `DbClient[K] & MockInstance` 교차 타입으로 노출한다.
+vitest 4의 `ReturnType<typeof vi.fn>`은 제네릭 메서드(`findOne<T>`)와 호환되지 않으므로,
+원본 시그니처와 Mock 헬퍼(`mockResolvedValue` 등)를 모두 만족시키기 위함이다.
+
 ---
 
 ## 7. 커버리지 임계값
@@ -153,8 +173,8 @@ describe("API 테스트", () => {
 ```ts
 coverage: {
   thresholds: {
-    branches: 92,
-    functions: 98,
+    branches: 90,
+    functions: 97,
     lines: 98,
     statements: 98,
   }
@@ -162,6 +182,8 @@ coverage: {
 ```
 
 임계값 변경 시 PR 설명에 근거 명시 필수.
+
+> ⚠️ vitest 4 + `coverage-v8` 4.x는 함수·분기를 더 세밀하게 카운트하여(Lines 100%여도 Funcs<100%로 잡힘) vitest 2 대비 함수·분기 비율이 소폭 낮게 측정된다. 2026-06-02 vitest 2→4 업그레이드(PR #423) 시 측정 방식 변화를 반영해 `branches 92→90`, `functions 98→97`로 재보정했다. 테스트 자체는 동일하게 통과하며 실제 커버리지 누락이 아니다.
 
 ---
 


### PR DESCRIPTION
## 개요
PR #423(vitest 2→4 업그레이드) 머지 후 전역 규칙(작업 완료 후 전체 문서 최신화)에 따른 문서 동기화.

## 변경
- **unit-testing.md**: Vitest 2.0→4.1, 임계값 재보정(`branches 92→90`, `functions 98→97`), vitest 4 생성자 mock(화살표 금지)·`MockDbClient` 타입 가이드 추가
- **ci-cd.md**: Dependabot PR 시크릿 제한 → E2E 스푸리어스 실패·로컬 Docker E2E 검증·수동 머지 흐름 기록
- **code-change-process.md**, **monitoring.md**: 커버리지 임계값 동기화

## 배경
vitest 4 + coverage-v8 4.x는 함수·분기를 더 세밀히 카운트해 측정치가 소폭 낮아짐(Lines 100%여도 Funcs<100%). 실제 누락이 아니며 939개 테스트 전부 통과. 측정 변화 반영을 위해 임계값을 재보정함.

🤖 Generated with [Claude Code](https://claude.com/claude-code)