### PR TITLE
chore(security): .gitignore에 .env*.local 추가 — R2 자격증명 유출 방지

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ dist/
 
 # env
 .env
+.env*.local
 .env.local
 .env.development.local
 .env.test.local


### PR DESCRIPTION
## 배경
R2 스토리지 이전 **Phase 1**(사용자 담당)에서 루트 `.env.r2.local`에 R2 자격증명(`R2_ACCOUNT_ID`·`R2_ACCESS_KEY_ID`·`R2_SECRET_ACCESS_KEY`)을 기입한다. 그런데 기존 `.gitignore`는 `.env.local`·`.env.development.local`·`.env.test.local`·`.env.production.local` 개별 항목만 있고 **`.env.r2.local`을 커버하지 않아** 실수로 커밋 시 자격증명이 유출될 수 있다 (`git check-ignore .env.r2.local` → 미매칭 확인됨).

## 변경
`.env*.local` catch-all 1줄 추가 (Next.js 관용 패턴). `.env.r2.local` 뿐 아니라 향후 모든 `.env.<name>.local` 로컬 시크릿 파일을 선제 보호.

## 검증
- `git check-ignore -v .env.r2.local` → `.gitignore:14:.env*.local` 매칭 ✅
- 기존 `.env.local`·`.env.production.local`·`.env.staging.local` 여전히 보호 ✅
- 문서/코드 무변경, 런타임 무영향.

🤖 Generated with [Claude Code](https://claude.com/claude-code)