### PR TITLE
fix(tarot): 카드 스프레드 단계 뒤로가기를 스프레드 선택 단계로 복귀

### DIFF
--- a/e2e/tarot-flow.spec.ts
+++ b/e2e/tarot-flow.spec.ts
@@ -82,6 +82,35 @@ test.describe("타로 서비스 플로우", () => {
     }
   });
 
+  test("뒤로가기: 카드 스프레드 단계 → 스프레드 선택 단계로 복귀 (캐릭터·주제 유지)", async ({ page }) => {
+    await page.emulateMedia({ reducedMotion: "reduce" });
+    await mockSessionCreate(page, "**/api/tarot/session");
+
+    // 풀 플로우: 캐릭터 → 주제(종합) → 스프레드(원카드) → 세션 카드 선택 단계
+    await page.goto("/tarot");
+    const characterCards = page.locator("button").filter({ hasText: /아르카나|미코|선화/ });
+    await expect(characterCards.first()).toBeVisible({ timeout: 10_000 });
+    await characterCards.first().click();
+
+    await expect(page.locator("[data-testid='topic-btn-general']")).toBeVisible({ timeout: 5_000 });
+    await page.locator("[data-testid='topic-btn-general']").click();
+
+    const spreadBtn = page.locator("[data-testid='spread-btn-one-card']");
+    await expect(spreadBtn).toBeVisible({ timeout: 5_000 });
+    await spreadBtn.evaluate((el) => (el as HTMLElement).click());
+    await page.waitForURL("**/tarot/session**", { timeout: 10_000 });
+
+    // 카드 스프레드 단계의 '뒤로' → 이전 단계(스프레드 선택)로 복귀 (상담사 선택 아님)
+    const backBtn = page.getByRole("button", { name: /스프레드 다시 선택/ });
+    await expect(backBtn).toBeVisible({ timeout: 10_000 });
+    await backBtn.click();
+
+    // 스프레드 선택 단계로 복귀 — 주제 유지(general 스프레드 노출), topic-select·character-select 아님
+    await page.waitForURL(/\/tarot\?.*step=spread/, { timeout: 5_000 });
+    await expect(page.locator("[data-testid='spread-btn-one-card']")).toBeVisible({ timeout: 5_000 });
+    await expect(page.locator("[data-testid='topic-btn-general']")).toHaveCount(0);
+  });
+
   test("카드 선택 중 중복/초과 클릭을 반복해도 리딩은 한 번만 시작된다", async ({ page }) => {
     await page.emulateMedia({ reducedMotion: "reduce" });
     await mockSessionCreate(page, "**/api/tarot/session");

--- a/src/app/tarot/page.tsx
+++ b/src/app/tarot/page.tsx
@@ -242,11 +242,18 @@ function TarotPageContent() {
   const preselectedCharId = searchParams.get("character");
   const preselectedChar = preselectedCharId ? getCharacterById(preselectedCharId) ?? null : null;
 
-  const [step, setStep] = useState<PageStep>(() => preselectedChar ? "topic-select" : "character-select");
+  // 세션(카드 스프레드)에서 '뒤로'로 복귀한 경우: ?step=spread + 스토어에 보존된 주제로 스프레드 선택 단계 재개
+  const sessionSnapshot = useSessionStore.getState();
+  const isResumeSpread = searchParams.get("step") === "spread" && !!preselectedChar && !!sessionSnapshot.topic;
+
+  const [step, setStep] = useState<PageStep>(() => {
+    if (isResumeSpread) return "spread-select";
+    return preselectedChar ? "topic-select" : "character-select";
+  });
   const [selectedCharacter, setSelectedCharacter] = useState<CharacterConfig | null>(() => preselectedChar);
-  const [selectedTopic, setSelectedTopic] = useState<Topic | null>(null);
+  const [selectedTopic, setSelectedTopic] = useState<Topic | null>(() => (isResumeSpread ? sessionSnapshot.topic : null));
   const [dialogueMessages, setDialogueMessages] = useState<ChatMessage[]>([]);
-  const [localFreeQuestion, setLocalFreeQuestion] = useState("");
+  const [localFreeQuestion, setLocalFreeQuestion] = useState(() => (isResumeSpread ? sessionSnapshot.freeQuestion ?? "" : ""));
 
   // 프리셀렉트 + 즐겨찾기 fallback: 캐릭터 선택 시 스토어 반영 + 인사 메시지 생성 + 스텝 전환
   usePreselectCharacter({
@@ -255,7 +262,7 @@ function TarotPageContent() {
       setSelectedCharacter(character);
       setCharacterId(character.id);
       setDialogueMessages([{ id: crypto.randomUUID(), role: "character", content: getCharacterGreeting(character, useLocaleStore.getState().locale), mood: "smile", timestamp: new Date() }]);
-      setStep("topic-select");
+      setStep(isResumeSpread ? "spread-select" : "topic-select");
     },
   });
 

--- a/src/app/tarot/session/page.tsx
+++ b/src/app/tarot/session/page.tsx
@@ -297,6 +297,28 @@ export default function TarotSessionPage() {
     setMood("default");
   }, [addChatMessage, setMood, locale]);
 
+  /** 카드 스프레드 단계에서 '뒤로' → 진행 상태만 비우고 스프레드 선택 단계로 복귀 (캐릭터/주제/스프레드 유지) */
+  const handleBackToSpread = useCallback(() => {
+    readingAbortRef.current?.abort();
+    if (autoStartTimerRef.current) {
+      clearTimeout(autoStartTimerRef.current);
+      autoStartTimerRef.current = null;
+    }
+    const cid = useSessionStore.getState().characterId;
+    // 진행 상태만 초기화 — characterId/topic/spreadType/userInfo/freeQuestion은 보존
+    useSessionStore.setState({
+      selectedCards: [],
+      chatMessages: [],
+      readingResult: null,
+      sessionId: null,
+      availableCards: [],
+      isLoading: false,
+    });
+    useCardAnimationStore.getState().reset();
+    router.push(cid ? `/tarot?character=${cid}&step=spread` : "/tarot");
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [router]); // NOSONAR — ref/store 접근은 stable
+
   // 결과 스트리밍 시 컨테이너 내부만 하단 스크롤 (윈도우 스크롤 방지)
   useEffect(() => {
     if (phase === "result") {
@@ -367,11 +389,11 @@ export default function TarotSessionPage() {
           {phase === "card-select" && (
             <div className="flex items-center justify-between mb-2">
               <button
-                onClick={() => { useSessionStore.getState().reset(); useCardAnimationStore.getState().reset(); router.push("/tarot"); }}
+                onClick={handleBackToSpread}
                 className="text-arcana-muted text-xs hover:text-arcana-purple transition-colors"
                 type="button"
               >
-                {t("tarot.session.btn.back-to-character")}
+                {t("tarot.session.btn.back-to-spread")}
               </button>
               <button
                 onClick={toggleConfirmMode}

--- a/src/i18n/translations/en/index.ts
+++ b/src/i18n/translations/en/index.ts
@@ -195,7 +195,7 @@ export const en: Partial<SharedKeys> = {
     "session.btn.try-again": "Try again",
     "session.btn.new-session": "New session",
     "session.btn.share": "Share result",
-    "session.btn.back-to-character": "← Choose another reader",
+    "session.btn.back-to-spread": "← Choose a different spread",
     "session.error.reading": "Something went wrong with the reading",
     "session.shuffle.fallback-text": "Choose your cards",
     "session.shuffle.skip-aria": "Skip card shuffle ceremony",

--- a/src/i18n/translations/ja/index.ts
+++ b/src/i18n/translations/ja/index.ts
@@ -197,7 +197,7 @@ export const ja: Partial<SharedKeys> = {
     "session.btn.try-again": "再試行",
     "session.btn.new-session": "新しい相談",
     "session.btn.share": "結果を共有",
-    "session.btn.back-to-character": "← 占い師を選び直す",
+    "session.btn.back-to-spread": "← スプレッドを選び直す",
     "session.error.reading": "解釈に問題が発生しました",
     "session.shuffle.fallback-text": "カードを選んでください",
     "session.shuffle.skip-aria": "カードシャッフル儀式をスキップ",

--- a/src/i18n/translations/ko/index.ts
+++ b/src/i18n/translations/ko/index.ts
@@ -190,7 +190,7 @@ export const ko: SharedKeys = {
     "session.btn.try-again": "다시 시도",
     "session.btn.new-session": "새로운 상담",
     "session.btn.share": "결과 공유하기",
-    "session.btn.back-to-character": "← 상담사 다시 선택",
+    "session.btn.back-to-spread": "← 스프레드 다시 선택",
     "session.error.reading": "해석에 문제가 발생했어요",
     "session.shuffle.fallback-text": "카드를 선택하세요",
     "session.shuffle.skip-aria": "카드 셔플 의식 스킵",

--- a/src/i18n/translations/shared/keys.ts
+++ b/src/i18n/translations/shared/keys.ts
@@ -199,7 +199,7 @@ export interface SharedKeys {
     "session.btn.try-again": string;
     "session.btn.new-session": string;
     "session.btn.share": string;
-    "session.btn.back-to-character": string;
+    "session.btn.back-to-spread": string;
     "session.error.reading": string;
     "session.shuffle.fallback-text": string;
     "session.shuffle.skip-aria": string;


### PR DESCRIPTION
## 배경 (WHY)

타로 세션의 **카드 스프레드(card-select) 단계**에서 상단 '뒤로' 버튼을 누르면, 세션이 **전체 초기화**되며 `/tarot`의 첫 단계인 **상담사 선택** 화면으로 돌아갔습니다. 사용자는 바로 이전 단계(스프레드 선택)로 돌아가길 기대하므로 불편했습니다.

## 변경 내용 (WHAT)

| 영역 | 변경 |
|---|---|
| 세션 페이지 ([session/page.tsx](../blob/fix/tarot-back-to-spread/src/app/tarot/session/page.tsx)) | 뒤로 버튼이 진행 상태(선택 카드·대화·결과·sessionId)만 비우고 **캐릭터·주제·스프레드·자유질문은 보존**한 채 `/tarot?character=<id>&step=spread` 로 이동. 라벨 `← 상담사 다시 선택` → `← 스프레드 다시 선택` |
| 타로 페이지 ([page.tsx](../blob/fix/tarot-back-to-spread/src/app/tarot/page.tsx)) | `?step=spread` + 보존된 주제가 있으면 **스프레드 선택 단계로 바로 복귀**(주제·자유질문 복원). 정상 진입 플로우는 영향 없음 |
| i18n | 이 버튼 전용 키 `session.btn.back-to-character` → `back-to-spread` (ko/en/ja + 타입) |
| e2e | 카드 스프레드 → 스프레드 선택 복귀 회귀 테스트 추가 |

## 검증

- **실제 브라우저(Playwright)로 전체 플로우 확인**: 상담사→주제(종합)→3카드→세션에서 뒤로 클릭 → `/tarot?character=arcana&step=spread`, 스프레드 선택 화면, 주제·자유질문 보존, 상담사 카드 없음. 스프레드 재선택 시 세션 깨끗하게 재진입.
- 추가 E2E 회귀 테스트 통과.
- `pnpm type-check` / `pnpm lint`(0 error) / `pnpm i18n:check` / `pnpm check:doc-links` / `pnpm check:env-docs` 통과.
- `pnpm test:coverage` 937/939 통과. 미통과 2건은 saju/shinjeom API의 **load-induced 5s 타임아웃 flaky**로, 격리 재실행 시 정상 통과 — 본 변경(타로 전용)과 무관. 변경 파일은 모두 커버리지 제외 경로(`src/app/**`)·i18n 데이터.

🤖 Generated with [Claude Code](https://claude.com/claude-code)