### PR TITLE
refactor(session): 사주·신점 세션 페이지 컨트롤러 훅 분리 (B-5 잔여)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,8 @@ src/
 │   ├── useResetScrollOnStep.ts   # step 변경 시 스크롤 최상단 초기화 (3페이지 공통)
 │   ├── useTarotReading.ts        # 타로 SSE 스트리밍·대기 연출·elapsed 카운터
 │   ├── useTarotCardSelection.ts  # 타로 세션 카드선택·리딩진행 컨트롤러 훅 (레이스 가드 포함, page=view 분리)
+│   ├── useSajuReading.ts         # 사주 세션 리딩진행 컨트롤러 훅 (SSE·대기연출·타임아웃, page=view 분리)
+│   ├── useShinjeomChat.ts        # 신점 세션 대화·최종리딩 컨트롤러 훅 (page=view 분리)
 │   ├── useSettings.ts            # 설정 페이지 상태·핸들러·storage 컨트롤러 훅 (page=view 분리)
 │   └── (+ useLocaleStore, useGenderStore, useSkinStore, useFavoriteCharacter, useTheme, useSSEStream, useCardAnimation, useCharacter, useReducedMotionStore 등)
 ├── i18n/            # locale 감지, Provider, useT, translations

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -58,6 +58,8 @@ sonar.coverage.exclusions=\
   src/hooks/useTarotReading.ts,\
   src/hooks/useTarotCardSelection.ts,\
   src/hooks/useSettings.ts,\
+  src/hooks/useSajuReading.ts,\
+  src/hooks/useShinjeomChat.ts,\
   src/hooks/useMouseParallax.ts,\
   src/components/effects/ServiceIllustrations.tsx,\
   src/lib/supabase/client.ts,\
@@ -117,6 +119,8 @@ sonar.cpd.exclusions=\
   src/hooks/useTarotReading.ts,\
   src/hooks/useTarotCardSelection.ts,\
   src/hooks/useSettings.ts,\
+  src/hooks/useSajuReading.ts,\
+  src/hooks/useShinjeomChat.ts,\
   src/components/saju/SajuChartReveal.tsx,\
   src/components/shinjeom/ShinjeomEnergyEffect.tsx,\
   src/components/session/ResultTextCard.tsx,\

--- a/src/app/(immersive)/saju/session/page.tsx
+++ b/src/app/(immersive)/saju/session/page.tsx
@@ -1,19 +1,13 @@
 "use client";
 
-import { useEffect, useState, useRef } from "react";
-import { useRouter } from "next/navigation";
 import Image from "next/image";
-import { fetchSSEStream } from "@/hooks/useSSEStream";
 import { ResultTextCard } from "@/components/session/ResultTextCard";
 import { SessionActionButtons } from "@/components/session/SessionActionButtons";
 import { ReadingErrorState } from "@/components/session/ReadingErrorState";
 import { ReadingSectionBlock } from "@/components/session/ReadingSectionBlock";
 import { shareWithUrl, shareWithText } from "@/lib/share-utils";
-import { ReadingResult } from "@/types/service";
-import { SajuResult } from "@/services/saju/saju-types";
 import { motion } from "framer-motion";
 import { useSajuSessionStore } from "@/hooks/useSajuSession";
-import { useCharacterStore } from "@/hooks/useCharacter";
 import { CharacterDisplay } from "@/components/character/CharacterDisplay";
 import { DialogueBox } from "@/components/chat/DialogueBox";
 import { ParticleOverlay } from "@/components/effects/ParticleOverlay";
@@ -22,33 +16,14 @@ import { SajuChart } from "@/components/saju/SajuChart";
 import { OhaengGraph } from "@/components/saju/OhaengGraph";
 import { DaeunTimeline } from "@/components/saju/DaeunTimeline";
 import { SajuChartReveal } from "@/components/saju/SajuChartReveal";
-import { getCharacterById } from "@/data/characters";
-import { CHARACTER_RESULT_MOODS } from "@/data/characters/waiting-lines";
 import { getWaitingLinesData } from "@/data/characters/waiting-lines-i18n";
-import { useLocaleStore } from "@/hooks/useLocaleStore";
-import { useT } from "@/i18n/useT";
 import { t as translate } from "@/i18n/translations";
 import type { Locale } from "@/i18n/config";
-import { useThemeStore } from "@/hooks/useTheme";
 import { getServiceBackgroundUrl } from "@/lib/storage/card-style";
 import { ServiceIllustrations } from "@/components/effects/ServiceIllustrations";
-import { rememberGuestSession } from "@/lib/guest-sessions";
+import { useSajuReading } from "@/hooks/useSajuReading";
 
 const SITE_NAME = "ArcanaInsight";
-
-/** 사주 init 메시지 — name이 비어 있으면 locale별 prefix를 자동 제거 */
-function buildSajuInitMsg(name: string, charId: string | null, locale: Locale): string {
-  const key = charId === "miko" ? "saju.session.msg.init-formal" : "saju.session.msg.init-casual";
-  const template = translate(key, locale);
-  if (!name) {
-    return template
-      .replace(/\{name\}님의 /g, "")
-      .replace(/\{name\}'s /g, "")
-      .replace(/\{name\}様の /g, "")
-      .replace("{name}", "");
-  }
-  return template.replace("{name}", name);
-}
 
 async function handleSajuShare(r: { shareToken?: string | null; overallReading?: string | null } | null, locale: Locale): Promise<void> {
   const shareToken = r?.shareToken;
@@ -66,158 +41,12 @@ async function handleSajuShare(r: { shareToken?: string | null; overallReading?:
 }
 
 export default function SajuSessionPage() {
-  const router = useRouter();
-  const locale = useLocaleStore((s) => s.locale);
-  const { t } = useT();
-  const { currentMood, setMood } = useCharacterStore();
   const {
-    phase, topic, characterId, userInfo, timeRange, chatMessages, readingResult, sajuData, isLoading,
-    setPhase, setSessionId, addChatMessage, setReadingResult, setSajuData, setLoading,
-  } = useSajuSessionStore();
-
-  const character = characterId ? getCharacterById(characterId) : null;
-  const [readingError, setReadingError] = useState(false);
-  const [readingErrorReason, setReadingErrorReason] = useState<"timeout" | "generic">("generic");
-  const resultContainerRef = useRef<HTMLDivElement>(null);
-  const redirectedRef = useRef(false);
-  const readingAbortRef = useRef<AbortController | null>(null);
-
-  useEffect(() => {
-    if (!topic || !character || !userInfo || !timeRange) {
-      if (!redirectedRef.current) { redirectedRef.current = true; router.push("/saju"); }
-      return;
-    }
-
-    // 세션 생성
-    fetch("/api/saju/session", {
-      method: "POST", headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ topic, characterId }),
-    }).then(async (res) => {
-      if (!res.ok) return;
-      const data = await res.json();
-      if (data.session?.id) { setSessionId(data.session.id); rememberGuestSession(data.session.id); }
-    }).catch((e) => console.warn("사주 세션 생성 실패 (리딩은 계속 진행):", e));
-
-    setMood("default");
-    const initMsg = buildSajuInitMsg(userInfo.name || "", characterId, locale);
-    addChatMessage({ id: crypto.randomUUID(), role: "character",
-      content: initMsg, mood: "default", timestamp: new Date(),
-    });
-
-    startReading();
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []); // NOSONAR
-
-  const startReading = () => {
-    setLoading(true);
-    setReadingError(false);
-    setReadingErrorReason("generic");
-    const state = useSajuSessionStore.getState();
-
-    // 대기 대사
-    const charId = state.characterId || "seonhwa";
-    const wl = getWaitingLinesData(useLocaleStore.getState().locale);
-    const lines = wl.sajuWaitingLines[charId] || wl.defaultSajuWaitingLines;
-    const timers: ReturnType<typeof setTimeout>[] = [];
-    // CLAUDE.md 규칙: 대기 대사 중 표정 변경 금지 — setMood 호출 제거
-    lines.forEach((line, i) => {
-      timers.push(setTimeout(() => {
-        addChatMessage({ id: crypto.randomUUID(), role: "character", content: line.content, mood: line.mood, timestamp: new Date() });
-      }, (i + 1) * 3000));
-    });
-    const stopTimers = () => timers.forEach(clearTimeout);
-
-    // 클라이언트 hard timeout (240초). 서버 AI_TIMEOUT_MS와 동조 — full-fortune/includeMonthly(max_tokens
-    // 17000~20000)는 reasoning 흡수까지 200~400s 소요 가능. 120s/180s에서는 본문 잘림 빈발.
-    const abortController = new AbortController();
-    readingAbortRef.current = abortController;
-    let finished = false;
-    const timeoutId = setTimeout(() => {
-      if (finished) return;
-      finished = true;
-      abortController.abort();
-      stopTimers();
-      console.warn("[saju-session] 클라이언트 타임아웃 240s");
-      setMood("default");
-      setReadingErrorReason("timeout");
-      setReadingError(true);
-      setLoading(false);
-    }, 240_000);
-
-    void fetchSSEStream({
-      url: "/api/saju/reading",
-      signal: abortController.signal,
-      body: {
-        sessionId: state.sessionId, topic: state.topic,
-        timeRange: state.timeRange, includeMonthly: state.includeMonthly,
-        characterId: state.characterId, userInfo: state.userInfo,
-        freeQuestion: state.freeQuestion,
-      },
-      onChunk: () => { /* 사주는 스트리밍 표시 불필요 — 대기 연출 사용 */ },
-      onDone: (data) => {
-        if (finished) return;
-        finished = true;
-        clearTimeout(timeoutId);
-        stopTimers();
-        const result = data.result as ReadingResult | undefined;
-        if (!result) {
-          setMood("default"); setReadingError(true); setLoading(false);
-          return;
-        }
-
-        // 결과 표시 불가 — DB 저장도 차단된 상태이므로 사용자에게 재시도 안내
-        if (result.parseError) {
-          console.warn("[saju-session] 결과 표시 불가:", { parseError: result.parseError });
-          const errLines = (charId && wl.characterErrorLines[charId]) ? wl.characterErrorLines[charId] : wl.defaultErrorLines;
-          addChatMessage({ id: crypto.randomUUID(), role: "character",
-            content: errLines.reading, mood: "default", timestamp: new Date() });
-          setMood("default"); setReadingError(true); setLoading(false);
-          return;
-        }
-
-        setReadingResult(result);
-        if (data.sajuData) setSajuData(data.sajuData as SajuResult);
-        setPhase("result"); setMood(CHARACTER_RESULT_MOODS[state.characterId ?? ""] ?? "smile");
-        const doneMsg = state.characterId === "miko"
-          ? translate("saju.session.msg.complete-formal", locale)
-          : translate("saju.session.msg.complete-casual", locale);
-        addChatMessage({ id: crypto.randomUUID(), role: "character",
-          content: doneMsg, mood: "smile", timestamp: new Date() });
-        setLoading(false);
-      },
-      onError: (msg) => {
-        if (finished) return;
-        finished = true;
-        clearTimeout(timeoutId);
-        stopTimers();
-        console.error("사주 리딩 실패:", msg);
-        const errLines = (charId && wl.characterErrorLines[charId]) ? wl.characterErrorLines[charId] : wl.defaultErrorLines;
-        const errText = msg.includes("GROK_API_KEY") ? errLines.api : errLines.reading;
-        addChatMessage({ id: crypto.randomUUID(), role: "character",
-          content: errText, mood: "default", timestamp: new Date() });
-        setMood("default"); setReadingError(true); setLoading(false);
-      },
-    }).then(() => {
-      if (!finished) clearTimeout(timeoutId);
-    });
-
-    return () => { clearTimeout(timeoutId); abortController.abort(); };
-  };
-
-  useEffect(() => {
-    // 결과 스트리밍 시 컨테이너 내부만 하단 스크롤 (윈도우 스크롤 방지)
-    if (phase === "result") {
-      const container = resultContainerRef.current;
-      if (container) container.scrollTop = container.scrollHeight;
-    }
-  }, [chatMessages, phase]);
-
-  useEffect(() => {
-    return () => { readingAbortRef.current?.abort(); };
-  }, []);
-
-  const birthYear = userInfo ? parseInt(userInfo.birthDate.split("-")[0]) : 2000;
-  const { activeTheme } = useThemeStore();
+    locale, t, router,
+    phase, character, currentMood, chatMessages, readingResult, sajuData, isLoading,
+    readingError, readingErrorReason, setReadingError,
+    startReading, resultContainerRef, birthYear, activeTheme,
+  } = useSajuReading();
 
   return (
     <div className="relative h-[calc(100dvh-7rem)] md:h-[calc(100dvh-3.5rem)] flex flex-col overflow-hidden">
@@ -312,7 +141,7 @@ export default function SajuSessionPage() {
               ) : (
                 <div className="flex flex-col items-center gap-3">
                   <div className="w-10 h-10 border-2 border-arcana-purple/30 border-t-arcana-purple rounded-full animate-spin" />
-                  <p className="text-arcana-muted text-xs font-serif">{getWaitingLinesData(locale).sajuAnalyzingText[characterId ?? ""] ?? getWaitingLinesData(locale).defaultSajuAnalyzingText}</p>
+                  <p className="text-arcana-muted text-xs font-serif">{getWaitingLinesData(locale).sajuAnalyzingText[character?.id ?? ""] ?? getWaitingLinesData(locale).defaultSajuAnalyzingText}</p>
                 </div>
               )}
             </div>

--- a/src/app/(immersive)/shinjeom/session/page.tsx
+++ b/src/app/(immersive)/shinjeom/session/page.tsx
@@ -1,7 +1,5 @@
 "use client";
 
-import { useState, useRef, useEffect } from "react";
-import { useRouter } from "next/navigation";
 import Image from "next/image";
 import { motion, AnimatePresence } from "framer-motion";
 import { useShinjeomSessionStore } from "@/hooks/useShinjeomSession";
@@ -12,21 +10,13 @@ import { ResultTextCard } from "@/components/session/ResultTextCard";
 import { ReadingSectionBlock } from "@/components/session/ReadingSectionBlock";
 import { SessionActionButtons } from "@/components/session/SessionActionButtons";
 import { shareWithUrl, shareWithText } from "@/lib/share-utils";
-import { getCharacterById } from "@/data/characters";
-import { useCharacterStore } from "@/hooks/useCharacter";
-import { CHARACTER_RESULT_MOODS } from "@/data/characters/waiting-lines";
 import { getWaitingLinesData } from "@/data/characters/waiting-lines-i18n";
-import { getCharacterGreeting } from "@/data/characters/locale-helpers";
-import { useLocaleStore } from "@/hooks/useLocaleStore";
-import { useT } from "@/i18n/useT";
 import { t as translate } from "@/i18n/translations";
 import type { Locale } from "@/i18n/config";
-import { fetchSSEStream } from "@/hooks/useSSEStream";
-import { useThemeStore } from "@/hooks/useTheme";
 import { getServiceBackgroundUrl } from "@/lib/storage/card-style";
 import { ShinjeomEnergyEffect } from "@/components/shinjeom/ShinjeomEnergyEffect";
 import { ServiceIllustrations } from "@/components/effects/ServiceIllustrations";
-import { rememberGuestSession } from "@/lib/guest-sessions";
+import { useShinjeomChat } from "@/hooks/useShinjeomChat";
 
 const SITE_NAME = "ArcanaInsight";
 
@@ -45,237 +35,14 @@ async function handleShinjeomShare(r: { shareToken?: string | null; overallReadi
   }
 }
 
-function getErrorMsg(charId: string | null | undefined, type: "api" | "reading", locale: string): string {
-  const wl = getWaitingLinesData(locale);
-  const lines = (charId && wl.characterErrorLines[charId]) || wl.defaultErrorLines;
-  return lines[type];
-}
-
-function updateMessageContent(msgId: string, content: string) {
-  useShinjeomSessionStore.setState((state) => ({
-    chatMessages: state.chatMessages.map((m) =>
-      m.id === msgId ? { ...m, content } : m
-    ),
-  }));
-}
-
-function removeMessage(msgId: string) {
-  useShinjeomSessionStore.setState((state) => ({
-    chatMessages: state.chatMessages.filter((m) => m.id !== msgId),
-  }));
-}
-
-
 export default function ShinjeomSessionPage() {
-  const router = useRouter();
-  const locale = useLocaleStore((s) => s.locale);
-  const { t } = useT();
   const {
-    phase, topic, characterId, chatMessages, turnCount, readingResult, isLoading,
-    addChatMessage, incrementTurn, setReadingResult, setLoading, setPhase, setSessionId, reset,
-  } = useShinjeomSessionStore();
-  const { setMood, currentMood } = useCharacterStore();
+    locale, t, router,
+    phase, character, characterId, currentMood, chatMessages, turnCount, readingResult, isLoading, reset,
+    inputText, setInputText, showEnergyEffect, setShowEnergyEffect,
+    handleSend, handleEndConsultation, chatContainerRef, activeTheme,
+  } = useShinjeomChat();
 
-  const character = characterId ? getCharacterById(characterId) : null;
-  const [inputText, setInputText] = useState("");
-  const [sessionCreated, setSessionCreated] = useState(false);
-  const [showEnergyEffect, setShowEnergyEffect] = useState(true);
-  const redirectedRef = useRef(false);
-  const readingAbortRef = useRef<AbortController | null>(null);
-
-  // 세션 생성
-  useEffect(() => {
-    if (!topic || !character) {
-      if (!redirectedRef.current) { redirectedRef.current = true; router.push("/shinjeom"); }
-      return;
-    }
-    if (sessionCreated) return;
-    // eslint-disable-next-line react-hooks/set-state-in-effect
-    setSessionCreated(true);
-
-    const initSession = async () => {
-      try {
-        const res = await fetch("/api/shinjeom/session", {
-          method: "POST", headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ topic, characterId }),
-        });
-        const data = await res.json();
-        if (data.session?.id) { setSessionId(data.session.id); rememberGuestSession(data.session.id); }
-      } catch (e) { console.warn("신점 세션 생성 실패 (상담은 계속 진행):", e); }
-    };
-    initSession();
-
-    setMood("default");
-    addChatMessage({
-      id: crypto.randomUUID(), role: "character",
-      content: getCharacterGreeting(character, useLocaleStore.getState().locale) + "\n\n" + getWaitingLinesData(useLocaleStore.getState().locale).shinjeomInitialPrompt,
-      mood: "default", timestamp: new Date(),
-    });
-  }, [topic, characterId, character, router, sessionCreated, setSessionId, setMood, addChatMessage]);
-
-  // 새 메시지 추가 시에만 컨테이너 내부 스크롤 (윈도우 스크롤 방지)
-  const chatContainerRef = useRef<HTMLDivElement>(null);
-  const messageCountRef = useRef(0);
-  useEffect(() => {
-    if (chatMessages.length !== messageCountRef.current) {
-      messageCountRef.current = chatMessages.length;
-      const container = chatContainerRef.current;
-      if (container) {
-        container.scrollTop = container.scrollHeight;
-      }
-    }
-  }, [chatMessages.length]);
-
-  useEffect(() => {
-    return () => { readingAbortRef.current?.abort(); };
-  }, []);
-
-  const handleSend = () => {
-    const message = inputText.trim();
-    if (!message || isLoading) return;
-
-    setInputText("");
-    setLoading(true);
-    setMood("mystical");
-
-    const messageIndex = useShinjeomSessionStore.getState().chatMessages.length;
-    addChatMessage({ id: crypto.randomUUID(), role: "user", content: message, timestamp: new Date() });
-    incrementTurn();
-
-    const msgId = crypto.randomUUID();
-    addChatMessage({ id: msgId, role: "character", content: "", mood: "mystical", timestamp: new Date() });
-
-    const abortController = new AbortController();
-    readingAbortRef.current?.abort();
-    readingAbortRef.current = abortController;
-    let finished = false;
-
-    const timeoutId = setTimeout(() => {
-      if (finished) return;
-      finished = true;
-      abortController.abort();
-      updateMessageContent(msgId, getErrorMsg(characterId, "api", locale));
-      setMood("default");
-      setLoading(false);
-    }, 240_000);
-
-    void fetchSSEStream({
-      url: "/api/shinjeom/message",
-      signal: abortController.signal,
-      body: {
-        sessionId: useShinjeomSessionStore.getState().sessionId,
-        topic, characterId,
-        userInfo: useShinjeomSessionStore.getState().userInfo,
-        currentMessage: message,
-        chatHistory: useShinjeomSessionStore.getState().chatMessages,
-        isFinalTurn: false,
-        messageIndex,
-      },
-      onChunk: (_chunk, fullText) => {
-        updateMessageContent(msgId, fullText);
-      },
-      onDone: () => {
-        if (finished) return;
-        finished = true;
-        clearTimeout(timeoutId);
-        setLoading(false);
-      },
-      onError: () => {
-        if (finished) return;
-        finished = true;
-        clearTimeout(timeoutId);
-        updateMessageContent(msgId, getErrorMsg(characterId, "reading", locale));
-        setMood("default");
-        setLoading(false);
-      },
-    }).then(() => {
-      if (!finished) clearTimeout(timeoutId);
-    });
-  };
-
-  const handleEndConsultation = () => {
-    if (turnCount < 1 || isLoading) return;
-
-    setLoading(true);
-    setMood("mystical");
-
-    const currentChatMessages = useShinjeomSessionStore.getState().chatMessages;
-    const msgId = crypto.randomUUID();
-    addChatMessage({
-      id: msgId, role: "character",
-      content: translate("shinjeom.session.msg.preparing-result", locale),
-      mood: "mystical", timestamp: new Date(),
-    });
-
-    const abortController = new AbortController();
-    readingAbortRef.current?.abort();
-    readingAbortRef.current = abortController;
-    let finished = false;
-
-    const timeoutId = setTimeout(() => {
-      if (finished) return;
-      finished = true;
-      abortController.abort();
-      updateMessageContent(msgId, getErrorMsg(characterId, "reading", locale));
-      setMood("default");
-      setLoading(false);
-    }, 240_000);
-
-    void fetchSSEStream({
-      url: "/api/shinjeom/message",
-      signal: abortController.signal,
-      body: {
-        sessionId: useShinjeomSessionStore.getState().sessionId,
-        topic, characterId,
-        userInfo: useShinjeomSessionStore.getState().userInfo,
-        currentMessage: undefined,
-        chatHistory: currentChatMessages,
-        isFinalTurn: true,
-        messageIndex: currentChatMessages.length,
-      },
-      onChunk: () => { /* 신점 최종 결과는 done 이벤트로 수신 */ },
-      onDone: (data) => {
-        if (finished) return;
-        finished = true;
-        clearTimeout(timeoutId);
-        const result = data.result as { parseError?: string } | undefined;
-        if (!result) {
-          updateMessageContent(msgId, getErrorMsg(characterId, "reading", locale));
-          setMood("default");
-          setLoading(false);
-          return;
-        }
-        // fallback_text — overallReading에 정제된 본문이 있으므로 결과 표시
-        if (
-          result.parseError === "invalid_json" ||
-          result.parseError === "missing_fields"
-        ) {
-          console.warn("[shinjeom-session] 결과 표시 불가:", { parseError: result.parseError });
-          updateMessageContent(msgId, getErrorMsg(characterId, "reading", locale));
-          setMood("default");
-          setLoading(false);
-          return;
-        }
-        removeMessage(msgId);
-        setReadingResult(data.result as Parameters<typeof setReadingResult>[0]);
-        setPhase("result");
-        setMood(CHARACTER_RESULT_MOODS[characterId ?? ""] ?? "smile");
-        setLoading(false);
-      },
-      onError: () => {
-        if (finished) return;
-        finished = true;
-        clearTimeout(timeoutId);
-        updateMessageContent(msgId, getErrorMsg(characterId, "reading", locale));
-        setMood("default");
-        setLoading(false);
-      },
-    }).then(() => {
-      if (!finished) clearTimeout(timeoutId);
-    });
-  };
-
-  const { activeTheme } = useThemeStore();
   if (!character) return null;
 
   return (

--- a/src/hooks/useSajuReading.ts
+++ b/src/hooks/useSajuReading.ts
@@ -1,0 +1,198 @@
+"use client";
+
+import { useEffect, useState, useRef } from "react";
+import { useRouter } from "next/navigation";
+import { fetchSSEStream } from "@/hooks/useSSEStream";
+import { ReadingResult } from "@/types/service";
+import { SajuResult } from "@/services/saju/saju-types";
+import { useSajuSessionStore } from "@/hooks/useSajuSession";
+import { useCharacterStore } from "@/hooks/useCharacter";
+import { getCharacterById } from "@/data/characters";
+import { CHARACTER_RESULT_MOODS } from "@/data/characters/waiting-lines";
+import { getWaitingLinesData } from "@/data/characters/waiting-lines-i18n";
+import { useLocaleStore } from "@/hooks/useLocaleStore";
+import { useT } from "@/i18n/useT";
+import { t as translate } from "@/i18n/translations";
+import type { Locale } from "@/i18n/config";
+import { useThemeStore } from "@/hooks/useTheme";
+import { rememberGuestSession } from "@/lib/guest-sessions";
+
+/** 사주 init 메시지 — name이 비어 있으면 locale별 prefix를 자동 제거 */
+function buildSajuInitMsg(name: string, charId: string | null, locale: Locale): string {
+  const key = charId === "miko" ? "saju.session.msg.init-formal" : "saju.session.msg.init-casual";
+  const template = translate(key, locale);
+  if (!name) {
+    return template
+      .replaceAll("{name}님의 ", "")
+      .replaceAll("{name}'s ", "")
+      .replaceAll("{name}様の ", "")
+      .replace("{name}", "");
+  }
+  return template.replace("{name}", name);
+}
+
+/**
+ * 사주 세션 페이지의 리딩 진행 로직을 캡슐화한 컨트롤러 훅.
+ * (이전에는 page.tsx 인라인이었으나 view/controller 분리를 위해 추출 — 동작은 verbatim 유지.)
+ */
+export function useSajuReading() {
+  const router = useRouter();
+  const locale = useLocaleStore((s) => s.locale);
+  const { t } = useT();
+  const { currentMood, setMood } = useCharacterStore();
+  const {
+    phase, topic, characterId, userInfo, timeRange, chatMessages, readingResult, sajuData, isLoading,
+    setPhase, setSessionId, addChatMessage, setReadingResult, setSajuData, setLoading,
+  } = useSajuSessionStore();
+
+  const character = characterId ? getCharacterById(characterId) : null;
+  const [readingError, setReadingError] = useState(false);
+  const [readingErrorReason, setReadingErrorReason] = useState<"timeout" | "generic">("generic");
+  const resultContainerRef = useRef<HTMLDivElement>(null);
+  const redirectedRef = useRef(false);
+  const readingAbortRef = useRef<AbortController | null>(null);
+
+  useEffect(() => {
+    if (!topic || !character || !userInfo || !timeRange) {
+      if (!redirectedRef.current) { redirectedRef.current = true; router.push("/saju"); }
+      return;
+    }
+
+    // 세션 생성
+    fetch("/api/saju/session", {
+      method: "POST", headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ topic, characterId }),
+    }).then(async (res) => {
+      if (!res.ok) return;
+      const data = await res.json();
+      if (data.session?.id) { setSessionId(data.session.id); rememberGuestSession(data.session.id); }
+    }).catch((e) => console.warn("사주 세션 생성 실패 (리딩은 계속 진행):", e));
+
+    setMood("default");
+    const initMsg = buildSajuInitMsg(userInfo.name || "", characterId, locale);
+    addChatMessage({ id: crypto.randomUUID(), role: "character",
+      content: initMsg, mood: "default", timestamp: new Date(),
+    });
+
+    startReading();
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []); // NOSONAR
+
+  const startReading = () => {
+    setLoading(true);
+    setReadingError(false);
+    setReadingErrorReason("generic");
+    const state = useSajuSessionStore.getState();
+
+    // 대기 대사
+    const charId = state.characterId || "seonhwa";
+    const wl = getWaitingLinesData(useLocaleStore.getState().locale);
+    const lines = wl.sajuWaitingLines[charId] || wl.defaultSajuWaitingLines;
+    const timers: ReturnType<typeof setTimeout>[] = [];
+    // CLAUDE.md 규칙: 대기 대사 중 표정 변경 금지 — setMood 호출 제거
+    lines.forEach((line, i) => {
+      timers.push(setTimeout(() => {
+        addChatMessage({ id: crypto.randomUUID(), role: "character", content: line.content, mood: line.mood, timestamp: new Date() });
+      }, (i + 1) * 3000));
+    });
+    const stopTimers = () => timers.forEach(clearTimeout);
+
+    // 클라이언트 hard timeout (240초). 서버 AI_TIMEOUT_MS와 동조 — full-fortune/includeMonthly(max_tokens
+    // 17000~20000)는 reasoning 흡수까지 200~400s 소요 가능. 120s/180s에서는 본문 잘림 빈발.
+    const abortController = new AbortController();
+    readingAbortRef.current = abortController;
+    let finished = false;
+    const timeoutId = setTimeout(() => {
+      if (finished) return;
+      finished = true;
+      abortController.abort();
+      stopTimers();
+      console.warn("[saju-session] 클라이언트 타임아웃 240s");
+      setMood("default");
+      setReadingErrorReason("timeout");
+      setReadingError(true);
+      setLoading(false);
+    }, 240_000);
+
+    void fetchSSEStream({
+      url: "/api/saju/reading",
+      signal: abortController.signal,
+      body: {
+        sessionId: state.sessionId, topic: state.topic,
+        timeRange: state.timeRange, includeMonthly: state.includeMonthly,
+        characterId: state.characterId, userInfo: state.userInfo,
+        freeQuestion: state.freeQuestion,
+      },
+      onChunk: () => { /* 사주는 스트리밍 표시 불필요 — 대기 연출 사용 */ },
+      onDone: (data) => {
+        if (finished) return;
+        finished = true;
+        clearTimeout(timeoutId);
+        stopTimers();
+        const result = data.result as ReadingResult | undefined;
+        if (!result) {
+          setMood("default"); setReadingError(true); setLoading(false);
+          return;
+        }
+
+        // 결과 표시 불가 — DB 저장도 차단된 상태이므로 사용자에게 재시도 안내
+        if (result.parseError) {
+          console.warn("[saju-session] 결과 표시 불가:", { parseError: result.parseError });
+          const errLines = (charId && wl.characterErrorLines[charId]) ? wl.characterErrorLines[charId] : wl.defaultErrorLines;
+          addChatMessage({ id: crypto.randomUUID(), role: "character",
+            content: errLines.reading, mood: "default", timestamp: new Date() });
+          setMood("default"); setReadingError(true); setLoading(false);
+          return;
+        }
+
+        setReadingResult(result);
+        if (data.sajuData) setSajuData(data.sajuData as SajuResult);
+        setPhase("result"); setMood(CHARACTER_RESULT_MOODS[state.characterId ?? ""] ?? "smile");
+        const doneMsg = state.characterId === "miko"
+          ? translate("saju.session.msg.complete-formal", locale)
+          : translate("saju.session.msg.complete-casual", locale);
+        addChatMessage({ id: crypto.randomUUID(), role: "character",
+          content: doneMsg, mood: "smile", timestamp: new Date() });
+        setLoading(false);
+      },
+      onError: (msg) => {
+        if (finished) return;
+        finished = true;
+        clearTimeout(timeoutId);
+        stopTimers();
+        console.error("사주 리딩 실패:", msg);
+        const errLines = (charId && wl.characterErrorLines[charId]) ? wl.characterErrorLines[charId] : wl.defaultErrorLines;
+        const errText = msg.includes("GROK_API_KEY") ? errLines.api : errLines.reading;
+        addChatMessage({ id: crypto.randomUUID(), role: "character",
+          content: errText, mood: "default", timestamp: new Date() });
+        setMood("default"); setReadingError(true); setLoading(false);
+      },
+    }).then(() => {
+      if (!finished) clearTimeout(timeoutId);
+    });
+
+    return () => { clearTimeout(timeoutId); abortController.abort(); };
+  };
+
+  useEffect(() => {
+    // 결과 스트리밍 시 컨테이너 내부만 하단 스크롤 (윈도우 스크롤 방지)
+    if (phase === "result") {
+      const container = resultContainerRef.current;
+      if (container) container.scrollTop = container.scrollHeight;
+    }
+  }, [chatMessages, phase]);
+
+  useEffect(() => {
+    return () => { readingAbortRef.current?.abort(); };
+  }, []);
+
+  const birthYear = userInfo ? Number.parseInt(userInfo.birthDate.split("-")[0]) : 2000;
+  const { activeTheme } = useThemeStore();
+
+  return {
+    locale, t, router,
+    phase, character, characterId, currentMood, chatMessages, readingResult, sajuData, isLoading,
+    readingError, readingErrorReason, setReadingError,
+    startReading, resultContainerRef, birthYear, activeTheme,
+  };
+}

--- a/src/hooks/useShinjeomChat.ts
+++ b/src/hooks/useShinjeomChat.ts
@@ -1,0 +1,259 @@
+"use client";
+
+import { useState, useRef, useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { useShinjeomSessionStore } from "@/hooks/useShinjeomSession";
+import { getCharacterById } from "@/data/characters";
+import { useCharacterStore } from "@/hooks/useCharacter";
+import { CHARACTER_RESULT_MOODS } from "@/data/characters/waiting-lines";
+import { getWaitingLinesData } from "@/data/characters/waiting-lines-i18n";
+import { getCharacterGreeting } from "@/data/characters/locale-helpers";
+import { useLocaleStore } from "@/hooks/useLocaleStore";
+import { useT } from "@/i18n/useT";
+import { t as translate } from "@/i18n/translations";
+import { fetchSSEStream } from "@/hooks/useSSEStream";
+import { useThemeStore } from "@/hooks/useTheme";
+import { rememberGuestSession } from "@/lib/guest-sessions";
+
+function getErrorMsg(charId: string | null | undefined, type: "api" | "reading", locale: string): string {
+  const wl = getWaitingLinesData(locale);
+  const lines = (charId && wl.characterErrorLines[charId]) || wl.defaultErrorLines;
+  return lines[type];
+}
+
+function updateMessageContent(msgId: string, content: string) {
+  useShinjeomSessionStore.setState((state) => ({
+    chatMessages: state.chatMessages.map((m) =>
+      m.id === msgId ? { ...m, content } : m
+    ),
+  }));
+}
+
+function removeMessage(msgId: string) {
+  useShinjeomSessionStore.setState((state) => ({
+    chatMessages: state.chatMessages.filter((m) => m.id !== msgId),
+  }));
+}
+
+/**
+ * 신점 세션 페이지의 대화·최종리딩 진행 로직을 캡슐화한 컨트롤러 훅.
+ * (이전에는 page.tsx 인라인이었으나 view/controller 분리를 위해 추출 — 동작은 verbatim 유지.)
+ */
+export function useShinjeomChat() {
+  const router = useRouter();
+  const locale = useLocaleStore((s) => s.locale);
+  const { t } = useT();
+  const {
+    phase, topic, characterId, chatMessages, turnCount, readingResult, isLoading,
+    addChatMessage, incrementTurn, setReadingResult, setLoading, setPhase, setSessionId, reset,
+  } = useShinjeomSessionStore();
+  const { setMood, currentMood } = useCharacterStore();
+
+  const character = characterId ? getCharacterById(characterId) : null;
+  const [inputText, setInputText] = useState("");
+  const [sessionCreated, setSessionCreated] = useState(false);
+  const [showEnergyEffect, setShowEnergyEffect] = useState(true);
+  const redirectedRef = useRef(false);
+  const readingAbortRef = useRef<AbortController | null>(null);
+
+  // 세션 생성
+  useEffect(() => {
+    if (!topic || !character) {
+      if (!redirectedRef.current) { redirectedRef.current = true; router.push("/shinjeom"); }
+      return;
+    }
+    if (sessionCreated) return;
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setSessionCreated(true);
+
+    const initSession = async () => {
+      try {
+        const res = await fetch("/api/shinjeom/session", {
+          method: "POST", headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ topic, characterId }),
+        });
+        const data = await res.json();
+        if (data.session?.id) { setSessionId(data.session.id); rememberGuestSession(data.session.id); }
+      } catch (e) { console.warn("신점 세션 생성 실패 (상담은 계속 진행):", e); }
+    };
+    initSession();
+
+    setMood("default");
+    addChatMessage({
+      id: crypto.randomUUID(), role: "character",
+      content: getCharacterGreeting(character, useLocaleStore.getState().locale) + "\n\n" + getWaitingLinesData(useLocaleStore.getState().locale).shinjeomInitialPrompt,
+      mood: "default", timestamp: new Date(),
+    });
+  }, [topic, characterId, character, router, sessionCreated, setSessionId, setMood, addChatMessage]);
+
+  // 새 메시지 추가 시에만 컨테이너 내부 스크롤 (윈도우 스크롤 방지)
+  const chatContainerRef = useRef<HTMLDivElement>(null);
+  const messageCountRef = useRef(0);
+  useEffect(() => {
+    if (chatMessages.length !== messageCountRef.current) {
+      messageCountRef.current = chatMessages.length;
+      const container = chatContainerRef.current;
+      if (container) {
+        container.scrollTop = container.scrollHeight;
+      }
+    }
+  }, [chatMessages.length]);
+
+  useEffect(() => {
+    return () => { readingAbortRef.current?.abort(); };
+  }, []);
+
+  const handleSend = () => {
+    const message = inputText.trim();
+    if (!message || isLoading) return;
+
+    setInputText("");
+    setLoading(true);
+    setMood("mystical");
+
+    const messageIndex = useShinjeomSessionStore.getState().chatMessages.length;
+    addChatMessage({ id: crypto.randomUUID(), role: "user", content: message, timestamp: new Date() });
+    incrementTurn();
+
+    const msgId = crypto.randomUUID();
+    addChatMessage({ id: msgId, role: "character", content: "", mood: "mystical", timestamp: new Date() });
+
+    const abortController = new AbortController();
+    readingAbortRef.current?.abort();
+    readingAbortRef.current = abortController;
+    let finished = false;
+
+    const timeoutId = setTimeout(() => {
+      if (finished) return;
+      finished = true;
+      abortController.abort();
+      updateMessageContent(msgId, getErrorMsg(characterId, "api", locale));
+      setMood("default");
+      setLoading(false);
+    }, 240_000);
+
+    void fetchSSEStream({
+      url: "/api/shinjeom/message",
+      signal: abortController.signal,
+      body: {
+        sessionId: useShinjeomSessionStore.getState().sessionId,
+        topic, characterId,
+        userInfo: useShinjeomSessionStore.getState().userInfo,
+        currentMessage: message,
+        chatHistory: useShinjeomSessionStore.getState().chatMessages,
+        isFinalTurn: false,
+        messageIndex,
+      },
+      onChunk: (_chunk, fullText) => {
+        updateMessageContent(msgId, fullText);
+      },
+      onDone: () => {
+        if (finished) return;
+        finished = true;
+        clearTimeout(timeoutId);
+        setLoading(false);
+      },
+      onError: () => {
+        if (finished) return;
+        finished = true;
+        clearTimeout(timeoutId);
+        updateMessageContent(msgId, getErrorMsg(characterId, "reading", locale));
+        setMood("default");
+        setLoading(false);
+      },
+    }).then(() => {
+      if (!finished) clearTimeout(timeoutId);
+    });
+  };
+
+  const handleEndConsultation = () => {
+    if (turnCount < 1 || isLoading) return;
+
+    setLoading(true);
+    setMood("mystical");
+
+    const currentChatMessages = useShinjeomSessionStore.getState().chatMessages;
+    const msgId = crypto.randomUUID();
+    addChatMessage({
+      id: msgId, role: "character",
+      content: translate("shinjeom.session.msg.preparing-result", locale),
+      mood: "mystical", timestamp: new Date(),
+    });
+
+    const abortController = new AbortController();
+    readingAbortRef.current?.abort();
+    readingAbortRef.current = abortController;
+    let finished = false;
+
+    const timeoutId = setTimeout(() => {
+      if (finished) return;
+      finished = true;
+      abortController.abort();
+      updateMessageContent(msgId, getErrorMsg(characterId, "reading", locale));
+      setMood("default");
+      setLoading(false);
+    }, 240_000);
+
+    void fetchSSEStream({
+      url: "/api/shinjeom/message",
+      signal: abortController.signal,
+      body: {
+        sessionId: useShinjeomSessionStore.getState().sessionId,
+        topic, characterId,
+        userInfo: useShinjeomSessionStore.getState().userInfo,
+        currentMessage: undefined,
+        chatHistory: currentChatMessages,
+        isFinalTurn: true,
+        messageIndex: currentChatMessages.length,
+      },
+      onChunk: () => { /* 신점 최종 결과는 done 이벤트로 수신 */ },
+      onDone: (data) => {
+        if (finished) return;
+        finished = true;
+        clearTimeout(timeoutId);
+        const result = data.result as { parseError?: string } | undefined;
+        if (!result) {
+          updateMessageContent(msgId, getErrorMsg(characterId, "reading", locale));
+          setMood("default");
+          setLoading(false);
+          return;
+        }
+        // fallback_text — overallReading에 정제된 본문이 있으므로 결과 표시
+        if (
+          result.parseError === "invalid_json" ||
+          result.parseError === "missing_fields"
+        ) {
+          console.warn("[shinjeom-session] 결과 표시 불가:", { parseError: result.parseError });
+          updateMessageContent(msgId, getErrorMsg(characterId, "reading", locale));
+          setMood("default");
+          setLoading(false);
+          return;
+        }
+        removeMessage(msgId);
+        setReadingResult(data.result as Parameters<typeof setReadingResult>[0]);
+        setPhase("result");
+        setMood(CHARACTER_RESULT_MOODS[characterId ?? ""] ?? "smile");
+        setLoading(false);
+      },
+      onError: () => {
+        if (finished) return;
+        finished = true;
+        clearTimeout(timeoutId);
+        updateMessageContent(msgId, getErrorMsg(characterId, "reading", locale));
+        setMood("default");
+        setLoading(false);
+      },
+    }).then(() => {
+      if (!finished) clearTimeout(timeoutId);
+    });
+  };
+
+  const { activeTheme } = useThemeStore();
+
+  return {
+    locale, t, router,
+    phase, character, characterId, currentMood, chatMessages, turnCount, readingResult, isLoading, reset,
+    inputText, setInputText, showEnergyEffect, setShowEnergyEffect,
+    handleSend, handleEndConsultation, chatContainerRef, activeTheme,
+  };
+}


### PR DESCRIPTION
## 배경
#437(타로 532→257·설정 350→241)에 이은 B-5 마무리. 사주·신점 세션 페이지 분리.

## 접근 — 저위험 (DOM/셀렉터 불변)
로직을 훅으로 **verbatim 이동**. `data-testid="shinjeom-get-result-btn"` 등 E2E 셀렉터 보존.

- **사주**: 리딩진행(SSE·대기연출·240s 타임아웃) → `useSajuReading`. **page 331→160줄**
- **신점**: 대화·최종리딩 → `useShinjeomChat`. **page 411→178줄**
- 신규 훅 2개 `sonar.coverage/cpd.exclusions` + `CLAUDE.md` 갱신
- trivial 동작불변 정리: saju `replaceAll`·`Number.parseInt`

## 검증
- ✅ type-check / lint(0 errors, 신규 훅 경고 0) / **build 성공**
- DOM/JSX 불변 = E2E 셀렉터 영향 0 — **CI E2E로 세션 플로우 최종 검증**
- 마이그레이션 0

이로써 **세션 4개 페이지(타로·사주·신점·설정) 전부 <300줄**, view/controller 분리 완료.

🤖 Generated with [Claude Code](https://claude.com/claude-code)