### PR TITLE
chore(sonar): 커버리지 exclusions 드리프트 정정 — vitest include와 동기화

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -53,7 +53,6 @@ sonar.coverage.exclusions=\
   src/data/mbti.ts,\
   src/data/topics-meta.ts,\
   src/lib/share-utils.ts,\
-  src/lib/guest-sessions.ts,\
   src/lib/particle-engine.ts,\
   src/hooks/useTarotReading.ts,\
   src/hooks/useTarotCardSelection.ts,\
@@ -68,11 +67,9 @@ sonar.coverage.exclusions=\
   src/lib/supabase/storage.ts,\
   src/lib/auth/**,\
   src/lib/storage/**,\
-  src/lib/time-utils.ts,\
   src/lib/db/schema/**,\
   src/lib/db/types.ts,\
   src/lib/db/supabase-admin-adapter.ts,\
-  src/lib/db/reading-saver.ts,\
   src/services/core/ai-provider.ts,\
   src/services/saju/saju-types.ts,\
   src/i18n/LocaleProvider.tsx,\


### PR DESCRIPTION
## 배경
전체 잔여 작업 전수조사 중 발견한 **무해한 커버리지 설정 드리프트** 정정.

`time-utils.ts`·`guest-sessions.ts`·`reading-saver.ts` 3파일은 B-4 커버리지 점진 확장(PR #438)에서 `vitest.config.ts`의 `coverage.include`에 추가되어 이제 `lcov.info`에 포함된다. 그러나 `sonar-project.properties`의 `sonar.coverage.exclusions`에는 옛 항목이 남아 있어 SonarCloud가 이 3파일을 커버리지 분모에서 제외하던 드리프트가 있었다.

## 변경
- `sonar.coverage.exclusions`에서 3파일 제거(각각 테스트 존재 → 측정 대상).
- 파일 상단 주석의 불변식("아래 목록은 lcov.info에 없는 파일만 제외")과 정합화.
- `cpd.exclusions`의 `guest-sessions`·`time-utils`는 중복도(CPD) 목적이라 유지(커버리지와 무관).

## 영향
- 런타임/빌드/테스트 코드 변경 없음(SonarCloud CI 설정만).
- 세 파일 모두 커버리지 양호 → SonarCloud 전체 커버리지 % 유지 또는 소폭 상승. 신규 코드 없음 → PR Quality Gate `new_coverage` 무영향.

🤖 Generated with [Claude Code](https://claude.com/claude-code)