### PR TITLE
docs: 레이아웃 Route Group 분리(PR #426) 문서 반영

### DIFF
--- a/docs/architecture/ai-infrastructure.md
+++ b/docs/architecture/ai-infrastructure.md
@@ -193,7 +193,7 @@ finished = true;
 clearTimeout(timer);
 ```
 
-재시도 UI: `data-testid="reading-retry"` 버튼이 표시되어 사용자가 재시도 가능. 적용 라우트: `src/app/tarot/session/page.tsx`, `src/app/saju/session/page.tsx`.
+재시도 UI: `data-testid="reading-retry"` 버튼이 표시되어 사용자가 재시도 가능. 적용 라우트: `src/app/(immersive)/tarot/session/page.tsx`, `src/app/(immersive)/saju/session/page.tsx`.
 
 ---
 

--- a/docs/architecture/system-overview.md
+++ b/docs/architecture/system-overview.md
@@ -9,6 +9,10 @@ ArcanaInsight의 3개 운세 서비스(타로·사주·신점) 사용자 흐름 
 ```
 사용자 브라우저
   └─ Next.js App Router (src/app/)
+       │  RootLayout(src/app/layout.tsx) = html/body·Provider·Header·전역 오버레이만
+       │  ├─ (immersive)/  — 타로·사주·신점 진입/세션, character/[id]. Footer 미렌더(이중 스크롤 방지)
+       │  └─ (site)/       — 홈, */result/[id], 마이페이지, 설정, 약관/개인정보, auth, dev. Footer 렌더
+       │  (괄호 그룹은 URL 불변. api/·error·not-found·globals.css·layout.tsx는 app 루트 유지)
        ├─ UI 레이어 (src/components/)
        │    ├─ card/         — CardFace, CardBack, CardItem, CardDeck, CardSpread, CardStyleSelector
        │    ├─ character/    — 캐릭터 등장 컴포넌트
@@ -124,7 +128,7 @@ ArcanaInsight의 3개 운세 서비스(타로·사주·신점) 사용자 흐름 
 
 ## 4. 타로 스프레드 × 주제 노출 규칙
 
-`src/app/tarot/page.tsx`의 `topicSpreads`에서 주제별로 노출할 스프레드를 제한합니다:
+`src/app/(immersive)/tarot/page.tsx`의 `topicSpreads`에서 주제별로 노출할 스프레드를 제한합니다:
 
 | 주제 | 노출 스프레드 |
 |------|-------------|
@@ -150,7 +154,7 @@ ArcanaInsight의 3개 운세 서비스(타로·사주·신점) 사용자 흐름 
 
 ---
 
-## 6. 홈 페이지 구성 (`src/app/page.tsx`)
+## 6. 홈 페이지 구성 (`src/app/(site)/page.tsx`)
 
 7개 섹션을 순서대로 조합:
 

--- a/docs/conventions/cross-platform.md
+++ b/docs/conventions/cross-platform.md
@@ -76,7 +76,23 @@ button, a, input { touch-action: manipulation; }   /* 더블탭 줌 방지 */
 
 ---
 
-## 6. 폼 입력 (iOS 대응)
+## 6. 레이아웃 그룹 — 몰입형 vs 사이트 (이중 스크롤 방지)
+
+App Router Route Group으로 렌더 라우트를 두 레이아웃으로 분리합니다 (괄호 그룹은 URL에 영향 없음).
+
+| 그룹 | 레이아웃 파일 | Footer | 대상 라우트 |
+|------|-------------|--------|-----------|
+| **(immersive)** | `src/app/(immersive)/layout.tsx` | **미렌더** | 타로·사주·신점 진입/세션 페이지, `character/[id]` |
+| **(site)** | `src/app/(site)/layout.tsx` | 렌더 | 홈, `*/result/[id]`, 마이페이지, 설정, 약관·개인정보, auth, dev |
+
+- **RootLayout**(`src/app/layout.tsx`)은 `html`/`body`·Provider·`Header`·전역 오버레이(ToastHost, LocaleConfirmModal, InteractionClickParticles)만 렌더한다. `main`/`Footer`/`MobileNav` 소유권은 그룹 레이아웃에 있다.
+- **이중 스크롤 금지**: `100dvh` 몰입형 스테이지 아래로 Footer가 붙으면 document가 추가로 스크롤되는 '이중 스크롤'이 발생한다. 몰입형 그룹은 **Footer를 렌더하지 않아** 구조적으로 이를 차단한다. 새 몰입형 페이지는 반드시 `(immersive)/` 그룹에 둔다.
+- 몰입형 `main`은 `pt-14 pb-14 md:pb-0`(Header·MobileNav 높이 보정) + `MobileNav`를 유지한다.
+- 모바일 고정 오버레이가 대사창(z-30)을 가리지 않도록 `z-40`/`bottom-36` 이상으로 배치한다 (예: `ReadingProgressIndicator`).
+
+---
+
+## 7. 폼 입력 (iOS 대응)
 
 | 요소 | 규칙 |
 |------|------|
@@ -86,7 +102,7 @@ button, a, input { touch-action: manipulation; }   /* 더블탭 줌 방지 */
 
 ---
 
-## 7. 검증 (E2E)
+## 8. 검증 (E2E)
 
 크로스 플랫폼 규칙 위반은 `e2e/cross-platform.spec.ts`에서 자동 감지됩니다:
 - 콘솔 에러 (pageerror)

--- a/docs/workflow/e2e-testing.md
+++ b/docs/workflow/e2e-testing.md
@@ -501,7 +501,7 @@ UI 텍스트가 i18n으로 변경되므로 한글 `hasText` regex 셀렉터 금�
 - LanguageSwitcher: `lang-option-${l}`, `mobile-lang-option-${l}`
 - LocaleConfirmModal: `locale-confirm-modal`, `locale-confirm-keep`, `locale-confirm-accept`
 - Toast: `toast`
-- 타로 플로우: `topic-btn-${topic}`, `spread-btn-${spread}`, `topic-back-btn` (`src/app/tarot/page.tsx`)
+- 타로 플로우: `topic-btn-${topic}`, `spread-btn-${spread}`, `topic-back-btn` (`src/app/(immersive)/tarot/page.tsx`)
 - 재시도 버튼: `reading-retry` (타로·사주 세션 페이지 타임아웃/에러 시)
 
 PR-6에서 locale 매트릭스 (165 test × 3 locale = 495 실행) 도입 예정. 상세: [`../conventions/i18n-style.md`](../conventions/i18n-style.md)


### PR DESCRIPTION
PR #426(모바일 몰입형 이중 스크롤 + 카드리딩 대기 UI 수정, 레이아웃 Route Group 분리) 머지에 따른 포스트 머지 문서 동기화.

## 변경
- **architecture/system-overview.md** — 레이어 다이어그램에 `(immersive)`/`(site)` 그룹 분기 주석 추가, 타로/홈 페이지 경로를 그룹 경로로 갱신
- **conventions/cross-platform.md** — "레이아웃 그룹 — 몰입형 vs 사이트(이중 스크롤 방지)" 섹션 신설(그룹 표 · RootLayout 소유권 · Footer 미렌더 규칙 · z-40 오버레이), 후속 섹션 재번호
- **architecture/ai-infrastructure.md** — 재시도 UI 적용 라우트 경로를 `(immersive)/`로 갱신
- **workflow/e2e-testing.md** — 타로 플로우 testid 안내 경로를 `(immersive)/tarot/page.tsx`로 갱신

URL은 불변(괄호 그룹)이므로 `/tarot/session` 등 URL 참조는 그대로 유지. `pnpm check:doc-links` 통과(기존 PR-5 대기 경고만).

> 코드 변경 없음. 문서 정합성 동기화 전용. 전역 규칙(머지 후 전체 문서 최신화)에 따라 생성하되, main 브랜치 보호 규칙으로 직접 푸시 대신 PR로 진행.

🤖 Generated with [Claude Code](https://claude.com/claude-code)