### PR TITLE
docs: R2 자산 이전 완료 반영 — card-styles는 Cloudflare R2

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,7 +65,7 @@ src/
 │   └── (+ useLocaleStore, useGenderStore, useSkinStore, useFavoriteCharacter, useTheme, useSSEStream, useCardAnimation, useCharacter, useReducedMotionStore 등)
 ├── i18n/            # locale 감지, Provider, useT, translations
 ├── lib/             # env, auth, db, storage, validation, request/rate-limit 유틸
-│   ├── storage/card-style.ts  # getCardStyleImageUrl, getCardStyleBackUrl
+│   ├── storage/card-style.ts  # getCardStyleImageUrl·getCardStyleBackUrl·getServiceBackgroundUrl. card-styles 자산은 Cloudflare R2(cdn.xzawed.xyz), storageBase()가 NEXT_PUBLIC_ASSET_BASE_URL↔Supabase 폴백 분기
 │   ├── share-utils.ts         # shareWithUrl·shareWithText (3서비스 공통 공유 유틸)
 │   └── guest-sessions.ts      # 익명 세션 id localStorage 보관 (로그인 시 claim 대상)
 ├── services/        # core AI provider/fallback + tarot/saju/shinjeom 서비스

--- a/docs/conventions/image-assets.md
+++ b/docs/conventions/image-assets.md
@@ -67,19 +67,22 @@
 
 ---
 
-## 5. 카드 아트 스타일 이미지 (Supabase Storage)
+## 5. 카드 아트 스타일 이미지 (Cloudflare R2)
 
-AI 생성 타로 카드 이미지는 Supabase Storage `card-styles` 버킷에 저장된다.  
-SVG 스킨 이미지(`images/skins/`)와 **별개**의 독립 시스템이다.
+AI 생성 타로 카드 이미지·서비스 배경은 **Cloudflare R2**(`arcana-assets` 버킷, `card-styles/` prefix)에 저장되어 커스텀 도메인 `cdn.xzawed.xyz`로 서빙된다. SVG 스킨 이미지(`images/skins/`)와 **별개**의 독립 시스템이다.
 
-| 구분 | 경로 패턴 | 비고 |
+> **이전 이력**: 2026-07-03 이전에는 Supabase Storage `card-styles` 버킷 사용. 무료티어(1GB) 초과(~2GB, 100% 카드아트) 해소를 위해 R2로 **무손실 이전**(351객체, 바이트·md5 일치 검증, Supabase 원본 삭제 → 224MB로 복귀). 정본: [`../superpowers/plans/2026-06-26-supabase-storage-r2-migration.md`](../superpowers/plans/2026-06-26-supabase-storage-r2-migration.md).
+
+| 구분 | 서빙 URL 패턴 (`cdn.xzawed.xyz` 기준) | 비고 |
 |------|---------|------|
-| 카드 앞면 | `{styleId}/{suit}/{number}.png` | 4종 스타일 × 카드 수 (`.png`) |
-| 카드 뒷면 | `{styleId}/card-back.webp` | 스타일별 전용 뒷면 (`.webp`) |
+| 카드 앞면 | `card-styles/cards/{styleId}/{suit}/{number}.png` | 4종 스타일 × 카드 수 (`.png`) |
+| 카드 뒷면 | `card-styles/cards/{styleId}/card-back.webp` | 스타일별 전용 뒷면 (`.webp`) |
+| 서비스 배경 | `card-styles/backgrounds/{service}/{theme}.png` | 타로/사주/신점 × 테마 |
 
-- 이미지 URL은 `src/lib/storage/card-style.ts`의 `getCardStyleImageUrl()` / `getCardStyleBackUrl()`로 조회
-- 생성: `pnpm generate:assets` (Replicate API, REPLICATE_API_KEY 필요)
-- 업로드: `pnpm upload:assets` / `pnpm upload:assets:skip`
+- URL은 `src/lib/storage/card-style.ts`의 `getCardStyleImageUrl()` / `getCardStyleBackUrl()` / `getServiceBackgroundUrl()`로 조회. `storageBase()`가 `NEXT_PUBLIC_ASSET_BASE_URL`(설정 시 R2) ↔ Supabase(폴백)를 분기 → env 정본: [`../operations/env-variables.md`](../operations/env-variables.md).
+- 카드 `<Image>`는 `unoptimized`로 R2에서 직접 로드(옵티마이저 우회). `next.config.ts` `remotePatterns`가 자산 호스트를 env에서 자동 파생.
+- 생성: `pnpm generate:assets` (Replicate API, REPLICATE_API_KEY 필요).
+- ⚠️ 업로드: 기존 `pnpm upload:assets`는 **Supabase 대상**이다. 현재 정본은 R2이므로 **신규 카드 자산은 R2에도 업로드해야 앱에 반영**된다(전용 R2 업로드 스크립트는 후속 과제 — 이전 시 사용한 S3 API PUT 방식 재사용 가능).
 
 ---
 

--- a/docs/superpowers/plans/2026-06-26-supabase-storage-r2-migration.md
+++ b/docs/superpowers/plans/2026-06-26-supabase-storage-r2-migration.md
@@ -1,7 +1,9 @@
 # Supabase Storage → Cloudflare R2 이전 (card-styles) — WBS 실행 계획
 
-> 작성일: 2026-06-26 · 상태: **계획 확정, 실행 보류**(주간 토큰 회복 후 착수)
-> 목적: Supabase Storage 무료티어(1GB) 초과(현재 ~2.2GB)를 **화질 손실 0**으로 해소.
+> 작성일: 2026-06-26 · 상태: ✅ **전체 완료 (2026-07-03)**
+> 목적: Supabase Storage 무료티어(1GB) 초과(~2.2GB)를 **화질 손실 0**으로 해소.
+
+> **완료 요약 (2026-07-03)**: 전 Phase 완료. `cdn.xzawed.xyz`(R2 `arcana-assets`/`card-styles/`) 커스텀 도메인 연결 → 351객체 무손실 이전(etag=md5 351/351, 바이트 완전일치) → `card-style.ts` env 분기(PR #450) + Railway `NEXT_PUBLIC_ASSET_BASE_URL` 설정·재배포 → Playwright 실브라우저 검증(card-styles 27요청 전부 cdn/200) → Supabase card-styles 351개 삭제 → **총 용량 2.2GB→224MB 무료티어 복귀**. 앱 정본은 R2. ⚠️ `xzawed.xyz` 도메인 자체는 사용자의 별개 앱(CustomWebService)이고, ArcanaInsight 운영지는 `arcanainsight-production.up.railway.app` — `cdn.` 서브도메인만 R2 CDN으로 사용.
 
 ---
 


### PR DESCRIPTION
## 배경
Supabase Storage → Cloudflare R2 자산 이전(`card-styles`)이 **전체 완료**(6 Phase). 문서를 실제 상태로 정정한다.

## 검증된 결과 (참고)
- R2 351객체 무손실 이전 (etag=md5 351/351, 바이트 완전일치 `2,072,226,852`)
- 프로덕션 [arcanainsight-production.up.railway.app](https://arcanainsight-production.up.railway.app) Playwright 검증: card-styles **27요청 전부 cdn.xzawed.xyz/200**, DOM 41 img 로드, supabase 0
- Supabase card-styles 삭제 → 총 용량 **2.2GB → 224MB** 무료티어 복귀

## 변경
| 파일 | 내용 |
|---|---|
| [image-assets.md §5](docs/conventions/image-assets.md) | "Supabase Storage" → "Cloudflare R2". 서빙 URL 패턴(`card-styles/` prefix)·`storageBase()` env 분기·`unoptimized` 직접 로드·신규 자산 R2 업로드 주의·이전 이력 |
| [R2 이전 plan](docs/superpowers/plans/2026-06-26-supabase-storage-r2-migration.md) | 상태 "실행 보류" → **✅ 전체 완료(2026-07-03)** + 완료 요약 배너 |
| [CLAUDE.md](CLAUDE.md) | `card-style.ts` 라인에 R2·storageBase 분기 노트 |

> ⚠️ 문서에 명시: `xzawed.xyz`는 사용자의 **별개 앱(CustomWebService)** 도메인이고, ArcanaInsight 운영지는 `arcanainsight-production.up.railway.app`. `cdn.xzawed.xyz` 서브도메인만 R2 CDN으로 사용.

## 검증
`check:doc-links`·`check:env-docs` 통과. 코드 변경 없음(문서만).

🤖 Generated with [Claude Code](https://claude.com/claude-code)