### PR TITLE
fix(security): 익명 RLS 하드닝 + 타로 parseResult missing_fields (전수조사 후속 #4/#6/#7)

### DIFF
--- a/docs/architecture/db-abstraction.md
+++ b/docs/architecture/db-abstraction.md
@@ -72,6 +72,7 @@ src/lib/db/
 | `017_daily_fortune_areas.sql` | daily_cards.area 컬럼 추가 + UNIQUE(date, character_id, area) 재구성 (DailyFortune 5영역) |
 | `018_birthtime_mbti.sql` | profiles.birth_hour HH:MM 형식 외 NULL 처리 + profiles.mbti 컬럼 추가 |
 | `019_fix_saju_readings.sql` | saju_readings.birth_hour NOT NULL 제약 해제 + saju_readings.mbti 컬럼 추가 (018 누락분) |
+| `020_harden_anon_rls.sql` | 익명 over-grant 하드닝 — readings/saju/shinjeom SELECT 소유자 전용(공개 `using(true)` 제거), sessions·saju_readings UPDATE 익명 분기 제거 (#4/#6). result는 service_role(getAdminDb) 조회라 무영향 |
 
 PostgreSQL 모드: `src/lib/db/schema/index.ts` (Drizzle)에 동일 스키마 정의됨
 
@@ -79,8 +80,9 @@ PostgreSQL 모드: `src/lib/db/schema/index.ts` (Drizzle)에 동일 스키마 �
 
 ## 5. share_token 공개 정책
 
-- 타로/사주 결과 페이지(`/*/result/[id]`)는 `share_token` URL 기반 공개 공유 링크
+- 타로/사주/신점 결과 페이지(`/*/result/[id]`)는 `share_token` URL 기반 공개 공유 링크
 - share_token 보유자 = 공개 열람 허용 (공유 링크 생성 = 공개 의도)
+- **공개 열람은 service_role 서버 레이어로 구현**: result 라우트가 `getAdminDb()`(service_role, RLS 우회)로 `share_token` 조회 → 리딩 테이블의 RLS는 **소유자 전용 SELECT**만 둔다(`using(true)` 공개 정책 없음, 020). anon 키 직접 호출로는 타인 리딩 열람 불가.
 - 소유자 전용 쓰기/삭제: `assertReadingAccess("owner")` 사용
 - share_token NULL 방지: Drizzle `$defaultFn(() => crypto.randomUUID())` + DB DEFAULT `gen_random_uuid()` 이중 보장
 

--- a/src/services/tarot/tarot-service.test.ts
+++ b/src/services/tarot/tarot-service.test.ts
@@ -344,7 +344,7 @@ describe("TarotService", () => {
       expect(result.advice).toBeDefined();
     });
 
-    describe("parseError 시그널 (truncated/invalid_json)", () => {
+    describe("parseError 시그널 (truncated/missing_fields/invalid_json/fallback_text)", () => {
       it("expectedCardCount보다 cardInterpretations가 적으면 parseError='truncated'를 반환한다", () => {
         const json = JSON.stringify({
           cardInterpretations: [
@@ -374,6 +374,30 @@ describe("TarotService", () => {
         expect(result.parseError).toBeUndefined();
         expect(result.expectedCardCount).toBe(3);
         expect(result.cardInterpretations).toHaveLength(3);
+      });
+
+      it("overallReading 또는 advice가 비면 parseError='missing_fields' (사주/신점과 동일 계약)", () => {
+        const json = JSON.stringify({
+          cardInterpretations: [
+            { cardId: "major-00", position: 0, interpretation: "해석1" },
+            { cardId: "major-01", position: 1, interpretation: "해석2" },
+            { cardId: "major-02", position: 2, interpretation: "해석3" },
+          ],
+          overallReading: "종합",
+          advice: "",
+        });
+        const result = service.parseResult(json, 3);
+        expect(result.parseError).toBe("missing_fields");
+      });
+
+      it("truncated가 missing_fields보다 우선한다", () => {
+        const json = JSON.stringify({
+          cardInterpretations: [{ cardId: "major-00", position: 0, interpretation: "해석1" }],
+          overallReading: "",
+          advice: "",
+        });
+        const result = service.parseResult(json, 5);
+        expect(result.parseError).toBe("truncated");
       });
 
       it("JSON 파싱 실패 후 fallback 텍스트가 있으면 parseError='fallback_text'를 반환한다", () => {

--- a/src/services/tarot/tarot-service.ts
+++ b/src/services/tarot/tarot-service.ts
@@ -52,16 +52,22 @@ export class TarotService implements DivinationService {
           ...(interp.interpretation !== undefined ? { interpretation: cleanReadingText(String(interp.interpretation)) } : {}),
         })
       );
+      const overallReading = cleanReadingText(String(parsed.overallReading || ""));
+      const advice = cleanReadingText(String(parsed.advice || ""));
       // 카드 수 부족 = AI 응답이 도중에 잘렸을 가능성 높음
       const isTruncated = typeof expectedCardCount === "number"
         && expectedCardCount > 0
         && cardInterpretations.length < expectedCardCount;
+      // 핵심 필드 빈 문자 = 부분 파싱 (사주/신점과 동일 계약 — 빈 리딩 DB 저장 방지)
+      const parseError = isTruncated
+        ? ("truncated" as const)
+        : (!overallReading || !advice ? ("missing_fields" as const) : undefined);
       return {
         cardInterpretations,
-        overallReading: cleanReadingText(String(parsed.overallReading || "")),
-        advice: cleanReadingText(String(parsed.advice || "")),
+        overallReading,
+        advice,
         ...(parsed.directAnswer !== undefined ? { directAnswer: cleanReadingText(String(parsed.directAnswer)) } : {}),
-        ...(isTruncated ? { parseError: "truncated" as const } : {}),
+        ...(parseError ? { parseError } : {}),
         ...(typeof expectedCardCount === "number" ? { expectedCardCount } : {}),
       };
     }

--- a/src/services/tarot/tarot-service.ts
+++ b/src/services/tarot/tarot-service.ts
@@ -1,10 +1,15 @@
-import { DivinationService, ReadingResult, SessionContext } from "@/types/service";
+import { DivinationService, ReadingResult, SessionContext, CardInterpretationItem } from "@/types/service";
 import { CharacterConfig } from "@/types/character";
 import { Session, Topic } from "@/types/session";
 import { getCharacterById } from "@/data/characters";
 import { buildSystemPrompt, buildReadingPrompt } from "@/services/core/prompt-builder";
 import { cleanReadingText, parseJsonSafe, extractFallbackText } from "@/services/core/text-cleaner";
 import { SpreadResolver } from "./spread-resolver";
+
+/** JSON 필드를 안전하게 문자열로 — 객체/비문자열은 빈 문자열 (기본 stringification 회피) */
+function asText(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}
 
 export class TarotService implements DivinationService {
   id = "tarot";
@@ -36,37 +41,45 @@ export class TarotService implements DivinationService {
     return buildReadingPrompt(context.topic, context.selectedCards ?? [], spread);
   }
 
+  /** AI JSON의 cardInterpretations 배열을 ReadingResult 형식으로 정규화 */
+  private mapCardInterpretations(raw: unknown): CardInterpretationItem[] {
+    const list = Array.isArray(raw) ? raw : [];
+    return list.map((interp: { cardId: string; position: number; interpretation?: string; symbolism?: string; situation?: string; action?: string; isReversed?: boolean }) => ({
+      cardId: interp.cardId,
+      position: interp.position,
+      isReversed: interp.isReversed,
+      ...(interp.symbolism === undefined ? {} : { symbolism: cleanReadingText(asText(interp.symbolism)) }),
+      ...(interp.situation === undefined ? {} : { situation: cleanReadingText(asText(interp.situation)) }),
+      ...(interp.action === undefined ? {} : { action: cleanReadingText(asText(interp.action)) }),
+      // deprecated backward-compat field
+      ...(interp.interpretation === undefined ? {} : { interpretation: cleanReadingText(asText(interp.interpretation)) }),
+    }));
+  }
+
+  /** parseError 시그널 결정 — 카드 수 부족(truncated) 우선, 핵심 필드 빈 문자는 missing_fields.
+   *  사주/신점과 동일 계약(.claude/rules/services.md) — 빈 리딩 DB 저장 방지. */
+  private resolveParseError(isTruncated: boolean, overallReading: string, advice: string): "truncated" | "missing_fields" | undefined {
+    if (isTruncated) return "truncated";
+    if (overallReading === "" || advice === "") return "missing_fields";
+    return undefined;
+  }
+
   parseResult(aiResponse: string, expectedCardCount?: number): ReadingResult {
     const parsed = parseJsonSafe(aiResponse);
 
     if (parsed) {
-      const cardInterpretations = (Array.isArray(parsed.cardInterpretations) ? parsed.cardInterpretations : []).map(
-        (interp: { cardId: string; position: number; interpretation?: string; symbolism?: string; situation?: string; action?: string; isReversed?: boolean }) => ({
-          cardId: interp.cardId,
-          position: interp.position,
-          isReversed: interp.isReversed,
-          ...(interp.symbolism !== undefined ? { symbolism: cleanReadingText(String(interp.symbolism)) } : {}),
-          ...(interp.situation !== undefined ? { situation: cleanReadingText(String(interp.situation)) } : {}),
-          ...(interp.action !== undefined ? { action: cleanReadingText(String(interp.action)) } : {}),
-          // deprecated backward-compat field
-          ...(interp.interpretation !== undefined ? { interpretation: cleanReadingText(String(interp.interpretation)) } : {}),
-        })
-      );
-      const overallReading = cleanReadingText(String(parsed.overallReading || ""));
-      const advice = cleanReadingText(String(parsed.advice || ""));
-      // 카드 수 부족 = AI 응답이 도중에 잘렸을 가능성 높음
+      const cardInterpretations = this.mapCardInterpretations(parsed.cardInterpretations);
+      const overallReading = cleanReadingText(asText(parsed.overallReading));
+      const advice = cleanReadingText(asText(parsed.advice));
       const isTruncated = typeof expectedCardCount === "number"
         && expectedCardCount > 0
         && cardInterpretations.length < expectedCardCount;
-      // 핵심 필드 빈 문자 = 부분 파싱 (사주/신점과 동일 계약 — 빈 리딩 DB 저장 방지)
-      const parseError = isTruncated
-        ? ("truncated" as const)
-        : (!overallReading || !advice ? ("missing_fields" as const) : undefined);
+      const parseError = this.resolveParseError(isTruncated, overallReading, advice);
       return {
         cardInterpretations,
         overallReading,
         advice,
-        ...(parsed.directAnswer !== undefined ? { directAnswer: cleanReadingText(String(parsed.directAnswer)) } : {}),
+        ...(parsed.directAnswer === undefined ? {} : { directAnswer: cleanReadingText(asText(parsed.directAnswer)) }),
         ...(parseError ? { parseError } : {}),
         ...(typeof expectedCardCount === "number" ? { expectedCardCount } : {}),
       };

--- a/supabase/migrations/020_harden_anon_rls.sql
+++ b/supabase/migrations/020_harden_anon_rls.sql
@@ -1,0 +1,46 @@
+-- 020_harden_anon_rls.sql
+-- 익명 RLS over-grant 하드닝 (#4 SELECT 열거 / #6 UPDATE 과잉)
+--
+-- 문제: 익명(user_id IS NULL) 세션/리딩에 대해 공개 anon 키로 직접 PostgREST 호출 시
+--   - readings/saju_readings/shinjeom_readings의 "viewable by share token" 정책(using true)이
+--     모든 리딩을 대량 열람 가능하게 함 (사주 birth_date/birth_name/gender 평문 PII 포함)
+--   - 소유자 SELECT 정책의 "OR s.user_id IS NULL" 분기가 익명 리딩 열거 허용
+--   - sessions/saju_readings UPDATE 정책의 "user_id IS NULL"/"true" 가 익명 행 임의 변경 허용
+--
+-- 안전성: 서버는 모든 쓰기/소유권/공유결과 조회를 getAdminDb()(service_role, RLS 우회)로 수행한다.
+--   - result 페이지(share_token)는 getAdminDb로 조회 → "using(true)" SELECT 정책 불필요
+--   - mypage(쿠키 클라이언트)는 본인 소유 세션의 리딩만 조회 → 소유자 정책으로 충분
+--   검증: 하드닝 정책 적용 후에도 authenticated 사용자가 본인 리딩 전수 가시(rollback 시뮬 확인).
+
+-- ── sessions UPDATE: 익명 분기 제거 (서버는 getAdminDb로 갱신) ──
+DROP POLICY IF EXISTS "Users can update own sessions" ON public.sessions;
+CREATE POLICY "Users can update own sessions" ON public.sessions FOR UPDATE
+  USING (auth.uid() = user_id);
+
+-- ── readings: 공개 SELECT(true) 제거 + 소유자 전용 ──
+DROP POLICY IF EXISTS "Readings viewable by share token" ON public.readings;
+DROP POLICY IF EXISTS "Readings viewable by session owner" ON public.readings;
+CREATE POLICY "Readings viewable by session owner" ON public.readings FOR SELECT
+  USING (EXISTS (
+    SELECT 1 FROM public.sessions s
+    WHERE s.id = readings.session_id AND s.user_id = auth.uid()
+  ));
+
+-- ── saju_readings: 공개 SELECT(true) 제거 + 소유자 전용 + 익명 UPDATE(true) 제거 ──
+DROP POLICY IF EXISTS "Saju readings viewable by share token" ON public.saju_readings;
+DROP POLICY IF EXISTS "Saju readings viewable by session owner" ON public.saju_readings;
+CREATE POLICY "Saju readings viewable by session owner" ON public.saju_readings FOR SELECT
+  USING (EXISTS (
+    SELECT 1 FROM public.sessions s
+    WHERE s.id = saju_readings.session_id AND s.user_id = auth.uid()
+  ));
+DROP POLICY IF EXISTS "Anyone can update saju readings" ON public.saju_readings;
+
+-- ── shinjeom_readings: 공개 SELECT(true) 제거 + 소유자 전용 ──
+DROP POLICY IF EXISTS "Shinjeom readings viewable by share token" ON public.shinjeom_readings;
+DROP POLICY IF EXISTS "Shinjeom readings viewable by session owner" ON public.shinjeom_readings;
+CREATE POLICY "Shinjeom readings viewable by session owner" ON public.shinjeom_readings FOR SELECT
+  USING (EXISTS (
+    SELECT 1 FROM public.sessions s
+    WHERE s.id = shinjeom_readings.session_id AND s.user_id = auth.uid()
+  ));


### PR DESCRIPTION
전수조사(이전 세션)에서 발견·검증된 후속 항목 중 보안 하드닝(#4/#6)과 정합성(#7)을 처리. (B parseError 영속화는 설계 상충으로 별도 — 아래 참조)

## #4/#6 익명 RLS over-grant 하드닝 (migration 020, **프로덕션 적용 완료**)

프로덕션 `pg_policies` 조회로 실태 확인 후 하드닝:

| 대상 | before | after |
|---|---|---|
| `readings`/`saju_readings`/`shinjeom_readings` SELECT | 소유자 OR `user_id IS NULL` **+ `using(true)` 공개 정책** | **소유자 전용** (`s.user_id = auth.uid()`) |
| `sessions` UPDATE | `auth.uid()=user_id OR user_id IS NULL` | `auth.uid()=user_id` |
| `saju_readings` UPDATE | **`true`** (anon 누구나) | 제거 |

- **효과**: 공개 anon 키로 익명 세션/리딩 대량 열거(사주 `birth_date`/`birth_name`/`gender` 평문 PII 포함) + 익명 행 임의 변경 차단.
- **안전성**: 서버는 모든 쓰기·소유권·공유결과 조회를 `getAdminDb()`(service_role, RLS 우회)로 수행. result 페이지(share_token)도 service_role 조회라 무영향. **rollback 트랜잭션 시뮬레이션**으로 하드닝 후에도 authenticated 사용자가 본인 리딩 64건 전수 가시 확인.
- **검증**: 적용 후 `pg_policies` 재확인 + Supabase 보안 어드바이저 — 신규 이슈 없음.

## #7 타로 parseResult `missing_fields` 대칭

- 타로 `parseResult`가 `overallReading`/`advice` 빈 문자에 `parseError`를 설정하지 않아 사주/신점과 비대칭 → 빈 리딩이 DB 저장될 수 있었음([.claude/rules/services.md](.claude/rules/services.md) 계약 위반).
- `overallReading || advice` 비면 `parseError='missing_fields'` 설정(`truncated` 우선). 3서비스 계약 통일.

## 검증

- ✅ type-check · lint(0 err) · build · test:coverage **972 tests(+2)**, 게이트 green (tarot-service 커버리지 포함)

## B (parseError 리딩 영속화) — 별도 처리 권장

[.claude/rules/services.md](.claude/rules/services.md)가 **parseError = 의도적 미저장**(빈 리딩 DB 저장 방지)을 명문화하고 있어, parseError 리딩을 강제 저장하면 빈 결과 페이지 회귀 위험이 있습니다. 또한 프로덕션 데이터상 in_progress 세션의 대부분은 정상 이탈(세션이 카드선택 화면 진입 시 생성)이라 영향이 부차적입니다. 올바른 해결은 **resume/재시도 UX**(별도 설계)이므로 이번 PR에서 제외했습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)