### PR TITLE
feat(saju): 용신 판별 억부용신 부족-가중 정밀화 (B-3)

### DIFF
--- a/src/services/saju/saju-calculator.test.ts
+++ b/src/services/saju/saju-calculator.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { calculateSaju } from "./saju-calculator";
+import { calculateSaju, determineYongsin } from "./saju-calculator";
 import type { SajuInput } from "./saju-types";
 import { STEM_KO, BRANCH_KO, STEM_ELEMENT } from "@/data/saju/constants";
 
@@ -385,5 +385,58 @@ describe("calculateSaju", () => {
         expect(pillar.branch).toBe(BRANCH_KO[pillar.branchHanja]);
       }
     });
+  });
+});
+
+describe("determineYongsin (억부용신 부족-가중 휴리스틱)", () => {
+  // 신강: 일간을 덜어내는 후보 = 식상(생출=관성 아님)·관성(극입) 중 분포상 가장 부족한 오행.
+  // dayElement=wood → 식상=fire, 관성=metal
+  it("신강 + 관성(metal)이 식상(fire)보다 부족 → 관성을 용신", () => {
+    const elements = { wood: 4, fire: 3, earth: 2, metal: 1, water: 2 };
+    const r = determineYongsin("wood", true, elements);
+    expect(r.element).toBe("metal");
+    expect(r.reason).toContain("신강");
+  });
+
+  it("신강 + 식상(fire)이 관성(metal)보다 부족 → 식상을 용신", () => {
+    const elements = { wood: 4, fire: 0, earth: 2, metal: 2, water: 1 };
+    const r = determineYongsin("wood", true, elements);
+    expect(r.element).toBe("fire");
+    expect(r.reason).toContain("신강");
+  });
+
+  it("신강 + 식상·관성 동률 → 첫 후보(관성)을 용신 (결정론적 동률 처리)", () => {
+    const elements = { wood: 4, fire: 2, earth: 1, metal: 2, water: 1 };
+    const r = determineYongsin("wood", true, elements);
+    expect(r.element).toBe("metal");
+  });
+
+  // 신약: 일간을 돕는 후보 = 인성(생입)·비겁(동일) 중 분포상 가장 부족한 오행.
+  // dayElement=wood → 인성=water, 비겁=wood
+  it("신약 + 인성(water)이 비겁(wood)보다 부족 → 인성을 용신", () => {
+    const elements = { wood: 2, fire: 3, earth: 2, metal: 2, water: 0 };
+    const r = determineYongsin("wood", false, elements);
+    expect(r.element).toBe("water");
+    expect(r.reason).toContain("신약");
+  });
+
+  it("신약 + 비겁(일간 wood)이 인성(water)보다 부족 → 일간 오행을 용신", () => {
+    const elements = { wood: 0, fire: 3, earth: 2, metal: 2, water: 2 };
+    const r = determineYongsin("wood", false, elements);
+    expect(r.element).toBe("wood");
+    expect(r.reason).toContain("신약");
+  });
+
+  it("신약 + 인성·비겁 동률 → 첫 후보(인성)을 용신", () => {
+    // dayElement=fire → 인성=wood, 비겁=fire
+    const elements = { wood: 1, fire: 1, earth: 3, metal: 2, water: 2 };
+    const r = determineYongsin("fire", false, elements);
+    expect(r.element).toBe("wood");
+  });
+
+  it("reason에 부족 근거가 명시된다 (투명성)", () => {
+    const elements = { wood: 4, fire: 3, earth: 2, metal: 1, water: 2 };
+    const r = determineYongsin("wood", true, elements);
+    expect(r.reason).toContain("부족");
   });
 });

--- a/src/services/saju/saju-calculator.ts
+++ b/src/services/saju/saju-calculator.ts
@@ -214,24 +214,48 @@ function judgeStrength(dayElement: OhaengType, elements: Record<OhaengType, numb
   return strength >= 4;
 }
 
-/** 용신 결정 (향후 elements 기반 정밀 판별로 확장 예정) */
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-function determineYongsin(dayElement: OhaengType, isStrong: boolean, _elements: Record<OhaengType, number>): { element: OhaengType; reason: string } {
-  // 신강이면 설기(일간을 약화시키는 오행), 신약이면 생조(일간을 강화하는 오행)
-  const weakenMap: Record<OhaengType, OhaengType> = {
+/** 용신 결정 — 억부용신(抑扶用神) 부족-가중 휴리스틱.
+ *  신강이면 일간을 덜어내는 후보(관성=극입·식상=생출), 신약이면 일간을 돕는 후보(인성=생입·비겁=동일) 중
+ *  오행 분포상 가장 부족한(=균형 회복에 가장 필요한) 오행을 용신으로 택한다.
+ *  동률은 첫 후보(관성/인성 — 전통 기본)로 결정론적 처리.
+ *  ⚠️ 용신론은 학파 간 이견이 있는 영역이라 본 구현은 결정론적 휴리스틱이며, reason에 근거를 투명하게 명시한다. */
+export function determineYongsin(
+  dayElement: OhaengType,
+  isStrong: boolean,
+  elements: Record<OhaengType, number>,
+): { element: OhaengType; reason: string } {
+  const genMap: Record<OhaengType, OhaengType> = {     // 식상: 일간이 생하는 오행
+    wood: "fire", fire: "earth", earth: "metal", metal: "water", water: "wood",
+  };
+  const weakenMap: Record<OhaengType, OhaengType> = {  // 관성: 일간을 극하는 오행
     wood: "metal", fire: "water", earth: "wood", metal: "fire", water: "earth",
   };
-  const supportMap: Record<OhaengType, OhaengType> = {
+  const supportMap: Record<OhaengType, OhaengType> = { // 인성: 일간을 생하는 오행
     wood: "water", fire: "wood", earth: "fire", metal: "earth", water: "metal",
   };
 
-  if (isStrong) {
-    const el = weakenMap[dayElement];
-    return { element: el, reason: `신강하므로 ${el}(일간을 제어하는 오행)이 용신` };
-  } else {
-    const el = supportMap[dayElement];
-    return { element: el, reason: `신약하므로 ${el}(일간을 생하는 오행)이 용신` };
+  // 후보 십성 (배열 첫 항목이 동률 시 기본). 신강=설기·제어, 신약=생조.
+  const candidates: { element: OhaengType; label: string }[] = isStrong
+    ? [
+        { element: weakenMap[dayElement], label: "일간을 극하는 관성" },
+        { element: genMap[dayElement], label: "일간이 생하는 식상" },
+      ]
+    : [
+        { element: supportMap[dayElement], label: "일간을 생하는 인성" },
+        { element: dayElement, label: "일간과 같은 비겁" },
+      ];
+
+  // 분포상 가장 부족한 후보 오행 선택 (부족 = 균형 회복에 필요). 동률은 첫 후보 유지.
+  let best = candidates[0];
+  for (let i = 1; i < candidates.length; i++) {
+    if (elements[candidates[i].element] < elements[best.element]) best = candidates[i];
   }
+
+  const head = isStrong ? "신강하여 설기·제어가 필요" : "신약하여 생조가 필요";
+  return {
+    element: best.element,
+    reason: `${head}하고, ${best.element}(${best.label})이 분포상 가장 부족(${elements[best.element]})하여 용신`,
+  };
 }
 
 /** 대운 계산 (8개) */


### PR DESCRIPTION
## 배경
`determineYongsin`이 `_elements`(오행 분포)를 미사용(eslint-disable)하고 `isStrong` boolean만으로 단일 오행을 반환했다. 오행 분포를 반영한 정밀화 (survey B-3).

## 변경 — 억부용신(抑扶用神) 부족-가중 휴리스틱
- **신강**: 일간을 덜어내는 후보(관성=극입·식상=생출) 중 분포상 **가장 부족한** 오행을 용신
- **신약**: 일간을 돕는 후보(인성=생입·비겁=동일) 중 가장 부족한 오행을 용신
- 부족 = 균형 회복에 필요. 동률은 첫 후보(관성/인성, 전통 기본)로 **결정론적** 처리
- `reason`에 십성·부족 카운트 근거를 **투명하게** 명시
- `eslint-disable` 제거, `export`로 단위 테스트화

## ⚠️ 도메인 주의
용신론은 학파 간 이견이 있는 영역입니다. 본 구현은 **결정론적 억부 휴리스틱**(부족한 균형 오행 보강)이며, 완전한 명리 체계(조후·통관·병약용신 등)는 아닙니다. 사용자 승인하에 이 깊이로 진행. 코드 doc·`reason`에 근거 명시.

## 검증 (TDD)
- `determineYongsin` 직접 단위 테스트 7건 선작성(신강/신약 × 후보별·동률·투명성)
- 기존 신강/신약 `reason` 통합 테스트 유지
- ✅ type-check / lint(0 errors) / **979 테스트** / 커버리지 branch 91.09·funcs 97.37·lines 99.52·stmts 98.67
- 마이그레이션 0, 신규 TS 파일 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)