### PR TITLE
feat(storage): 카드/배경 자산 R2 전환 (NEXT_PUBLIC_ASSET_BASE_URL)

### DIFF
--- a/docs/operations/env-variables.md
+++ b/docs/operations/env-variables.md
@@ -5,7 +5,7 @@
 
 `src/lib/env.ts`의 getter 함수와 대응하는 전체 환경변수 목록입니다.
 환경변수는 코드에 하드코딩 금지 — 원칙적으로 `src/lib/env.ts`의 getter 함수를 통해 접근합니다.
-단, `NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_ANON_KEY`, `SUPABASE_SERVICE_ROLE_KEY`, `NEXT_PUBLIC_SITE_URL`은 Supabase 클라이언트 초기화 코드에서 `process.env.*`로 직접 접근합니다 (Next.js NEXT_PUBLIC_ 패턴 준수).
+단, `NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_ANON_KEY`, `SUPABASE_SERVICE_ROLE_KEY`, `NEXT_PUBLIC_SITE_URL`, `NEXT_PUBLIC_ASSET_BASE_URL`은 클라이언트/스토리지 초기화 코드에서 `process.env.*`로 직접 접근합니다 (Next.js NEXT_PUBLIC_ 패턴 준수).
 
 ---
 
@@ -31,6 +31,21 @@
 | `GROK_MODEL` | Grok 텍스트 생성 모델 | `grok-3` (CI 하드코딩값. `grok-4-fast-non-reasoning`은 reasoning 토큰 차단이 필요할 때의 선택적 대안) |
 | `GROK_REASONING_EFFORT` | Grok-3 계열 reasoning 노력 수준. `low`/`high`. 비-reasoning 모델은 무시됨 | `low` |
 | `ANTHROPIC_API_KEY` | Anthropic Claude API 키 (Grok 장애 시 자동 fallback) | 미설정 시 Grok 단독 사용 |
+
+---
+
+## 자산 CDN (선택 — Cloudflare R2)
+
+카드·배경 이미지(`card-styles` 버킷)의 서빙 베이스를 전환하는 선택 변수입니다. DB 모드와 무관하게 적용됩니다.
+
+| 변수 | 설명 | 기본값 |
+|------|------|--------|
+| `NEXT_PUBLIC_ASSET_BASE_URL` | 자산 CDN 루트. 설정 시 `{base}/card-styles/...`로 서빙(예: Cloudflare R2 커스텀 도메인). 미설정 시 Supabase Storage로 폴백 | 미설정(Supabase 사용) |
+
+- 예시: `NEXT_PUBLIC_ASSET_BASE_URL=https://cdn.xzawed.xyz`
+- `NEXT_PUBLIC_` 접두사라 **빌드 타임에 인라인**됩니다 → Railway에 설정 후 재배포해야 반영. 변수 제거 + 재배포로 즉시 Supabase 롤백.
+- 코드: [`src/lib/storage/card-style.ts`](../../src/lib/storage/card-style.ts) `storageBase()`, [`next.config.ts`](../../next.config.ts) `images.remotePatterns`(호스트 자동 파생).
+- 설계·이전 절차 정본: [`../superpowers/plans/2026-06-26-supabase-storage-r2-migration.md`](../superpowers/plans/2026-06-26-supabase-storage-r2-migration.md)
 
 ---
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -2,6 +2,19 @@ import type { NextConfig } from "next";
 
 const isDevelopment = process.env.NODE_ENV === "development";
 
+// NEXT_PUBLIC_ASSET_BASE_URL(R2 이전 시) 설정 시 그 호스트를 이미지 remotePatterns에 추가한다.
+// 미설정 시 Supabase 호스트만 허용(기존 동작). 카드 이미지는 unoptimized라 필수는 아니나
+// 최적화 경로(StyleSelector 등)를 안전하게 허용한다.
+const assetHost = (() => {
+  const base = process.env.NEXT_PUBLIC_ASSET_BASE_URL;
+  if (!base) return null;
+  try {
+    return new URL(base).hostname;
+  } catch {
+    return null;
+  }
+})();
+
 const securityHeaders = [
   {
     key: "Content-Security-Policy",
@@ -36,6 +49,9 @@ const nextConfig: NextConfig = {
         hostname: "*.supabase.co",
         pathname: "/storage/v1/object/public/**",
       },
+      ...(assetHost
+        ? [{ protocol: "https" as const, hostname: assetHost }]
+        : []),
     ],
     // Large transparent character PNGs can stall first-time AVIF optimization
     // in Chromium mobile runs. WebP keeps alpha support with steadier latency.

--- a/src/__tests__/lib/storage/card-style.test.ts
+++ b/src/__tests__/lib/storage/card-style.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import {
   getCardStyleImageUrl,
   getCardStyleBackUrl,
@@ -10,6 +10,8 @@ const BASE = `${SUPABASE_URL}/storage/v1/object/public/card-styles`;
 
 beforeAll(() => {
   process.env.NEXT_PUBLIC_SUPABASE_URL = SUPABASE_URL;
+  // 폴백(Supabase) 모드 테스트 격리 — R2 베이스가 설정돼 있으면 제거
+  delete process.env.NEXT_PUBLIC_ASSET_BASE_URL;
 });
 
 describe('getCardStyleImageUrl', () => {
@@ -78,5 +80,43 @@ describe('getServiceBackgroundUrl', () => {
     expect(getServiceBackgroundUrl('shinjeom', 'winter')).toBe(
       `${BASE}/backgrounds/shinjeom/winter.png`
     );
+  });
+});
+
+describe('NEXT_PUBLIC_ASSET_BASE_URL 설정 시 (R2/CDN 우선)', () => {
+  const ASSET_BASE = 'https://cdn.example.xyz';
+  const R2_BASE = `${ASSET_BASE}/card-styles`;
+
+  beforeAll(() => {
+    process.env.NEXT_PUBLIC_ASSET_BASE_URL = ASSET_BASE;
+  });
+  afterAll(() => {
+    delete process.env.NEXT_PUBLIC_ASSET_BASE_URL;
+  });
+
+  it('카드 이미지 URL이 자산 베이스를 사용한다', () => {
+    expect(getCardStyleImageUrl('dark-fantasy', 'major-00')).toBe(
+      `${R2_BASE}/cards/dark-fantasy/major/00.png`
+    );
+  });
+
+  it('카드 뒷면 URL이 자산 베이스를 사용한다', () => {
+    expect(getCardStyleBackUrl('anime-mystical')).toBe(
+      `${R2_BASE}/cards/anime-mystical/card-back.webp`
+    );
+  });
+
+  it('서비스 배경 URL이 자산 베이스를 사용한다', () => {
+    expect(getServiceBackgroundUrl('tarot', 'spring')).toBe(
+      `${R2_BASE}/backgrounds/tarot/spring.png`
+    );
+  });
+
+  it('베이스 끝 슬래시를 정규화한다 (이중 슬래시 방지)', () => {
+    process.env.NEXT_PUBLIC_ASSET_BASE_URL = `${ASSET_BASE}/`;
+    expect(getCardStyleBackUrl('dark-fantasy')).toBe(
+      `${R2_BASE}/cards/dark-fantasy/card-back.webp`
+    );
+    process.env.NEXT_PUBLIC_ASSET_BASE_URL = ASSET_BASE;
   });
 });

--- a/src/lib/storage/card-style.ts
+++ b/src/lib/storage/card-style.ts
@@ -10,7 +10,11 @@ function storageBase(): string {
   // 미설정 시 Supabase Storage로 폴백한다. env 토글만으로 즉시 롤백 가능.
   // 설계: docs/superpowers/plans/2026-06-26-supabase-storage-r2-migration.md
   const assetBase = process.env.NEXT_PUBLIC_ASSET_BASE_URL;
-  if (assetBase) return `${assetBase.replace(/\/+$/, '')}/${BUCKET}`;
+  if (assetBase) {
+    // 끝 슬래시 정규화(이중 슬래시 방지). 정규식 백트래킹 회피 위해 문자열 API 사용.
+    const base = assetBase.endsWith('/') ? assetBase.slice(0, -1) : assetBase;
+    return `${base}/${BUCKET}`;
+  }
   const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
   if (!url) throw new Error('NEXT_PUBLIC_SUPABASE_URL is not set');
   return `${url}/storage/v1/object/public/${BUCKET}`;

--- a/src/lib/storage/card-style.ts
+++ b/src/lib/storage/card-style.ts
@@ -6,6 +6,11 @@ const BUCKET = 'card-styles';
 type ServiceType = 'tarot' | 'saju' | 'shinjeom';
 
 function storageBase(): string {
+  // NEXT_PUBLIC_ASSET_BASE_URL(예: https://cdn.xzawed.xyz) 설정 시 R2/CDN 우선 사용,
+  // 미설정 시 Supabase Storage로 폴백한다. env 토글만으로 즉시 롤백 가능.
+  // 설계: docs/superpowers/plans/2026-06-26-supabase-storage-r2-migration.md
+  const assetBase = process.env.NEXT_PUBLIC_ASSET_BASE_URL;
+  if (assetBase) return `${assetBase.replace(/\/+$/, '')}/${BUCKET}`;
   const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
   if (!url) throw new Error('NEXT_PUBLIC_SUPABASE_URL is not set');
   return `${url}/storage/v1/object/public/${BUCKET}`;


### PR DESCRIPTION
## 배경
Supabase Storage 무료티어(1GB) 초과 — `card-styles` 버킷(카드아트+배경 ~1.98GB)이 원인. **데이터는 이미 Cloudflare R2로 무손실 이전 완료**(별도 진행: 351객체, `etag=md5` 351/351, 바이트 완전일치 `2,072,226,852`, `cdn.xzawed.xyz` GET 200 검증). 이 PR은 **앱 코드 스위치**만 담당한다.

## 변경
| 파일 | 내용 |
|---|---|
| [card-style.ts](src/lib/storage/card-style.ts) | `storageBase()`: `NEXT_PUBLIC_ASSET_BASE_URL` 설정 시 `{base}/card-styles`(R2/CDN), 미설정 시 Supabase 폴백. 끝 슬래시 정규화 |
| [next.config.ts](next.config.ts) | 자산 베이스 호스트를 env에서 동적 파생 → `images.remotePatterns`에 추가(미설정 시 Supabase만) |
| [env-variables.md](docs/operations/env-variables.md) | `NEXT_PUBLIC_ASSET_BASE_URL` 선택 변수 + 롤백 절차 문서화 |
| [card-style.test.ts](src/__tests__/lib/storage/card-style.test.ts) | R2 모드 4건 추가(URL·슬래시 정규화) + 폴백 격리 (8→**12개**) |

## 참조 감사 (Phase 6 삭제 안전성)
- `card-styles` 버킷 자산은 **전부 `storageBase()` 3헬퍼**(`getCardStyleImageUrl`·`getCardStyleBackUrl`·`getServiceBackgroundUrl`) 경유 — 하드코딩 Supabase URL **0건**. → env 분기 한 곳이 유일 스위치.
- 배경 jpg(`hero-bg`·`login-bg` 등 10개)는 **로컬 `public/images/backgrounds/`** 서빙 → 이전과 무관, Supabase 삭제 무영향.
- `lib/supabase/storage.ts`·`lib/storage/index.ts`는 **card-skins 버킷**(범위 밖) — 미변경.

## ⚠️ 머지 안전성 (리뷰 포인트)
**이 PR만으로는 R2로 전환되지 않습니다.** `NEXT_PUBLIC_ASSET_BASE_URL`(빌드타임 inline)을 **Railway에 설정 + 재배포**해야 반영됩니다. 미설정 시 동작 100% 동일(Supabase). 롤백 = 변수 제거 + 재배포.

## 검증
| 게이트 | 결과 |
|---|---|
| type-check | ✅ 0 |
| lint | ✅ 0 errors |
| card-style test | ✅ 12/12 |
| **R2 모드 build** (`NEXT_PUBLIC_ASSET_BASE_URL` 설정) | ✅ 성공 |
| check:env-docs / doc-links | ✅ 통과 |

정본: [2026-06-26-supabase-storage-r2-migration.md](docs/superpowers/plans/2026-06-26-supabase-storage-r2-migration.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)