### PR TITLE
refactor(session): 타로 세션·설정 페이지 컨트롤러 훅 분리 (B-5 저위험)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,6 +58,8 @@ src/
 │   ├── usePreselectCharacter.ts  # URL ?character= 파라미터 + 선호 상담사 자동 선택
 │   ├── useResetScrollOnStep.ts   # step 변경 시 스크롤 최상단 초기화 (3페이지 공통)
 │   ├── useTarotReading.ts        # 타로 SSE 스트리밍·대기 연출·elapsed 카운터
+│   ├── useTarotCardSelection.ts  # 타로 세션 카드선택·리딩진행 컨트롤러 훅 (레이스 가드 포함, page=view 분리)
+│   ├── useSettings.ts            # 설정 페이지 상태·핸들러·storage 컨트롤러 훅 (page=view 분리)
 │   └── (+ useLocaleStore, useGenderStore, useSkinStore, useFavoriteCharacter, useTheme, useSSEStream, useCardAnimation, useCharacter, useReducedMotionStore 등)
 ├── i18n/            # locale 감지, Provider, useT, translations
 ├── lib/             # env, auth, db, storage, validation, request/rate-limit 유틸

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -56,6 +56,8 @@ sonar.coverage.exclusions=\
   src/lib/guest-sessions.ts,\
   src/lib/particle-engine.ts,\
   src/hooks/useTarotReading.ts,\
+  src/hooks/useTarotCardSelection.ts,\
+  src/hooks/useSettings.ts,\
   src/hooks/useMouseParallax.ts,\
   src/components/effects/ServiceIllustrations.tsx,\
   src/lib/supabase/client.ts,\
@@ -113,6 +115,8 @@ sonar.cpd.exclusions=\
   src/components/tarot/CardInterpretationList.tsx,\
   src/components/tarot/TarotResultPanel.tsx,\
   src/hooks/useTarotReading.ts,\
+  src/hooks/useTarotCardSelection.ts,\
+  src/hooks/useSettings.ts,\
   src/components/saju/SajuChartReveal.tsx,\
   src/components/shinjeom/ShinjeomEnergyEffect.tsx,\
   src/components/session/ResultTextCard.tsx,\

--- a/src/app/(immersive)/tarot/session/page.tsx
+++ b/src/app/(immersive)/tarot/session/page.tsx
@@ -1,13 +1,11 @@
 "use client";
 
-import React, { useEffect, useCallback, useState, useRef } from "react";
+import React from "react";
 import dynamic from "next/dynamic";
-import { useRouter } from "next/navigation";
 import Image from "next/image";
 import { motion, AnimatePresence } from "framer-motion";
 import { ReadingErrorState } from "@/components/session/ReadingErrorState";
 import { useSessionStore } from "@/hooks/useSession";
-import { useCharacterStore } from "@/hooks/useCharacter";
 import { useCardAnimationStore } from "@/hooks/useCardAnimation";
 import { CharacterDisplay } from "@/components/character/CharacterDisplay";
 import { DialogueBox } from "@/components/chat/DialogueBox";
@@ -26,27 +24,13 @@ const ReadingProgressIndicator = dynamic(
 );
 import { ParticleOverlay } from "@/components/effects/ParticleOverlay";
 import { MysticBackground, ThemeAtmosphere } from "@/components/effects/MysticBackground";
-import { getCharacterById } from "@/data/characters";
-import { getCharacterGreeting } from "@/data/characters/locale-helpers";
-import { useLocaleStore } from "@/hooks/useLocaleStore";
-import { DeckManager } from "@/services/tarot/deck-manager";
-import { spreads } from "@/data/spreads";
 import { TarotResultPanel } from "@/components/tarot/TarotResultPanel";
-import { TarotCard, SelectedCard } from "@/types/card";
-import { ChatMessage } from "@/types/session";
-import { useT } from "@/i18n/useT";
-import { useThemeStore } from "@/hooks/useTheme";
 import { getServiceBackgroundUrl } from "@/lib/storage/card-style";
 import { t as translate } from "@/i18n/translations";
 import type { Locale } from "@/i18n/config";
 import { shareWithUrl, shareWithText } from "@/lib/share-utils";
-import { useReadingRevealStore } from "@/hooks/useReadingReveal";
-import { useTarotReading } from "@/hooks/useTarotReading";
 import { ServiceIllustrations } from "@/components/effects/ServiceIllustrations";
-import { rememberGuestSession } from "@/lib/guest-sessions";
-
-
-const deckManager = new DeckManager();
+import { useTarotCardSelection } from "@/hooks/useTarotCardSelection";
 
 /** 타로 결과 공유 버튼 핸들러 — CC 22 → 모듈 레벨 추출 */
 async function shareTarotResult(locale: Locale): Promise<void> {
@@ -68,273 +52,14 @@ async function shareTarotResult(locale: Locale): Promise<void> {
 }
 
 export default function TarotSessionPage() {
-  const router = useRouter();
-  const locale = useLocaleStore((s) => s.locale);
-  const { t } = useT();
-  const { currentMood, setMood } = useCharacterStore();
-  const { animationPhase, setAnimationPhase } = useCardAnimationStore();
   const {
-    phase, topic, characterId, spreadType, requiredCards, selectedCards, chatMessages, readingResult, isLoading,
-    setPhase, setSessionId, setAvailableCards,
-    selectCard, addChatMessage,
-  } = useSessionStore();
-
-  const character = characterId ? getCharacterById(characterId) : null;
-
-  const { isRevealComplete, reset: resetReveal } = useReadingRevealStore();
-
-  const [shuffledDeck, setShuffledDeck] = useState<TarotCard[]>([]);
-  const [selectedIndices, setSelectedIndices] = useState<number[]>([]);
-  const [revealedPositions, setRevealedPositions] = useState<number[]>([]);
-  const [pendingConfirm, _setPendingConfirm] = useState(false);
-  const pendingConfirmRef = useRef(false);
-  const setPendingConfirm = (v: boolean) => { pendingConfirmRef.current = v; _setPendingConfirm(v); };
-
-  const { readingError, readingErrorReason, isConnecting, elapsedSec, readingAbortRef, startReading, setReadingError } =
-    useTarotReading({ setRevealedPositions, setPendingConfirm });
-
-  const [confirmEachCard, setConfirmEachCard] = useState(false);
-  const resultContainerRef = useRef<HTMLDivElement>(null);
-  const redirectedRef = useRef(false);
-  // 빠른 연속 터치 race 차단: 동기 ref-lock (RAF로 다음 frame에 unlock)
-  const selectionLockRef = useRef(false);
-  // 마지막 카드 자동 시작 setTimeout 이중 큐잉 차단
-  const autoStartTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const toggleConfirmMode = () => {
-    setConfirmEachCard((prev) => {
-      const next = !prev;
-      localStorage.setItem("arcana-confirm-each-card", String(next));
-      return next;
-    });
-  };
-
-  useEffect(() => {
-    const t = setTimeout(() => {
-      setConfirmEachCard(localStorage.getItem("arcana-confirm-each-card") === "true");
-    }, 0);
-    return () => clearTimeout(t);
-  }, []);
-
-  // unmount cleanup: 진행 중인 SSE abort + 자동 시작 타이머 clear (saju/shinjeom과 동일 패턴)
-  useEffect(() => {
-    return () => {
-      readingAbortRef.current?.abort();
-      if (autoStartTimerRef.current) {
-        clearTimeout(autoStartTimerRef.current);
-        autoStartTimerRef.current = null;
-      }
-    };
-  }, []);
-
-  // phase가 초기화되면 reveal 상태도 리셋
-  useEffect(() => {
-    if (phase === "card-shuffle" || phase === "card-select") {
-      resetReveal();
-    }
-  }, [phase, resetReveal]);
-
-  useEffect(() => {
-    if (!topic || !character || !spreadType) {
-      if (!redirectedRef.current) { redirectedRef.current = true; router.push("/tarot"); }
-      return;
-    }
-    const allCards = deckManager.getAllCards();
-    const shuffled = [...allCards];
-    for (let i = shuffled.length - 1; i > 0; i--) {
-      const j = Math.floor(Math.random() * (i + 1));
-      [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
-    }
-    setShuffledDeck(shuffled);
-    setAvailableCards(shuffled);
-
-    // 세션 생성을 await하여 sessionId 확보 후 카드 선택 시작
-    const initSession = async () => {
-      try {
-        const res = await fetch("/api/tarot/session", {
-          method: "POST", headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ topic, characterId, spreadType }),
-        });
-        if (!res.ok) throw new Error(`세션 생성 실패: ${res.status}`);
-        const data = await res.json();
-        if (data.session?.id) { setSessionId(data.session.id); rememberGuestSession(data.session.id); }
-      } catch (err) {
-        console.warn("세션 생성 실패 (리딩은 계속 진행):", err);
-      }
-    };
-    initSession();
-
-    setMood("default");
-    addChatMessage({ id: crypto.randomUUID(), role: "character", content: getCharacterGreeting(character, locale), mood: "default", timestamp: new Date() });
-
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [topic]); // NOSONAR
-
-  // ShuffleCeremony 제거 — card-shuffle 페이즈 진입 즉시 card-select로 전환
-  useEffect(() => {
-    if (phase === "card-shuffle") {
-      handleCeremonyComplete();
-    }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [phase]); // NOSONAR
-
-  const handleCeremonyComplete = useCallback(() => {
-    const { requiredCards: required } = useSessionStore.getState();
-    setAnimationPhase("spreading");
-    setPhase("card-select");
-    addChatMessage({
-      id: crypto.randomUUID(), role: "character",
-      content: t("tarot.session.msg.pick-cards-prompt").replace("{n}", String(required)),
-      mood: "default", timestamp: new Date(),
-    });
-  }, [addChatMessage, setAnimationPhase, setPhase, t]);
-
-  const handleCardSelect = useCallback((index: number) => {
-    // 빠른 연속 터치 race 차단:
-    // 1. selectionLockRef 동기 ref-lock (state 반영 전 두 번째 click 차단)
-    // 2. pendingConfirmRef (확인 대기 중 추가 선택 차단)
-    if (selectionLockRef.current || pendingConfirmRef.current) return;
-    // TOCTOU 방지: lock을 fresh getState 호출 직전에 즉시 set (다른 click handler가 동일 frame에 진입해도 차단)
-    selectionLockRef.current = true;
-    requestAnimationFrame(() => { selectionLockRef.current = false; });
-    // 항상 fresh 상태를 읽어 stale closure 방지
-    const { selectedCards: currentCards, requiredCards: required } = useSessionStore.getState();
-    if (currentCards.length >= required) return;
-    // 같은 deck index 중복 클릭 방어 (CardDeck isSelected prop의 stale 보완)
-    if (currentCards.some((c) => c.card.id === shuffledDeck[index]?.id)) return;
-
-    const card = shuffledDeck[index];
-    if (!card) return;
-    const isReversed = Math.random() > 0.5;
-    const position = currentCards.length;
-    const selected: SelectedCard = { card, position, isReversed, selectedAt: new Date() };
-    if (!selectCard(selected)) return;
-    setSelectedIndices((prev) => prev.includes(index) ? prev : [...prev, index]);
-    setRevealedPositions((prev) => prev.includes(position) ? prev : [...prev, position]);
-    setMood("surprised");
-
-    const currentCount = currentCards.length + 1;
-    const isLast = currentCount >= required;
-
-    if (isLast && !confirmEachCard) {
-      // 확인 모드 OFF + 마지막 카드 → 자동으로 리딩 시작 (즉시 잠금으로 중복 방지)
-      setPendingConfirm(true);
-      // setTimeout 이중 큐잉 차단: 이미 예약된 타이머가 있으면 재예약 안 함
-      if (autoStartTimerRef.current) return;
-      autoStartTimerRef.current = setTimeout(() => {
-        autoStartTimerRef.current = null;
-        const { selectedCards: allCards, requiredCards: req } = useSessionStore.getState();
-        // 800ms 동안 cancel·race로 카드 수가 줄었으면 startReading 차단 (서버에 부족한 cards 전달 방지)
-        if (allCards.length < req) {
-          console.warn("[tarot-session] auto-start aborted: insufficient cards", allCards.length, "/", req);
-          setPendingConfirm(false);
-          return;
-        }
-        startReading(allCards);
-      }, 800);
-    } else if (confirmEachCard || isLast) {
-      // 확인 모드 ON 또는 마지막 카드(확인 모드 ON) → 확인 요청
-      setPendingConfirm(true);
-      setTimeout(() => {
-        addChatMessage({
-          id: crypto.randomUUID(), role: "character",
-          content: isLast
-            ? t("tarot.session.msg.confirm-final").replace("{n}", String(required))
-            : t("tarot.session.msg.confirm-card")
-                .replace(/\{current\}/g, String(currentCount))
-                .replace(/\{total\}/g, String(required)),
-          mood: "mystical", timestamp: new Date(),
-        });
-      }, 500);
-    }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [shuffledDeck, confirmEachCard, selectCard, setMood, addChatMessage]); // NOSONAR
-
-  /** 확인 → 마지막 카드면 리딩 시작, 아니면 다음 카드 선택 계속 */
-  const handleConfirmCard = useCallback(() => {
-    // 빠른 더블클릭으로 startReading 이중 호출 차단
-    if (!pendingConfirmRef.current) return;
-    if (autoStartTimerRef.current) {
-      clearTimeout(autoStartTimerRef.current);
-      autoStartTimerRef.current = null;
-    }
-    setPendingConfirm(false);
-    const { selectedCards: currentCards } = useSessionStore.getState();
-    if (currentCards.length >= requiredCards) {
-      startReading(currentCards);
-    } else {
-      const nextCardMsg = translate("tarot.session.msg.next-card", locale)
-        .replace("{current}", String(currentCards.length))
-        .replace("{total}", String(requiredCards));
-      addChatMessage({
-        id: crypto.randomUUID(), role: "character",
-        content: nextCardMsg,
-        mood: "default", timestamp: new Date(),
-      });
-      setMood("default");
-    }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [requiredCards, addChatMessage, setMood]); // NOSONAR
-
-  /** 취소 → 마지막 카드 제거, 다시 선택 가능 */
-  const handleCancelLastCard = useCallback(() => {
-    // 자동 시작 타이머가 예약돼 있으면 cancel — store가 줄어든 상태로 startReading 발화 방지
-    if (autoStartTimerRef.current) {
-      clearTimeout(autoStartTimerRef.current);
-      autoStartTimerRef.current = null;
-    }
-    setPendingConfirm(false);
-    const currentCards = useSessionStore.getState().selectedCards;
-    if (currentCards.length === 0) return;
-    const lastCard = currentCards[currentCards.length - 1];
-    const remaining = currentCards.slice(0, -1);
-    useSessionStore.setState({ selectedCards: remaining });
-    setSelectedIndices((prev) => prev.slice(0, -1));
-    setRevealedPositions((prev) => prev.filter((p) => p !== lastCard.position));
-    addChatMessage({
-      id: crypto.randomUUID(), role: "character",
-      content: translate("tarot.session.msg.different-card", locale),
-      mood: "default", timestamp: new Date(),
-    });
-    setMood("default");
-  }, [addChatMessage, setMood, locale]);
-
-  /** 카드 스프레드 단계에서 '뒤로' → 진행 상태만 비우고 스프레드 선택 단계로 복귀 (캐릭터/주제/스프레드 유지) */
-  const handleBackToSpread = useCallback(() => {
-    readingAbortRef.current?.abort();
-    if (autoStartTimerRef.current) {
-      clearTimeout(autoStartTimerRef.current);
-      autoStartTimerRef.current = null;
-    }
-    const cid = useSessionStore.getState().characterId;
-    // 진행 상태만 초기화 — characterId/topic/spreadType/userInfo/freeQuestion은 보존
-    useSessionStore.setState({
-      selectedCards: [],
-      chatMessages: [],
-      readingResult: null,
-      sessionId: null,
-      availableCards: [],
-      isLoading: false,
-    });
-    useCardAnimationStore.getState().reset();
-    router.push(cid ? `/tarot?character=${cid}&step=spread` : "/tarot");
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [router]); // NOSONAR — ref/store 접근은 stable
-
-  // 결과 스트리밍 시 컨테이너 내부만 하단 스크롤 (윈도우 스크롤 방지)
-  useEffect(() => {
-    if (phase === "result") {
-      const container = resultContainerRef.current;
-      if (container) container.scrollTop = container.scrollHeight;
-    }
-  }, [chatMessages, phase]);
-
-  const spread = spreadType ? spreads[spreadType] : null;
-  // showLabel: AI 리딩 완료(result phase + reveal complete) 시에만 카드 텍스트 공개
-  const showCardLabel = phase === "result" && isRevealComplete;
-  const particleDensityMap: Record<string, "low" | "medium" | "high"> = { reading: "medium", result: "low" };
-  const particleDensity = particleDensityMap[phase] ?? "medium";
-  const effectTheme = character?.effectTheme;
-  const { activeTheme } = useThemeStore();
+    locale, t, router,
+    phase, character, currentMood, chatMessages, selectedCards, requiredCards, readingResult, isLoading, animationPhase,
+    shuffledDeck, selectedIndices, revealedPositions, pendingConfirm, confirmEachCard,
+    toggleConfirmMode, handleCardSelect, handleConfirmCard, handleCancelLastCard, handleBackToSpread,
+    readingError, readingErrorReason, isConnecting, elapsedSec, startReading, setReadingError,
+    spread, showCardLabel, particleDensity, effectTheme, activeTheme, resultContainerRef,
+  } = useTarotCardSelection();
 
   return (
     <div className="relative h-[calc(100dvh-7rem)] md:h-[calc(100dvh-3.5rem)] flex flex-col overflow-hidden">

--- a/src/app/(site)/settings/page.tsx
+++ b/src/app/(site)/settings/page.tsx
@@ -1,18 +1,11 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
 import Image from "next/image";
 import Link from "next/link";
-import { useThemeStore, themes, getThemeName, ThemeId } from "@/hooks/useTheme";
-import { useSkinStore } from "@/hooks/useSkinStore";
-import { useGenderStore } from "@/hooks/useGenderStore";
-import { useReducedMotionStore } from "@/hooks/useReducedMotionStore";
+import { themes, getThemeName } from "@/hooks/useTheme";
 import { cardSkins, getSkinName, getSkinDescription } from "@/data/skins";
 import { cardStyles, getStyleName, getStyleDescription, THEME_TO_STYLE_MAP, DEFAULT_STYLE_ID } from "@/data/cardStyles";
-import { useCardStyleStore } from "@/hooks/useCardStyleStore";
-import { GenderFilter } from "@/types/character";
-import { useT } from "@/i18n/useT";
-import { useLocaleStore } from "@/hooks/useLocaleStore";
+import { useSettings } from "@/hooks/useSettings";
 
 const STYLE_COLORS: Record<string, string> = {
   "dark-fantasy": "linear-gradient(135deg, #1a0a2e, #6b21a8)",
@@ -20,45 +13,6 @@ const STYLE_COLORS: Record<string, string> = {
   "anime-mystical": "linear-gradient(135deg, #1e3a8a, #60a5fa)",
   "modern-digital": "linear-gradient(135deg, #0f2944, #00b4d8)",
 };
-
-const USER_INFO_KEY = "arcana_user_info";
-const USER_INFO_CONSENT_KEY = "arcana_privacy_agreed";
-
-function hasSavedUserInfo(): boolean {
-  try {
-    return !!sessionStorage.getItem(USER_INFO_KEY);
-  } catch {
-    return false;
-  }
-}
-
-function clearSavedUserInfo(): void {
-  try {
-    sessionStorage.removeItem(USER_INFO_KEY);
-    sessionStorage.removeItem(USER_INFO_CONSENT_KEY);
-    // 이전 localStorage 저장 방식에서 남은 데이터를 함께 정리한다.
-    localStorage.removeItem(USER_INFO_KEY);
-    localStorage.removeItem(USER_INFO_CONSENT_KEY);
-  } catch {
-    // storage 차단 환경에서는 표시 상태만 갱신한다.
-  }
-}
-
-function isConfirmEachCardEnabled(): boolean {
-  try {
-    return localStorage.getItem("arcana-confirm-each-card") === "true";
-  } catch {
-    return false;
-  }
-}
-
-function saveConfirmEachCard(enabled: boolean): void {
-  try {
-    localStorage.setItem("arcana-confirm-each-card", String(enabled));
-  } catch {
-    // storage 차단 환경에서는 현재 화면 상태만 유지한다.
-  }
-}
 
 function SaveToast({ visible, text }: { visible: boolean; text: string }) {
   return (
@@ -75,77 +29,14 @@ function SaveToast({ visible, text }: { visible: boolean; text: string }) {
 }
 
 export default function SettingsPage() {
-  const { t } = useT();
-  const locale = useLocaleStore((s) => s.locale);
-  const { mode, activeTheme, setMode } = useThemeStore();
-  const { selectedSkinId, setSkin } = useSkinStore();
-  const { styleOverride, useSkinMode, setStyleOverride, clearOverride, enableSkinMode } = useCardStyleStore();
-  const { genderFilter, setGenderFilter } = useGenderStore();
-  const { reducedMotion, setReducedMotion } = useReducedMotionStore();
-
-  const isStyleMode = !useSkinMode;
-  const [confirmEachCard, setConfirmEachCard] = useState(false);
-  const [hasSavedInfo, setHasSavedInfo] = useState(false);
-  const [toastVisible, setToastVisible] = useState(false);
-
-  useEffect(() => {
-    const t = setTimeout(() => {
-      setConfirmEachCard(isConfirmEachCardEnabled());
-      setHasSavedInfo(hasSavedUserInfo());
-    }, 0);
-    return () => clearTimeout(t);
-  }, []);
-
-  const showToast = useCallback(() => {
-    setToastVisible(true);
-    const t = setTimeout(() => setToastVisible(false), 1800);
-    return () => clearTimeout(t);
-  }, []);
-
-  const handleThemeChange = (id: "auto" | ThemeId) => {
-    setMode(id);
-    showToast();
-  };
-
-  const handleSkinChange = (skinId: string) => {
-    setSkin(skinId);
-    enableSkinMode();
-    showToast();
-  };
-
-  const handleGenderChange = (id: GenderFilter) => {
-    setGenderFilter(id);
-    showToast();
-  };
-
-  const toggleConfirmMode = () => {
-    const next = !confirmEachCard;
-    setConfirmEachCard(next);
-    saveConfirmEachCard(next);
-    showToast();
-  };
-
-  const toggleReducedMotion = () => {
-    setReducedMotion(!reducedMotion);
-    showToast();
-  };
-
-  const clearSavedInfo = () => {
-    clearSavedUserInfo();
-    setHasSavedInfo(false);
-    showToast();
-  };
-
-  const themeOptions: { id: "auto" | ThemeId; label: string; icon: string }[] = [
-    { id: "auto", label: t("settings.theme.auto-label"), icon: "🔄" },
-    ...Object.values(themes).map((th) => ({ id: th.id, label: th.nameKo, icon: th.icon })),
-  ];
-
-  const genderOptions: { id: GenderFilter; label: string }[] = [
-    { id: "all", label: t("settings.gender.all") },
-    { id: "female", label: t("settings.gender.female") },
-    { id: "male", label: t("settings.gender.male") },
-  ];
+  const {
+    t, locale,
+    mode, activeTheme, isStyleMode, styleOverride, useSkinMode, selectedSkinId,
+    genderFilter, reducedMotion, confirmEachCard, hasSavedInfo, toastVisible,
+    setStyleOverride, clearOverride, showToast,
+    handleThemeChange, handleSkinChange, handleGenderChange, toggleConfirmMode, toggleReducedMotion, clearSavedInfo,
+    themeOptions, genderOptions,
+  } = useSettings();
 
   return (
     <div className="relative">

--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -1,0 +1,137 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { useThemeStore, themes, ThemeId } from "@/hooks/useTheme";
+import { useSkinStore } from "@/hooks/useSkinStore";
+import { useGenderStore } from "@/hooks/useGenderStore";
+import { useReducedMotionStore } from "@/hooks/useReducedMotionStore";
+import { useCardStyleStore } from "@/hooks/useCardStyleStore";
+import { GenderFilter } from "@/types/character";
+import { useT } from "@/i18n/useT";
+import { useLocaleStore } from "@/hooks/useLocaleStore";
+
+const USER_INFO_KEY = "arcana_user_info";
+const USER_INFO_CONSENT_KEY = "arcana_privacy_agreed";
+
+function hasSavedUserInfo(): boolean {
+  try {
+    return !!sessionStorage.getItem(USER_INFO_KEY);
+  } catch {
+    return false;
+  }
+}
+
+function clearSavedUserInfo(): void {
+  try {
+    sessionStorage.removeItem(USER_INFO_KEY);
+    sessionStorage.removeItem(USER_INFO_CONSENT_KEY);
+    // 이전 localStorage 저장 방식에서 남은 데이터를 함께 정리한다.
+    localStorage.removeItem(USER_INFO_KEY);
+    localStorage.removeItem(USER_INFO_CONSENT_KEY);
+  } catch {
+    // storage 차단 환경에서는 표시 상태만 갱신한다.
+  }
+}
+
+function isConfirmEachCardEnabled(): boolean {
+  try {
+    return localStorage.getItem("arcana-confirm-each-card") === "true";
+  } catch {
+    return false;
+  }
+}
+
+function saveConfirmEachCard(enabled: boolean): void {
+  try {
+    localStorage.setItem("arcana-confirm-each-card", String(enabled));
+  } catch {
+    // storage 차단 환경에서는 현재 화면 상태만 유지한다.
+  }
+}
+
+/**
+ * 설정 페이지의 상태·핸들러·storage 로직을 캡슐화한 컨트롤러 훅.
+ * (이전에는 page.tsx 인라인이었으나 view/controller 분리를 위해 추출 — 동작은 verbatim 유지.)
+ */
+export function useSettings() {
+  const { t } = useT();
+  const locale = useLocaleStore((s) => s.locale);
+  const { mode, activeTheme, setMode } = useThemeStore();
+  const { selectedSkinId, setSkin } = useSkinStore();
+  const { styleOverride, useSkinMode, setStyleOverride, clearOverride, enableSkinMode } = useCardStyleStore();
+  const { genderFilter, setGenderFilter } = useGenderStore();
+  const { reducedMotion, setReducedMotion } = useReducedMotionStore();
+
+  const isStyleMode = !useSkinMode;
+  const [confirmEachCard, setConfirmEachCard] = useState(false);
+  const [hasSavedInfo, setHasSavedInfo] = useState(false);
+  const [toastVisible, setToastVisible] = useState(false);
+
+  useEffect(() => {
+    const t = setTimeout(() => {
+      setConfirmEachCard(isConfirmEachCardEnabled());
+      setHasSavedInfo(hasSavedUserInfo());
+    }, 0);
+    return () => clearTimeout(t);
+  }, []);
+
+  const showToast = useCallback(() => {
+    setToastVisible(true);
+    const t = setTimeout(() => setToastVisible(false), 1800);
+    return () => clearTimeout(t);
+  }, []);
+
+  const handleThemeChange = (id: "auto" | ThemeId) => {
+    setMode(id);
+    showToast();
+  };
+
+  const handleSkinChange = (skinId: string) => {
+    setSkin(skinId);
+    enableSkinMode();
+    showToast();
+  };
+
+  const handleGenderChange = (id: GenderFilter) => {
+    setGenderFilter(id);
+    showToast();
+  };
+
+  const toggleConfirmMode = () => {
+    const next = !confirmEachCard;
+    setConfirmEachCard(next);
+    saveConfirmEachCard(next);
+    showToast();
+  };
+
+  const toggleReducedMotion = () => {
+    setReducedMotion(!reducedMotion);
+    showToast();
+  };
+
+  const clearSavedInfo = () => {
+    clearSavedUserInfo();
+    setHasSavedInfo(false);
+    showToast();
+  };
+
+  const themeOptions: { id: "auto" | ThemeId; label: string; icon: string }[] = [
+    { id: "auto", label: t("settings.theme.auto-label"), icon: "🔄" },
+    ...Object.values(themes).map((th) => ({ id: th.id, label: th.nameKo, icon: th.icon })),
+  ];
+
+  const genderOptions: { id: GenderFilter; label: string }[] = [
+    { id: "all", label: t("settings.gender.all") },
+    { id: "female", label: t("settings.gender.female") },
+    { id: "male", label: t("settings.gender.male") },
+  ];
+
+  return {
+    t, locale,
+    mode, activeTheme, isStyleMode, styleOverride, useSkinMode, selectedSkinId,
+    genderFilter, reducedMotion, confirmEachCard, hasSavedInfo, toastVisible,
+    setStyleOverride, clearOverride, showToast,
+    handleThemeChange, handleSkinChange, handleGenderChange, toggleConfirmMode, toggleReducedMotion, clearSavedInfo,
+    themeOptions, genderOptions,
+  };
+}

--- a/src/hooks/useTarotCardSelection.ts
+++ b/src/hooks/useTarotCardSelection.ts
@@ -99,7 +99,7 @@ export function useTarotCardSelection() {
     const allCards = deckManager.getAllCards();
     const shuffled = [...allCards];
     for (let i = shuffled.length - 1; i > 0; i--) {
-      const j = Math.floor(Math.random() * (i + 1));
+      const j = Math.floor(Math.random() * (i + 1)); // NOSONAR S2245 — 타로 카드 셔플(비보안 엔터테인먼트 용도)
       [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
     }
     setShuffledDeck(shuffled);
@@ -162,7 +162,7 @@ export function useTarotCardSelection() {
 
     const card = shuffledDeck[index];
     if (!card) return;
-    const isReversed = Math.random() > 0.5;
+    const isReversed = Math.random() > 0.5; // NOSONAR S2245 — 카드 정/역방향 무작위(비보안 용도)
     const position = currentCards.length;
     const selected: SelectedCard = { card, position, isReversed, selectedAt: new Date() };
     if (!selectCard(selected)) return;

--- a/src/hooks/useTarotCardSelection.ts
+++ b/src/hooks/useTarotCardSelection.ts
@@ -1,0 +1,311 @@
+"use client";
+
+import { useEffect, useCallback, useState, useRef } from "react";
+import { useRouter } from "next/navigation";
+import { useSessionStore } from "@/hooks/useSession";
+import { useCharacterStore } from "@/hooks/useCharacter";
+import { useCardAnimationStore } from "@/hooks/useCardAnimation";
+import { getCharacterById } from "@/data/characters";
+import { getCharacterGreeting } from "@/data/characters/locale-helpers";
+import { useLocaleStore } from "@/hooks/useLocaleStore";
+import { DeckManager } from "@/services/tarot/deck-manager";
+import { spreads } from "@/data/spreads";
+import { TarotCard, SelectedCard } from "@/types/card";
+import { useT } from "@/i18n/useT";
+import { useThemeStore } from "@/hooks/useTheme";
+import { t as translate } from "@/i18n/translations";
+import { useReadingRevealStore } from "@/hooks/useReadingReveal";
+import { useTarotReading } from "@/hooks/useTarotReading";
+import { rememberGuestSession } from "@/lib/guest-sessions";
+
+const deckManager = new DeckManager();
+
+/**
+ * 타로 세션 페이지의 카드 선택·리딩 진행 로직을 캡슐화한 컨트롤러 훅.
+ * (이전에는 page.tsx 인라인이었으나 view/controller 분리를 위해 추출 — 동작은 verbatim 유지.)
+ * 레이스 컨디션 가드(ref-lock·타이머 중복 차단·TOCTOU)는 원본 그대로 보존한다.
+ */
+export function useTarotCardSelection() {
+  const router = useRouter();
+  const locale = useLocaleStore((s) => s.locale);
+  const { t } = useT();
+  const { currentMood, setMood } = useCharacterStore();
+  const { animationPhase, setAnimationPhase } = useCardAnimationStore();
+  const {
+    phase, topic, characterId, spreadType, requiredCards, selectedCards, chatMessages, readingResult, isLoading,
+    setPhase, setSessionId, setAvailableCards,
+    selectCard, addChatMessage,
+  } = useSessionStore();
+
+  const character = characterId ? getCharacterById(characterId) : null;
+
+  const { isRevealComplete, reset: resetReveal } = useReadingRevealStore();
+
+  const [shuffledDeck, setShuffledDeck] = useState<TarotCard[]>([]);
+  const [selectedIndices, setSelectedIndices] = useState<number[]>([]);
+  const [revealedPositions, setRevealedPositions] = useState<number[]>([]);
+  const [pendingConfirm, _setPendingConfirm] = useState(false);
+  const pendingConfirmRef = useRef(false);
+  const setPendingConfirm = (v: boolean) => { pendingConfirmRef.current = v; _setPendingConfirm(v); };
+
+  const { readingError, readingErrorReason, isConnecting, elapsedSec, readingAbortRef, startReading, setReadingError } =
+    useTarotReading({ setRevealedPositions, setPendingConfirm });
+
+  const [confirmEachCard, setConfirmEachCard] = useState(false);
+  const resultContainerRef = useRef<HTMLDivElement>(null);
+  const redirectedRef = useRef(false);
+  // 빠른 연속 터치 race 차단: 동기 ref-lock (RAF로 다음 frame에 unlock)
+  const selectionLockRef = useRef(false);
+  // 마지막 카드 자동 시작 setTimeout 이중 큐잉 차단
+  const autoStartTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const toggleConfirmMode = () => {
+    setConfirmEachCard((prev) => {
+      const next = !prev;
+      localStorage.setItem("arcana-confirm-each-card", String(next));
+      return next;
+    });
+  };
+
+  useEffect(() => {
+    const t = setTimeout(() => {
+      setConfirmEachCard(localStorage.getItem("arcana-confirm-each-card") === "true");
+    }, 0);
+    return () => clearTimeout(t);
+  }, []);
+
+  // unmount cleanup: 진행 중인 SSE abort + 자동 시작 타이머 clear (saju/shinjeom과 동일 패턴)
+  useEffect(() => {
+    return () => {
+      readingAbortRef.current?.abort();
+      if (autoStartTimerRef.current) {
+        clearTimeout(autoStartTimerRef.current);
+        autoStartTimerRef.current = null;
+      }
+    };
+  }, []);
+
+  // phase가 초기화되면 reveal 상태도 리셋
+  useEffect(() => {
+    if (phase === "card-shuffle" || phase === "card-select") {
+      resetReveal();
+    }
+  }, [phase, resetReveal]);
+
+  useEffect(() => {
+    if (!topic || !character || !spreadType) {
+      if (!redirectedRef.current) { redirectedRef.current = true; router.push("/tarot"); }
+      return;
+    }
+    const allCards = deckManager.getAllCards();
+    const shuffled = [...allCards];
+    for (let i = shuffled.length - 1; i > 0; i--) {
+      const j = Math.floor(Math.random() * (i + 1));
+      [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
+    }
+    setShuffledDeck(shuffled);
+    setAvailableCards(shuffled);
+
+    // 세션 생성을 await하여 sessionId 확보 후 카드 선택 시작
+    const initSession = async () => {
+      try {
+        const res = await fetch("/api/tarot/session", {
+          method: "POST", headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ topic, characterId, spreadType }),
+        });
+        if (!res.ok) throw new Error(`세션 생성 실패: ${res.status}`);
+        const data = await res.json();
+        if (data.session?.id) { setSessionId(data.session.id); rememberGuestSession(data.session.id); }
+      } catch (err) {
+        console.warn("세션 생성 실패 (리딩은 계속 진행):", err);
+      }
+    };
+    initSession();
+
+    setMood("default");
+    addChatMessage({ id: crypto.randomUUID(), role: "character", content: getCharacterGreeting(character, locale), mood: "default", timestamp: new Date() });
+
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [topic]); // NOSONAR
+
+  // ShuffleCeremony 제거 — card-shuffle 페이즈 진입 즉시 card-select로 전환
+  useEffect(() => {
+    if (phase === "card-shuffle") {
+      handleCeremonyComplete();
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [phase]); // NOSONAR
+
+  const handleCeremonyComplete = useCallback(() => {
+    const { requiredCards: required } = useSessionStore.getState();
+    setAnimationPhase("spreading");
+    setPhase("card-select");
+    addChatMessage({
+      id: crypto.randomUUID(), role: "character",
+      content: t("tarot.session.msg.pick-cards-prompt").replace("{n}", String(required)),
+      mood: "default", timestamp: new Date(),
+    });
+  }, [addChatMessage, setAnimationPhase, setPhase, t]);
+
+  const handleCardSelect = useCallback((index: number) => {
+    // 빠른 연속 터치 race 차단:
+    // 1. selectionLockRef 동기 ref-lock (state 반영 전 두 번째 click 차단)
+    // 2. pendingConfirmRef (확인 대기 중 추가 선택 차단)
+    if (selectionLockRef.current || pendingConfirmRef.current) return;
+    // TOCTOU 방지: lock을 fresh getState 호출 직전에 즉시 set (다른 click handler가 동일 frame에 진입해도 차단)
+    selectionLockRef.current = true;
+    requestAnimationFrame(() => { selectionLockRef.current = false; });
+    // 항상 fresh 상태를 읽어 stale closure 방지
+    const { selectedCards: currentCards, requiredCards: required } = useSessionStore.getState();
+    if (currentCards.length >= required) return;
+    // 같은 deck index 중복 클릭 방어 (CardDeck isSelected prop의 stale 보완)
+    if (currentCards.some((c) => c.card.id === shuffledDeck[index]?.id)) return;
+
+    const card = shuffledDeck[index];
+    if (!card) return;
+    const isReversed = Math.random() > 0.5;
+    const position = currentCards.length;
+    const selected: SelectedCard = { card, position, isReversed, selectedAt: new Date() };
+    if (!selectCard(selected)) return;
+    setSelectedIndices((prev) => prev.includes(index) ? prev : [...prev, index]);
+    setRevealedPositions((prev) => prev.includes(position) ? prev : [...prev, position]);
+    setMood("surprised");
+
+    const currentCount = currentCards.length + 1;
+    const isLast = currentCount >= required;
+
+    if (isLast && !confirmEachCard) {
+      // 확인 모드 OFF + 마지막 카드 → 자동으로 리딩 시작 (즉시 잠금으로 중복 방지)
+      setPendingConfirm(true);
+      // setTimeout 이중 큐잉 차단: 이미 예약된 타이머가 있으면 재예약 안 함
+      if (autoStartTimerRef.current) return;
+      autoStartTimerRef.current = setTimeout(() => {
+        autoStartTimerRef.current = null;
+        const { selectedCards: allCards, requiredCards: req } = useSessionStore.getState();
+        // 800ms 동안 cancel·race로 카드 수가 줄었으면 startReading 차단 (서버에 부족한 cards 전달 방지)
+        if (allCards.length < req) {
+          console.warn("[tarot-session] auto-start aborted: insufficient cards", allCards.length, "/", req);
+          setPendingConfirm(false);
+          return;
+        }
+        startReading(allCards);
+      }, 800);
+    } else if (confirmEachCard || isLast) {
+      // 확인 모드 ON 또는 마지막 카드(확인 모드 ON) → 확인 요청
+      setPendingConfirm(true);
+      setTimeout(() => {
+        addChatMessage({
+          id: crypto.randomUUID(), role: "character",
+          content: isLast
+            ? t("tarot.session.msg.confirm-final").replace("{n}", String(required))
+            : t("tarot.session.msg.confirm-card")
+                .replace(/\{current\}/g, String(currentCount))
+                .replace(/\{total\}/g, String(required)),
+          mood: "mystical", timestamp: new Date(),
+        });
+      }, 500);
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [shuffledDeck, confirmEachCard, selectCard, setMood, addChatMessage]); // NOSONAR
+
+  /** 확인 → 마지막 카드면 리딩 시작, 아니면 다음 카드 선택 계속 */
+  const handleConfirmCard = useCallback(() => {
+    // 빠른 더블클릭으로 startReading 이중 호출 차단
+    if (!pendingConfirmRef.current) return;
+    if (autoStartTimerRef.current) {
+      clearTimeout(autoStartTimerRef.current);
+      autoStartTimerRef.current = null;
+    }
+    setPendingConfirm(false);
+    const { selectedCards: currentCards } = useSessionStore.getState();
+    if (currentCards.length >= requiredCards) {
+      startReading(currentCards);
+    } else {
+      const nextCardMsg = translate("tarot.session.msg.next-card", locale)
+        .replace("{current}", String(currentCards.length))
+        .replace("{total}", String(requiredCards));
+      addChatMessage({
+        id: crypto.randomUUID(), role: "character",
+        content: nextCardMsg,
+        mood: "default", timestamp: new Date(),
+      });
+      setMood("default");
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [requiredCards, addChatMessage, setMood]); // NOSONAR
+
+  /** 취소 → 마지막 카드 제거, 다시 선택 가능 */
+  const handleCancelLastCard = useCallback(() => {
+    // 자동 시작 타이머가 예약돼 있으면 cancel — store가 줄어든 상태로 startReading 발화 방지
+    if (autoStartTimerRef.current) {
+      clearTimeout(autoStartTimerRef.current);
+      autoStartTimerRef.current = null;
+    }
+    setPendingConfirm(false);
+    const currentCards = useSessionStore.getState().selectedCards;
+    if (currentCards.length === 0) return;
+    const lastCard = currentCards[currentCards.length - 1];
+    const remaining = currentCards.slice(0, -1);
+    useSessionStore.setState({ selectedCards: remaining });
+    setSelectedIndices((prev) => prev.slice(0, -1));
+    setRevealedPositions((prev) => prev.filter((p) => p !== lastCard.position));
+    addChatMessage({
+      id: crypto.randomUUID(), role: "character",
+      content: translate("tarot.session.msg.different-card", locale),
+      mood: "default", timestamp: new Date(),
+    });
+    setMood("default");
+  }, [addChatMessage, setMood, locale]);
+
+  /** 카드 스프레드 단계에서 '뒤로' → 진행 상태만 비우고 스프레드 선택 단계로 복귀 (캐릭터/주제/스프레드 유지) */
+  const handleBackToSpread = useCallback(() => {
+    readingAbortRef.current?.abort();
+    if (autoStartTimerRef.current) {
+      clearTimeout(autoStartTimerRef.current);
+      autoStartTimerRef.current = null;
+    }
+    const cid = useSessionStore.getState().characterId;
+    // 진행 상태만 초기화 — characterId/topic/spreadType/userInfo/freeQuestion은 보존
+    useSessionStore.setState({
+      selectedCards: [],
+      chatMessages: [],
+      readingResult: null,
+      sessionId: null,
+      availableCards: [],
+      isLoading: false,
+    });
+    useCardAnimationStore.getState().reset();
+    router.push(cid ? `/tarot?character=${cid}&step=spread` : "/tarot");
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [router]); // NOSONAR — ref/store 접근은 stable
+
+  // 결과 스트리밍 시 컨테이너 내부만 하단 스크롤 (윈도우 스크롤 방지)
+  useEffect(() => {
+    if (phase === "result") {
+      const container = resultContainerRef.current;
+      if (container) container.scrollTop = container.scrollHeight;
+    }
+  }, [chatMessages, phase]);
+
+  const spread = spreadType ? spreads[spreadType] : null;
+  // showLabel: AI 리딩 완료(result phase + reveal complete) 시에만 카드 텍스트 공개
+  const showCardLabel = phase === "result" && isRevealComplete;
+  const particleDensityMap: Record<string, "low" | "medium" | "high"> = { reading: "medium", result: "low" };
+  const particleDensity = particleDensityMap[phase] ?? "medium";
+  const effectTheme = character?.effectTheme;
+  const { activeTheme } = useThemeStore();
+
+  return {
+    // i18n / router
+    locale, t, router,
+    // 세션 store 파생 (렌더용)
+    phase, character, currentMood, chatMessages, selectedCards, requiredCards, readingResult, isLoading, animationPhase,
+    // 선택 상태
+    shuffledDeck, selectedIndices, revealedPositions, pendingConfirm, confirmEachCard,
+    // 핸들러
+    toggleConfirmMode, handleCardSelect, handleConfirmCard, handleCancelLastCard, handleBackToSpread,
+    // 리딩 상태
+    readingError, readingErrorReason, isConnecting, elapsedSec, startReading, setReadingError,
+    // 파생 / refs
+    spread, showCardLabel, particleDensity, effectTheme, activeTheme, resultContainerRef,
+  };
+}


### PR DESCRIPTION
## 배경
대형 페이지 파일(survey B-5). 타로 세션 532줄·설정 350줄을 view/controller로 분리.

## 접근 — 저위험 (DOM/셀렉터 불변)
로직을 훅으로 **verbatim 이동**(재작성 아님)해 동작·DOM·E2E 셀렉터를 보존. 레이스 컨디션 가드(ref-lock·타이머 중복차단·TOCTOU)는 원본 그대로 옮김.

- **타로 세션**: 카드선택·리딩진행 로직 → `useTarotCardSelection` 훅. **page 532→257줄**
- **설정**: 상태·핸들러·storage 로직 → `useSettings` 훅. **page 350→241줄**
- 신규 훅 2개 `sonar.coverage/cpd.exclusions` 동기화 + `CLAUDE.md` 훅 목록 갱신

## 검증
- ✅ type-check / lint(0 errors) / **build 성공** / 984 테스트 / 커버리지 게이트 통과
- DOM/JSX 불변이라 E2E 셀렉터 영향 0 — **CI E2E로 세션 플로우 동작 최종 검증**
- 마이그레이션 0

## 잔여 (후속, B-5 범위 내)
`saju`(331)·`shinjeom`(411) 세션 페이지도 동일 패턴으로 분리 가능 — 저위험·일부 우선 진행 합의에 따라 본 PR은 가장 큰 타로 + 안전한 설정에 집중.

🤖 Generated with [Claude Code](https://claude.com/claude-code)