### PR TITLE
fix(mypage): 익명 세션 로그인 시 자동 claim — 리딩 이력 미노출 수정

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,7 +36,7 @@ src/
 │   ├── card/        # CardFace, CardBack, CardItem, CardDeck, CardSpread, CardStyleSelector (스타일 선택 UI)
 │   ├── common/      # UserInfoForm (mode: "tarot"|"saju"|"shinjeom"), PageSpinner, BirthTimeInput,
 │   │                # ResultPageShell, ResultShareButton, ReadingText, Toast, Icon,
-│   │                # LocaleConfirmModal, PrivacyConsentModal
+│   │                # LocaleConfirmModal, PrivacyConsentModal, SessionClaimer (로그인 시 익명 세션 claim)
 │   ├── effects/     # ThemeEffectEngine, ThemeAtmosphereLayer, InteractionEffects,
 │   │                # ServiceBackground, ParticleOverlay, MysticBackground, ScrollReveal,
 │   │                # CanvasParticleLayer (particle-engine.ts 기반, density: low/medium/high, prefers-reduced-motion 지원),
@@ -62,7 +62,8 @@ src/
 ├── i18n/            # locale 감지, Provider, useT, translations
 ├── lib/             # env, auth, db, storage, validation, request/rate-limit 유틸
 │   ├── storage/card-style.ts  # getCardStyleImageUrl, getCardStyleBackUrl
-│   └── share-utils.ts         # shareWithUrl·shareWithText (3서비스 공통 공유 유틸)
+│   ├── share-utils.ts         # shareWithUrl·shareWithText (3서비스 공통 공유 유틸)
+│   └── guest-sessions.ts      # 익명 세션 id localStorage 보관 (로그인 시 claim 대상)
 ├── services/        # core AI provider/fallback + tarot/saju/shinjeom 서비스
 ├── styles/          # theme-effects.css — CSS variable 기반 5-레이어 이펙트 정의
 │                    # service-illustrations.css — 장면별 CSS 클래스 + 11개 keyframe (orbit-spin, spark-twinkle, ember-drift, mist-rise, crystal-pulse 등)
@@ -82,6 +83,7 @@ supabase/migrations/ # Supabase SQL migrations
 
 - AI 신뢰성: `src/services/core/`의 `FallbackProvider`가 Grok 우선 호출 후 Claude로 fallback. 상세는 [`docs/architecture/ai-infrastructure.md`](docs/architecture/ai-infrastructure.md).
 - DB/Auth 추상화: `DB_PROVIDER=supabase|postgres`에 따라 DB, Auth, Storage 구현을 런타임 분기. 상세는 [`docs/architecture/db-abstraction.md`](docs/architecture/db-abstraction.md), [`docs/architecture/auth-abstraction.md`](docs/architecture/auth-abstraction.md).
+- 익명 세션 claim (PR: 리딩 이력 미노출 수정): 게스트/만료 세션 상태에서 만든 세션은 `user_id=NULL`로 저장되어 로그인 mypage 이력(`findMany("sessions",{user_id})`)에서 누락된다. `rememberGuestSession`(`lib/guest-sessions.ts`)이 생성 시 sessionId를 localStorage에 보관 → `SessionClaimer`가 로그인 감지 시 `POST /api/sessions/claim` → `db.claimSessions`가 `UPDATE sessions SET user_id WHERE id IN(...) AND user_id IS NULL`로 귀속. 설계 정본 [`docs/superpowers/specs/2026-06-23-anon-session-claim-design.md`](docs/superpowers/specs/2026-06-23-anon-session-claim-design.md).
 - API 보안: Rate Limit -> Zod `safeParse` -> Auth -> 소유권 검증 순서. 새 API는 [`docs/conventions/zod-schemas.md`](docs/conventions/zod-schemas.md)를 먼저 확인.
 - SSE 스트리밍: 타로/사주/신점 리딩은 `SSE_HEADERS`, `fetchSSEStream()`, `AbortController` 패턴을 사용. 상세는 [`docs/architecture/ai-infrastructure.md`](docs/architecture/ai-infrastructure.md).
 - i18n: `middleware`가 locale을 결정하고 `x-locale` 헤더와 쿠키를 유지. 상세는 [`docs/architecture/i18n.md`](docs/architecture/i18n.md), [`docs/conventions/i18n-style.md`](docs/conventions/i18n-style.md).

--- a/docs/architecture/db-abstraction.md
+++ b/docs/architecture/db-abstraction.md
@@ -37,7 +37,7 @@ API Route
 ```
 src/lib/db/
 ├── index.ts                    # getDb() 팩토리
-├── types.ts                    # DbClient 공통 인터페이스 (findMany: limit/offset 옵션 포함)
+├── types.ts                    # DbClient 공통 인터페이스 (findMany limit/offset, claimSessions: 익명 세션 user_id 귀속)
 ├── supabase-adapter.ts         # Supabase 구현체
 ├── supabase-admin-adapter.ts   # service_role 기반 RLS 우회 어댑터 (Supabase 전용)
 ├── postgres-adapter.ts         # Drizzle ORM 구현체

--- a/docs/superpowers/specs/2026-06-23-anon-session-claim-design.md
+++ b/docs/superpowers/specs/2026-06-23-anon-session-claim-design.md
@@ -1,0 +1,96 @@
+# 익명 세션 로그인 시 자동 claim — 설계
+
+> 신고 버그: "로그인한 계정의 과거 타로 리딩 이력이 mypage에 미노출".
+> 진단(프로덕션 데이터 forensic): 리딩이 자주 익명(`user_id=NULL`)으로 저장되는데(전체 세션의 47%, 최근 활동은 대부분 익명), 로그인 후 이를 계정에 연결하는 claim 메커니즘이 전혀 없어(grep 0건) `.eq("user_id", uuid)` 필터에서 영구 누락. 데이터·RLS·쿼리 자체는 정상(완료 리딩 64건 전부 저장·가시 확인).
+
+## 목표
+
+게스트/만료 세션 상태에서 만든 익명 리딩 세션을, 사용자가 로그인하면 자동으로 그 계정에 연결해 mypage 이력에 노출한다. 기존 게스트 리딩 UX는 그대로 유지한다.
+
+## 비목표 (이번 범위 외)
+
+- parseError 시 리딩 영속화(B) — 데이터상 부차적, 별도 처리.
+- 로그인 게이트(리딩 전 로그인 강제) — 게스트 UX 보존 위해 채택 안 함.
+- fire-and-forget 저장 관측성(C).
+
+## 아키텍처
+
+```
+[세션 생성(tarot/saju/shinjeom session/page.tsx)]
+   └─ rememberGuestSession(id)  → localStorage "arcana_guest_sessions" (최근 30개 cap)
+
+[로그인 발생] onAuthStateChange(SIGNED_IN | INITIAL_SESSION)
+   └─ SessionClaimer(client, 루트 레이아웃) → pending id 존재 시
+        POST /api/sessions/claim { sessionIds }
+           └─ RateLimit → Zod → requireUser → getAdminDb().claimSessions(ids, userId)
+                 UPDATE sessions SET user_id=<me> WHERE id IN(ids) AND user_id IS NULL
+           ← { claimed: n }
+        → 성공 id를 localStorage에서 제거
+
+[다음 mypage 로드] findMany("sessions",{user_id}) → claim된 세션 노출
+```
+
+## 컴포넌트별 책임
+
+### 1. `src/lib/guest-sessions.ts` (신규, 클라이언트 유틸)
+- `rememberGuestSession(id: string): void` — localStorage 배열에 prepend, dedup, 최근 30개 cap. try/catch graceful(차단 환경 무동작).
+- `getGuestSessions(): string[]` — 저장된 id 배열.
+- `clearGuestSessions(ids: string[]): void` — 지정 id 제거(claim 성공분).
+- 항상 저장(인증 여부 무관) — claim의 `WHERE user_id IS NULL` 가드가 멱등 보장(이미 소유/타인 소유 세션은 no-op).
+
+### 2. `src/components/common/SessionClaimer.tsx` (신규, client)
+- `useEffect`에서 `createClient().auth.onAuthStateChange` 구독.
+- 인증된 상태(`session` 존재) + `getGuestSessions().length > 0` 일 때 1회 claim 호출(in-flight ref로 중복 방지).
+- `POST /api/sessions/claim` 성공 → `clearGuestSessions(claimedIds)`.
+- 실패 → localStorage 유지(다음 로그인에 재시도). 조용히 실패(콘솔 warn).
+- 루트 레이아웃(`src/app/layout.tsx`)의 Provider 내부에 마운트 → 어떤 경로에서 로그인해도 동작.
+
+### 3. `POST /api/sessions/claim` (`src/app/api/sessions/claim/route.ts`, 신규)
+- 보안 순서: `checkRateLimit("claim:"+ip, 20, 60_000)` → `ClaimSessionsSchema.safeParse` → `requireUser()`(401 throw) → `getAdminDb().claimSessions(parsed.sessionIds, user.id)`.
+- 응답: `{ claimed: number }`.
+- requireUser 실패(미인증) → 401. (claim은 로그인 필수)
+
+### 4. `ClaimSessionsSchema` (`src/lib/validation/api-schemas.ts`)
+- `z.object({ sessionIds: z.array(z.string().uuid()).min(1).max(100) })`.
+
+### 5. `DbClient.claimSessions` (`src/lib/db/types.ts` + 양쪽 어댑터)
+- 인터페이스: `claimSessions(sessionIds: string[], userId: string): Promise<number>` (claim된 행 수).
+- Supabase(`supabase-adapter.ts`): `.from("sessions").update({user_id:userId}).in("id",sessionIds).is("user_id",null).select("id")` → 길이 반환. (기존 `.eq` 루프는 `IS NULL`을 못 다뤄 전용 메서드 필요)
+- Postgres(`postgres-adapter.ts`): Drizzle `.update(sessions).set({userId}).where(and(inArray(sessions.id, sessionIds), isNull(sessions.userId))).returning({id})` → 길이.
+- `getAdminDb()`(supabase 모드 = service role)로 호출 → RLS 우회, `IS NULL` 가드가 소유권 보호.
+
+### 6. quick-win #5 — result rate-limit 키 분리
+- `tarot/saju/shinjeom result/[id]/route.ts`의 `result:${ip}` → `tarot-result:`/`saju-result:`/`shinjeom-result:` 로 서비스별 분리.
+
+## 데이터 흐름 / 멱등성
+
+- 항상-저장 + claim의 `IS NULL` 가드 = 멱등. 이미 소유·타인 소유 세션은 UPDATE 미적용(0건).
+- SessionClaimer는 pending id가 있을 때만 호출 → 반복 SIGNED_IN/refresh에도 안전.
+
+## 에러 처리
+
+- claim API 실패/네트워크 오류 → localStorage 유지, 다음 로그인 재시도. 사용자 흐름 비차단.
+- 빈 sessionIds → 클라이언트가 호출 안 함.
+- localStorage 차단 환경 → 유틸이 graceful no-op(claim 미동작, 기존 동작 유지).
+
+## 보안
+
+- claim은 호출자가 UUID를 아는 익명 세션만 자기 것으로 귀속. `WHERE user_id IS NULL` 가드로 타 사용자 소유 세션 탈취 불가. session_id는 UUID v4(추측 불가). 익명 세션엔 신원 결부 PII 없음 → 영향 낮음.
+- 보안 패턴(RateLimit→Zod→Auth) 준수. requireUser로 미인증 차단.
+
+## 테스트
+
+- `src/__tests__/api/sessions-claim.test.ts`: rate-limit 차단, Zod 거부(빈/비UUID/초과), requireUser 401, 정상 claim count, 멱등(이미 소유 0건).
+- 어댑터 `claimSessions` 단위 테스트(supabase mock — `.in`/`.is` 호출 검증).
+- `src/__tests__/lib/guest-sessions.test.ts`: 저장/조회/제거/cap/dedup/차단환경.
+- E2E: 실 Supabase 인증 세션 필요(claim은 로그인 전제) → 이번 자동화 보류, smart-ci 영역. 메모만.
+
+## DB_PROVIDER 분기
+
+- supabase 모드: getAdminDb()=service role. claimSessions가 RLS 우회.
+- postgres 모드: getAdminDb()=PostgresAdapter(RLS 없음), Drizzle로 동일 의미 구현. requireUser=NextAuth.
+
+## 영향 파일 요약
+
+신규: `src/lib/guest-sessions.ts`, `src/components/common/SessionClaimer.tsx`, `src/app/api/sessions/claim/route.ts`, 테스트 3종.
+수정: `src/lib/db/types.ts`, `src/lib/db/supabase-adapter.ts`, `src/lib/db/postgres-adapter.ts`, `src/lib/validation/api-schemas.ts`, `src/app/layout.tsx`(SessionClaimer 마운트), `src/app/(immersive)/{tarot,saju,shinjeom}/session/page.tsx`(rememberGuestSession 호출), `src/app/api/{tarot,saju,shinjeom}/result/[id]/route.ts`(rate-limit 키). sonar exclusions(신규 TS 파일) 동기화.

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -53,6 +53,7 @@ sonar.coverage.exclusions=\
   src/data/mbti.ts,\
   src/data/topics-meta.ts,\
   src/lib/share-utils.ts,\
+  src/lib/guest-sessions.ts,\
   src/lib/particle-engine.ts,\
   src/hooks/useTarotReading.ts,\
   src/hooks/useMouseParallax.ts,\
@@ -101,6 +102,8 @@ sonar.cpd.exclusions=\
   src/components/effects/CanvasParticleLayer.tsx,\
   src/components/common/BirthTimeInput.tsx,\
   src/components/common/PageSpinner.tsx,\
+  src/components/common/SessionClaimer.tsx,\
+  src/lib/guest-sessions.ts,\
   src/components/effects/ThemeEffectEngine.tsx,\
   src/components/effects/ThemeAtmosphereLayer.tsx,\
   src/components/effects/InteractionEffects.tsx,\

--- a/src/__tests__/api/sessions-claim.test.ts
+++ b/src/__tests__/api/sessions-claim.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi } from "vitest";
+import { setupDoMock } from "@/test-helpers/reset-modules";
+import { MOCK_USER, makeAuthMock } from "@/test-helpers/mock-auth";
+import { makeMockDb } from "@/test-helpers/mock-db";
+import { makePostRequest } from "@/test-helpers/mock-request";
+
+setupDoMock();
+
+const UUID_A = "11111111-1111-4111-8111-111111111111";
+const UUID_B = "22222222-2222-4222-8222-222222222222";
+
+async function setup(opts: { user?: typeof MOCK_USER | null; claimed?: number; rateLimit?: boolean } = {}) {
+  const mockDb = makeMockDb();
+  mockDb.claimSessions.mockResolvedValue(opts.claimed ?? 2);
+  const user = "user" in opts ? opts.user : MOCK_USER;
+
+  vi.doMock("@/lib/rate-limit", () => ({
+    checkRateLimit: vi.fn().mockResolvedValue(opts.rateLimit ?? true),
+    rateLimitResponse: vi.fn().mockReturnValue(
+      new Response(JSON.stringify({ error: "rate limited" }), { status: 429 })
+    ),
+  }));
+  vi.doMock("@/lib/db", () => ({
+    getDb: vi.fn().mockReturnValue(mockDb),
+    getAdminDb: vi.fn().mockReturnValue(mockDb),
+  }));
+  vi.doMock("@/lib/auth", () => makeAuthMock(user));
+
+  const route = await import("@/app/api/sessions/claim/route");
+  return { POST: route.POST as (req: Request) => Promise<Response>, mockDb };
+}
+
+describe("POST /api/sessions/claim", () => {
+  it("로그인 + 유효 sessionIds → claimed 수 반환", async () => {
+    const { POST, mockDb } = await setup({ claimed: 2 });
+    const res = await POST(makePostRequest({ sessionIds: [UUID_A, UUID_B] }));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ claimed: 2 });
+    expect(mockDb.claimSessions).toHaveBeenCalledWith([UUID_A, UUID_B], MOCK_USER.id);
+  });
+
+  it("비로그인 → 401, claim 미호출", async () => {
+    const { POST, mockDb } = await setup({ user: null });
+    const res = await POST(makePostRequest({ sessionIds: [UUID_A] }));
+    expect(res.status).toBe(401);
+    expect(mockDb.claimSessions).not.toHaveBeenCalled();
+  });
+
+  it("빈 sessionIds → 400", async () => {
+    const { POST } = await setup();
+    const res = await POST(makePostRequest({ sessionIds: [] }));
+    expect(res.status).toBe(400);
+  });
+
+  it("UUID가 아닌 값 → 400", async () => {
+    const { POST } = await setup();
+    const res = await POST(makePostRequest({ sessionIds: ["not-a-uuid"] }));
+    expect(res.status).toBe(400);
+  });
+
+  it("sessionIds 누락 → 400", async () => {
+    const { POST } = await setup();
+    const res = await POST(makePostRequest({}));
+    expect(res.status).toBe(400);
+  });
+
+  it("100개 초과 → 400", async () => {
+    const { POST } = await setup();
+    const tooMany = Array.from({ length: 101 }, () => UUID_A);
+    const res = await POST(makePostRequest({ sessionIds: tooMany }));
+    expect(res.status).toBe(400);
+  });
+
+  it("rate limit 초과 → 429", async () => {
+    const { POST, mockDb } = await setup({ rateLimit: false });
+    const res = await POST(makePostRequest({ sessionIds: [UUID_A] }));
+    expect(res.status).toBe(429);
+    expect(mockDb.claimSessions).not.toHaveBeenCalled();
+  });
+
+  it("claimSessions 예외 → 500", async () => {
+    const { POST, mockDb } = await setup();
+    mockDb.claimSessions.mockRejectedValue(new Error("DB error"));
+    const res = await POST(makePostRequest({ sessionIds: [UUID_A] }));
+    expect(res.status).toBe(500);
+  });
+
+  it("claim 0건도 정상 200 (멱등 — 이미 소유/타인 소유)", async () => {
+    const { POST } = await setup({ claimed: 0 });
+    const res = await POST(makePostRequest({ sessionIds: [UUID_A] }));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ claimed: 0 });
+  });
+});

--- a/src/__tests__/lib/guest-sessions.test.ts
+++ b/src/__tests__/lib/guest-sessions.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { rememberGuestSession, getGuestSessions, clearGuestSessions } from "@/lib/guest-sessions";
+
+function installMemoryStorage() {
+  const store = new Map<string, string>();
+  Object.defineProperty(globalThis, "localStorage", {
+    configurable: true,
+    value: {
+      getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
+      setItem: (k: string, v: string) => { store.set(k, v); },
+      removeItem: (k: string) => { store.delete(k); },
+      clear: () => store.clear(),
+      key: () => null,
+      get length() { return store.size; },
+    } as Storage,
+  });
+  return store;
+}
+
+describe("guest-sessions", () => {
+  beforeEach(() => {
+    installMemoryStorage();
+  });
+
+  it("세션 id를 저장하고 조회한다", () => {
+    rememberGuestSession("a");
+    rememberGuestSession("b");
+    expect(getGuestSessions()).toEqual(["b", "a"]); // 최신이 앞
+  });
+
+  it("빈 id는 무시한다", () => {
+    rememberGuestSession("");
+    expect(getGuestSessions()).toEqual([]);
+  });
+
+  it("중복 id는 한 번만, 최신으로 끌어올린다", () => {
+    rememberGuestSession("a");
+    rememberGuestSession("b");
+    rememberGuestSession("a");
+    expect(getGuestSessions()).toEqual(["a", "b"]);
+  });
+
+  it("최대 30개로 제한한다(cap)", () => {
+    for (let i = 0; i < 35; i++) rememberGuestSession(`id-${i}`);
+    const ids = getGuestSessions();
+    expect(ids).toHaveLength(30);
+    expect(ids[0]).toBe("id-34"); // 최신
+    expect(ids).not.toContain("id-0"); // 오래된 것은 밀려남
+  });
+
+  it("지정 id를 제거한다", () => {
+    rememberGuestSession("a");
+    rememberGuestSession("b");
+    rememberGuestSession("c");
+    clearGuestSessions(["a", "c"]);
+    expect(getGuestSessions()).toEqual(["b"]);
+  });
+
+  it("전부 제거되면 키를 삭제한다", () => {
+    rememberGuestSession("a");
+    clearGuestSessions(["a"]);
+    expect(getGuestSessions()).toEqual([]);
+  });
+
+  it("빈 배열 clear는 무동작", () => {
+    rememberGuestSession("a");
+    clearGuestSessions([]);
+    expect(getGuestSessions()).toEqual(["a"]);
+  });
+
+  it("손상된 JSON은 빈 배열로 처리한다", () => {
+    localStorage.setItem("arcana_guest_sessions", "{not json");
+    expect(getGuestSessions()).toEqual([]);
+  });
+
+  it("배열이 아닌 값은 빈 배열로 처리한다", () => {
+    localStorage.setItem("arcana_guest_sessions", JSON.stringify({ x: 1 }));
+    expect(getGuestSessions()).toEqual([]);
+  });
+
+  it("localStorage 차단 환경에서도 throw하지 않는다", () => {
+    Object.defineProperty(globalThis, "localStorage", {
+      configurable: true,
+      value: {
+        getItem: vi.fn(() => { throw new Error("blocked"); }),
+        setItem: vi.fn(() => { throw new Error("blocked"); }),
+        removeItem: vi.fn(() => { throw new Error("blocked"); }),
+      } as unknown as Storage,
+    });
+    expect(() => rememberGuestSession("a")).not.toThrow();
+    expect(getGuestSessions()).toEqual([]);
+    expect(() => clearGuestSessions(["a"])).not.toThrow();
+  });
+});

--- a/src/app/(immersive)/saju/session/page.tsx
+++ b/src/app/(immersive)/saju/session/page.tsx
@@ -32,6 +32,7 @@ import type { Locale } from "@/i18n/config";
 import { useThemeStore } from "@/hooks/useTheme";
 import { getServiceBackgroundUrl } from "@/lib/storage/card-style";
 import { ServiceIllustrations } from "@/components/effects/ServiceIllustrations";
+import { rememberGuestSession } from "@/lib/guest-sessions";
 
 const SITE_NAME = "ArcanaInsight";
 
@@ -94,7 +95,7 @@ export default function SajuSessionPage() {
     }).then(async (res) => {
       if (!res.ok) return;
       const data = await res.json();
-      if (data.session?.id) setSessionId(data.session.id);
+      if (data.session?.id) { setSessionId(data.session.id); rememberGuestSession(data.session.id); }
     }).catch((e) => console.warn("사주 세션 생성 실패 (리딩은 계속 진행):", e));
 
     setMood("default");

--- a/src/app/(immersive)/shinjeom/session/page.tsx
+++ b/src/app/(immersive)/shinjeom/session/page.tsx
@@ -26,6 +26,7 @@ import { useThemeStore } from "@/hooks/useTheme";
 import { getServiceBackgroundUrl } from "@/lib/storage/card-style";
 import { ShinjeomEnergyEffect } from "@/components/shinjeom/ShinjeomEnergyEffect";
 import { ServiceIllustrations } from "@/components/effects/ServiceIllustrations";
+import { rememberGuestSession } from "@/lib/guest-sessions";
 
 const SITE_NAME = "ArcanaInsight";
 
@@ -99,7 +100,7 @@ export default function ShinjeomSessionPage() {
           body: JSON.stringify({ topic, characterId }),
         });
         const data = await res.json();
-        if (data.session?.id) setSessionId(data.session.id);
+        if (data.session?.id) { setSessionId(data.session.id); rememberGuestSession(data.session.id); }
       } catch (e) { console.warn("신점 세션 생성 실패 (상담은 계속 진행):", e); }
     };
     initSession();

--- a/src/app/(immersive)/tarot/session/page.tsx
+++ b/src/app/(immersive)/tarot/session/page.tsx
@@ -43,6 +43,7 @@ import { shareWithUrl, shareWithText } from "@/lib/share-utils";
 import { useReadingRevealStore } from "@/hooks/useReadingReveal";
 import { useTarotReading } from "@/hooks/useTarotReading";
 import { ServiceIllustrations } from "@/components/effects/ServiceIllustrations";
+import { rememberGuestSession } from "@/lib/guest-sessions";
 
 
 const deckManager = new DeckManager();
@@ -155,7 +156,7 @@ export default function TarotSessionPage() {
         });
         if (!res.ok) throw new Error(`세션 생성 실패: ${res.status}`);
         const data = await res.json();
-        if (data.session?.id) setSessionId(data.session.id);
+        if (data.session?.id) { setSessionId(data.session.id); rememberGuestSession(data.session.id); }
       } catch (err) {
         console.warn("세션 생성 실패 (리딩은 계속 진행):", err);
       }

--- a/src/app/api/CLAUDE.md
+++ b/src/app/api/CLAUDE.md
@@ -23,6 +23,8 @@ api/
 ├── daily-card/route.ts
 ├── daily-fortune/route.ts
 ├── locale/route.ts
+├── sessions/
+│   └── claim/route.ts    # 익명 세션 user_id 귀속 (POST, 로그인 필수)
 └── profile/
     └── favorite-character/route.ts
 ```

--- a/src/app/api/saju/result/[id]/route.ts
+++ b/src/app/api/saju/result/[id]/route.ts
@@ -19,7 +19,7 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
     const reqLocale = await getRequestLocale()
     if (isLocale(reqLocale)) locale = reqLocale
     const ip = getClientIp(request.headers)
-    if (!(await checkRateLimit(`result:${ip}`, 60, 60_000))) return rateLimitResponse(locale)
+    if (!(await checkRateLimit(`saju-result:${ip}`, 60, 60_000))) return rateLimitResponse(locale)
 
     const { id } = await params
     const db = getAdminDb()

--- a/src/app/api/sessions/claim/route.ts
+++ b/src/app/api/sessions/claim/route.ts
@@ -1,0 +1,33 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getAdminDb } from "@/lib/db";
+import { getCurrentUser } from "@/lib/auth";
+import { ClaimSessionsSchema } from "@/lib/validation/api-schemas";
+import { checkRateLimit, rateLimitResponse } from "@/lib/rate-limit";
+import { getClientIp } from "@/lib/request-utils";
+import { getRequestLocale } from "@/i18n/server-locale";
+
+/**
+ * 익명 세션(user_id IS NULL)을 현재 로그인 사용자에게 귀속(claim)한다.
+ * 게스트/만료 세션 상태에서 만든 리딩을 로그인 후 mypage 이력에 노출하기 위함.
+ * 보안 순서: Rate Limit → Zod → Auth(로그인 필수) → claim(`WHERE user_id IS NULL` 가드).
+ */
+export async function POST(request: NextRequest) {
+  try {
+    const locale = await getRequestLocale();
+    const ip = getClientIp(request.headers);
+    if (!(await checkRateLimit(`claim:${ip}`, 20, 60_000))) return rateLimitResponse(locale);
+
+    const parsed = ClaimSessionsSchema.safeParse(await request.json());
+    if (!parsed.success) return NextResponse.json({ error: "Invalid request" }, { status: 400 });
+
+    const user = await getCurrentUser();
+    if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+    const db = getAdminDb();
+    const claimed = await db.claimSessions(parsed.data.sessionIds, user.id);
+    return NextResponse.json({ claimed });
+  } catch (e) {
+    console.error("세션 claim 오류:", e instanceof Error ? e.message : String(e));
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/src/app/api/shinjeom/result/[id]/route.ts
+++ b/src/app/api/shinjeom/result/[id]/route.ts
@@ -13,7 +13,7 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
     const reqLocale = await getRequestLocale()
     if (isLocale(reqLocale)) locale = reqLocale
     const ip = getClientIp(request.headers)
-    if (!(await checkRateLimit(`result:${ip}`, 60, 60_000))) return rateLimitResponse(locale)
+    if (!(await checkRateLimit(`shinjeom-result:${ip}`, 60, 60_000))) return rateLimitResponse(locale)
 
     const { id } = await params
     const db = getAdminDb()

--- a/src/app/api/tarot/result/[id]/route.ts
+++ b/src/app/api/tarot/result/[id]/route.ts
@@ -13,7 +13,7 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
     const reqLocale = await getRequestLocale()
     if (isLocale(reqLocale)) locale = reqLocale
     const ip = getClientIp(request.headers)
-    if (!(await checkRateLimit(`result:${ip}`, 60, 60_000))) return rateLimitResponse(locale)
+    if (!(await checkRateLimit(`tarot-result:${ip}`, 60, 60_000))) return rateLimitResponse(locale)
 
     const { id } = await params
     const db = getAdminDb()

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -10,6 +10,7 @@ import { DEFAULT_LOCALE, LOCALE_COOKIE, isLocale, type Locale } from "@/i18n/con
 import { t as translate } from "@/i18n/translations";
 import { ToastHost } from "@/components/common/Toast";
 import { LocaleConfirmModal } from "@/components/common/LocaleConfirmModal";
+import { SessionClaimer } from "@/components/common/SessionClaimer";
 import { InteractionClickParticles } from "@/components/effects/InteractionEffects";
 
 export const viewport: Viewport = {
@@ -79,6 +80,7 @@ export default async function RootLayout({
             {children}
             <ToastHost />
             <LocaleConfirmModal />
+            <SessionClaimer />
             <InteractionClickParticles />
           </ThemeProvider>
         </LocaleProvider>

--- a/src/components/common/SessionClaimer.tsx
+++ b/src/components/common/SessionClaimer.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { createClient } from "@/lib/supabase/client";
+import { getGuestSessions, clearGuestSessions } from "@/lib/guest-sessions";
+
+/**
+ * 로그인 시 클라이언트에 보관된 익명 sessionId를 서버로 보내 계정에 연결(claim)한다.
+ * 게스트/만료 세션 상태에서 만든 리딩이 로그인 후 mypage 이력에 노출되도록 복구한다.
+ *
+ * Supabase auth 상태 변화(INITIAL_SESSION: 이미 로그인 / SIGNED_IN: 방금 로그인)에서
+ * 세션이 존재하고 보관된 익명 id가 있을 때만 1회 claim 호출(in-flight 가드).
+ * 실패 시 localStorage를 유지해 다음 로그인에 재시도한다.
+ * (DB_PROVIDER=postgres 모드는 Supabase auth 이벤트가 없어 동작하지 않음 — 기본 supabase 모드 전용.)
+ */
+export function SessionClaimer() {
+  const inFlightRef = useRef(false);
+
+  useEffect(() => {
+    const supabase = createClient();
+
+    const claim = async () => {
+      if (inFlightRef.current) return;
+      const ids = getGuestSessions();
+      if (ids.length === 0) return;
+      inFlightRef.current = true;
+      try {
+        const res = await fetch("/api/sessions/claim", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ sessionIds: ids }),
+        });
+        if (res.ok) clearGuestSessions(ids);
+      } catch {
+        // 네트워크 실패 — localStorage 유지, 다음 로그인 재시도
+      } finally {
+        inFlightRef.current = false;
+      }
+    };
+
+    const { data: { subscription } } = supabase.auth.onAuthStateChange((event, session) => {
+      if (session?.user && (event === "SIGNED_IN" || event === "INITIAL_SESSION")) {
+        void claim();
+      }
+    });
+
+    return () => subscription.unsubscribe();
+  }, []);
+
+  return null;
+}

--- a/src/lib/db/postgres-adapter.test.ts
+++ b/src/lib/db/postgres-adapter.test.ts
@@ -249,4 +249,19 @@ describe("PostgresAdapter", () => {
       ).rejects.toThrow("Upsert failed for table: daily_cards");
     });
   });
+
+  // ── claimSessions ──────────────────────────────────────────────────────────
+  describe("claimSessions", () => {
+    it("빈 배열이면 0 반환 + update 미호출", async () => {
+      const adapter = new PostgresAdapter();
+      expect(await adapter.claimSessions([], "u-1")).toBe(0);
+      expect(mockDb.update).not.toHaveBeenCalled();
+    });
+
+    it("claim된 행 수를 반환한다", async () => {
+      mockUpdateWith([{ id: "a" }, { id: "b" }]);
+      const adapter = new PostgresAdapter();
+      expect(await adapter.claimSessions(["a", "b", "c"], "u-1")).toBe(2);
+    });
+  });
 });

--- a/src/lib/db/postgres-adapter.ts
+++ b/src/lib/db/postgres-adapter.ts
@@ -1,6 +1,6 @@
 import { drizzle } from "drizzle-orm/postgres-js"
 import postgres from "postgres"
-import { eq, and, inArray, getTableColumns, asc, desc } from "drizzle-orm"
+import { eq, and, inArray, isNull, getTableColumns, asc, desc } from "drizzle-orm"
 import type { PgTable, PgColumn } from "drizzle-orm/pg-core"
 import type { ColumnBaseConfig, ColumnDataType } from "drizzle-orm"
 import * as schema from "./schema/index"
@@ -155,5 +155,22 @@ export class PostgresAdapter implements DbClient {
       .returning()
     if (!result[0]) throw new Error(`Upsert failed for table: ${table}`)
     return normalizeRow<T>(result[0] as Record<string, unknown>)
+  }
+
+  async claimSessions(sessionIds: string[], userId: string): Promise<number> {
+    if (sessionIds.length === 0) return 0
+    const db = getConnection()
+    const t = resolveTable("sessions")
+    const cols = getTableColumns(t)
+    const idCol = cols["id"]
+    const userCol = cols["userId"] ?? cols["user_id"]
+    if (!idCol || !userCol) throw new Error("Unknown column: sessions.id/user_id")
+    const result = await db
+      .update(t)
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      .set({ userId } as any)
+      .where(and(inArray(idCol, sessionIds), isNull(userCol)))
+      .returning({ id: idCol })
+    return (result as unknown[]).length
   }
 }

--- a/src/lib/db/supabase-adapter.test.ts
+++ b/src/lib/db/supabase-adapter.test.ts
@@ -306,4 +306,52 @@ describe("SupabaseAdapter", () => {
       await expect(adapter.upsert("daily_cards", {}, "date")).rejects.toThrow("upsert failed");
     });
   });
+
+  // ─── claimSessions ──────────────────────────────────────────────────────────
+  describe("claimSessions", () => {
+    function makeClaimChain(result: { data?: unknown; error?: { code?: string; message: string } | null }) {
+      const outcome = { data: result.data ?? null, error: result.error ?? null };
+      return {
+        update: vi.fn().mockReturnThis(),
+        in: vi.fn().mockReturnThis(),
+        is: vi.fn().mockReturnThis(),
+        select: vi.fn().mockResolvedValue(outcome),
+      };
+    }
+
+    it("빈 배열이면 0 반환 + 쿼리 미실행", async () => {
+      const from = vi.fn();
+      mockCreateClient.mockResolvedValue({ from });
+      expect(await adapter.claimSessions([], "user-1")).toBe(0);
+      expect(from).not.toHaveBeenCalled();
+    });
+
+    it("claim된 행 수를 반환하고 올바른 조건으로 쿼리한다", async () => {
+      const chain = makeClaimChain({ data: [{ id: "a" }, { id: "b" }] });
+      mockCreateClient.mockResolvedValue({ from: vi.fn().mockReturnValue(chain) });
+      const result = await adapter.claimSessions(["a", "b", "c"], "user-1");
+      expect(result).toBe(2);
+      expect(chain.update).toHaveBeenCalledWith({ user_id: "user-1" });
+      expect(chain.in).toHaveBeenCalledWith("id", ["a", "b", "c"]);
+      expect(chain.is).toHaveBeenCalledWith("user_id", null);
+    });
+
+    it("data가 null이면 0 반환", async () => {
+      const chain = makeClaimChain({ data: null });
+      mockCreateClient.mockResolvedValue({ from: vi.fn().mockReturnValue(chain) });
+      expect(await adapter.claimSessions(["a"], "user-1")).toBe(0);
+    });
+
+    it("코드 없는 에러(네트워크) → 0 반환", async () => {
+      const chain = makeClaimChain({ error: { message: "fetch failed" } });
+      mockCreateClient.mockResolvedValue({ from: vi.fn().mockReturnValue(chain) });
+      expect(await adapter.claimSessions(["a"], "user-1")).toBe(0);
+    });
+
+    it("코드 있는 에러 → throw", async () => {
+      const chain = makeClaimChain({ error: { code: "42501", message: "permission denied" } });
+      mockCreateClient.mockResolvedValue({ from: vi.fn().mockReturnValue(chain) });
+      await expect(adapter.claimSessions(["a"], "user-1")).rejects.toThrow("permission denied");
+    });
+  });
 });

--- a/src/lib/db/supabase-adapter.ts
+++ b/src/lib/db/supabase-adapter.ts
@@ -105,4 +105,23 @@ export class SupabaseAdapter implements DbClient {
     if (error) throw new Error(error.message)
     return result as T
   }
+
+  async claimSessions(sessionIds: string[], userId: string): Promise<number> {
+    if (sessionIds.length === 0) return 0
+    const supabase = await this.client()
+    const { data, error } = await supabase
+      .from("sessions")
+      .update({ user_id: userId })
+      .in("id", sessionIds)
+      .is("user_id", null)
+      .select("id")
+    if (error) {
+      if (!error.code) {
+        console.warn(`DB claimSessions unavailable: ${error.message}`)
+        return 0
+      }
+      throw new Error(`DB write error [${error.code}]: ${error.message}`)
+    }
+    return (data ?? []).length
+  }
 }

--- a/src/lib/db/types.ts
+++ b/src/lib/db/types.ts
@@ -18,4 +18,7 @@ export interface DbClient {
   update<T>(table: string, where: Record<string, unknown>, data: Record<string, unknown>): Promise<T | null>
   /** Upsert — conflictOn은 콤마 구분 컬럼명 (예: "date,character_id") */
   upsert<T>(table: string, data: Record<string, unknown>, conflictOn: string): Promise<T>
+  /** 익명 세션(user_id IS NULL)을 사용자에게 귀속 — claim된 행 수 반환.
+   *  `WHERE id IN (sessionIds) AND user_id IS NULL` 가드로 타인 소유 세션 보호. */
+  claimSessions(sessionIds: string[], userId: string): Promise<number>
 }

--- a/src/lib/guest-sessions.ts
+++ b/src/lib/guest-sessions.ts
@@ -1,0 +1,43 @@
+/**
+ * 비인증(게스트/만료 세션) 상태에서 생성된 익명 세션 id를 클라이언트에 보관한다.
+ * 로그인 시 SessionClaimer가 이를 서버로 보내 계정에 연결(claim)한다.
+ *
+ * 항상 저장(인증 여부 무관) — claim API의 `WHERE user_id IS NULL` 가드가 멱등을 보장하므로
+ * 이미 소유/타인 소유 세션은 서버에서 no-op 처리된다.
+ * localStorage 차단 환경에서는 graceful no-op (기존 동작 유지).
+ */
+const STORAGE_KEY = "arcana_guest_sessions";
+const CAP = 30;
+
+export function rememberGuestSession(id: string): void {
+  if (!id) return;
+  try {
+    const next = [id, ...getGuestSessions().filter((s) => s !== id)].slice(0, CAP);
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+  } catch {
+    // storage 차단 환경 — 무동작
+  }
+}
+
+export function getGuestSessions(): string[] {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    const parsed: unknown = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed.filter((x): x is string => typeof x === "string") : [];
+  } catch {
+    return [];
+  }
+}
+
+export function clearGuestSessions(ids: string[]): void {
+  if (ids.length === 0) return;
+  try {
+    const remove = new Set(ids);
+    const next = getGuestSessions().filter((s) => !remove.has(s));
+    if (next.length === 0) localStorage.removeItem(STORAGE_KEY);
+    else localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+  } catch {
+    // storage 차단 환경 — 무동작
+  }
+}

--- a/src/lib/validation/api-schemas.test.ts
+++ b/src/lib/validation/api-schemas.test.ts
@@ -7,6 +7,7 @@ import {
   SajuSessionSchema,
   ShinjeomSessionSchema,
   DailyCardSchema,
+  ClaimSessionsSchema,
 } from "./api-schemas";
 
 // ──────────────────────────────────────────────
@@ -288,5 +289,32 @@ describe("DailyCardSchema", () => {
 
   it("characterId 누락 시 실패", () => {
     expect(DailyCardSchema.safeParse({ date: "2026-04-24" }).success).toBe(false);
+  });
+});
+
+// ──────────────────────────────────────────────
+// ClaimSessionsSchema
+// ──────────────────────────────────────────────
+describe("ClaimSessionsSchema", () => {
+  const UUID = "11111111-1111-4111-8111-111111111111";
+
+  it("유효한 UUID 배열 통과", () => {
+    expect(ClaimSessionsSchema.safeParse({ sessionIds: [UUID] }).success).toBe(true);
+  });
+
+  it("빈 배열 실패", () => {
+    expect(ClaimSessionsSchema.safeParse({ sessionIds: [] }).success).toBe(false);
+  });
+
+  it("UUID 형식이 아니면 실패", () => {
+    expect(ClaimSessionsSchema.safeParse({ sessionIds: ["not-a-uuid"] }).success).toBe(false);
+  });
+
+  it("100개 초과 실패", () => {
+    expect(ClaimSessionsSchema.safeParse({ sessionIds: Array.from({ length: 101 }, () => UUID) }).success).toBe(false);
+  });
+
+  it("sessionIds 누락 실패", () => {
+    expect(ClaimSessionsSchema.safeParse({}).success).toBe(false);
   });
 });

--- a/src/lib/validation/api-schemas.ts
+++ b/src/lib/validation/api-schemas.ts
@@ -30,6 +30,11 @@ export const LocaleSchema = z.object({
   locale: localeEnum,
 });
 
+// 익명 세션 claim 스키마 — 로그인 시 클라이언트 보관 익명 sessionId 일괄 귀속
+export const ClaimSessionsSchema = z.object({
+  sessionIds: z.array(z.string().uuid()).min(1).max(100),
+});
+
 // 세션 생성 스키마
 export const TarotSessionSchema = z.object({
   topic: topicStr,

--- a/src/test-helpers/mock-db.ts
+++ b/src/test-helpers/mock-db.ts
@@ -19,6 +19,7 @@ export function makeMockDb(overrides: Partial<MockDbClient> = {}): MockDbClient 
     insertMany: vi.fn(),
     update: vi.fn(),
     upsert: vi.fn(),
+    claimSessions: vi.fn(),
     ...overrides,
   } as MockDbClient;
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -41,6 +41,7 @@ export default defineConfig({
         "src/app/api/saju/reading/route.ts",          // PR C
         "src/app/api/shinjeom/message/route.ts",      // PR C
         "src/app/api/shinjeom/result/[id]/route.ts",  // PR-L
+        "src/app/api/sessions/claim/route.ts",        // 익명 세션 claim
         "src/lib/supabase/admin.ts",  // Admin client — 테스트 있음
         "src/lib/db/index.ts",        // DB provider 팩토리 — 테스트 있음
         "src/i18n/config.ts",         // PR-1 i18n config — 테스트 있음


### PR DESCRIPTION
## 문제 (사용자 신고)

로그인한 계정의 과거 타로 리딩 이력이 mypage에 노출되지 않음.

## 진단 — 프로덕션 데이터 forensic (Supabase MCP)

| 지표 | 값 |
|---|---|
| 전체 세션 | 251 |
| 로그인 세션(user_id 있음) | 132 — **로그인 사용자 user_id는 정상 기록** |
| **익명 세션(user_id NULL)** | **119 (47%)** |
| completed = readings | 158 = 158 (1:1 정상 저장) |
| 신고자 본인 completed 리딩 | 64건 전부 저장·RLS 가시 |

- ✅ 데이터·RLS·쿼리·인증 메커니즘 모두 **정상** (옛 로그인 이력은 보임).
- ❌ **리딩이 자주 익명(user_id=NULL)으로 저장**되고(게스트/만료 세션), **로그인 후 계정에 연결하는 claim 메커니즘이 전혀 없음**(`src/` grep 0건, auth callback은 토큰 교환만).
- 공통 메커니즘: mypage `findMany("sessions",{user_id})` → `.eq("user_id", uuid)`는 SQL 3치 논리상 **NULL 행을 절대 매칭 못 함** → 익명 리딩 영구 누락.

> 데이터는 `readings` RLS `using(true)` + share_token 결과 페이지로 보존됨 — 유실이 아닌 mypage 이력 discoverability 문제. (전수조사에서 parseError·fire-and-forget도 확인됐으나 데이터상 부차적)

## 수정 — 로그인 시 자동 claim

- **`lib/guest-sessions.ts`**: 세션 생성 시 sessionId를 localStorage 보관(cap 30, 차단환경 graceful).
- **`components/common/SessionClaimer.tsx`**: 로그인 감지(`onAuthStateChange`) → `POST /api/sessions/claim` → 성공 시 localStorage 정리. 루트 레이아웃 마운트.
- **`POST /api/sessions/claim`**: RateLimit → Zod(`ClaimSessionsSchema`) → 로그인 필수(401) → `claimSessions`.
- **`DbClient.claimSessions`**: `UPDATE sessions SET user_id WHERE id IN(...) AND user_id IS NULL` (supabase `.in().is(null)` / postgres `inArray+isNull`). `IS NULL` 가드로 타인 세션 탈취 불가.
- tarot/saju/shinjeom 세션 생성 지점에 `rememberGuestSession` 연결.
- **quick-win**: result 라우트 3종 rate-limit 키 충돌 분리(`result:` → `{tarot,saju,shinjeom}-result:`).

## 검증

- ✅ `type-check` · `lint`(0 err) · `build`(`/api/sessions/claim` 등록 확인)
- ✅ `test:coverage` — **970 tests(+31)** 통과, 커버리지 게이트 green (claim 라우트 100% lines)
- 신규 테스트: `sessions-claim`(9), `guest-sessions`(10), supabase/postgres `claimSessions`, `ClaimSessionsSchema`
- E2E: 실 Supabase 인증 세션 전제라 자동화 보류(smart-ci 영역) — 메모.

## 비고

`DB_PROVIDER=postgres` 모드는 Supabase auth 이벤트가 없어 SessionClaimer 미동작(기본 supabase 모드 전용). 설계 정본: `docs/superpowers/specs/2026-06-23-anon-session-claim-design.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)