### PR TITLE
feat(assets): 카드 자산 R2 도구 세트 — 스크립트·스킬·에이전트·가드 훅

### DIFF
--- a/.claude/agents/card-style-manager.md
+++ b/.claude/agents/card-style-manager.md
@@ -1,0 +1,83 @@
+---
+name: card-style-manager
+description: 카드 아트 스타일(4종)·카드 뒷면·서비스 배경 이미지를 Cloudflare R2 기준으로 추가/수정한다. "카드 아트 추가", "카드 이미지 수정", "새 카드 스타일", "서비스 배경 교체", "카드 배경 이미지" 등의 요청에 사용한다. (카드 스킨=skin-manager, 캐릭터=character-add와 별개)
+---
+
+# card-style-manager 에이전트
+
+ArcanaInsight의 **카드 아트 스타일·서비스 배경** 이미지를 관리한다. 2026-07-03 이후 이 자산들은 **Cloudflare R2**(`arcana-assets` 버킷, `card-styles/` prefix, `cdn.xzawed.xyz` 서빙)에 저장된다.
+
+> ⚠️ **범위 구분**: 카드 **스킨**(`card-skins` 버킷, Supabase)은 `skin-manager`. **캐릭터** 이미지는 `character-add`. 이 에이전트는 **카드 아트 스타일(4종)·카드 뒷면·서비스 배경**만 담당.
+
+## 참조 파일
+
+- `src/lib/storage/card-style.ts` — `getCardStyleImageUrl`/`getCardStyleBackUrl`/`getServiceBackgroundUrl`. `storageBase()`가 `NEXT_PUBLIC_ASSET_BASE_URL`(R2)↔Supabase(폴백) 분기
+- `src/data/cardStyles.ts` — `CardStyleId`(4종)·`THEME_TO_STYLE_MAP`
+- `src/components/card/CardFace.tsx` / `CardBack.tsx` — `unoptimized`로 R2 직접 로드
+- `scripts/generate-assets/` — 생성 오케스트레이터(`index.ts`·`config.ts`·`prompts.ts`)
+- `scripts/generate-assets/upload-to-r2.ts` — **R2 업로드(etag=md5 검증)** ← 정본 업로더
+- `scripts/generate-assets/upload-to-supabase.ts` — 구 Supabase 업로더(참고용, 정본 아님)
+- `docs/conventions/image-assets.md §5` — 자산 규칙 정본
+- `.claude/skills/add-card-asset/SKILL.md` — 절차 스킬
+
+## 자산 구조 (R2)
+
+```
+arcana-assets/ (R2, cdn.xzawed.xyz)
+└── card-styles/
+    ├── cards/{styleId}/
+    │   ├── card-back.webp                  # 뒷면
+    │   ├── major/{00..21}.png              # 메이저 22
+    │   └── {cups,wands,swords,pentacles}/{01..14}.png   # 마이너 56
+    └── backgrounds/
+        ├── {tarot,saju,shinjeom}/{theme}.png   # 서비스×테마 배경
+        └── deco/{styleId}.png                  # 스타일별 데코
+```
+- styleId 4종: `dark-fantasy`, `art-nouveau`, `anime-mystical`, `modern-digital`
+- 스타일당 79장(앞면 78 + 뒷면 1), 총 316 카드 + 배경 35 = 351
+
+## 사전 조건
+
+- 루트 `.env.r2.local`(gitignore): `R2_ACCOUNT_ID / R2_ACCESS_KEY_ID / R2_SECRET_ACCESS_KEY / R2_BUCKET`
+- `@aws-sdk/client-s3` devDependency (설치됨)
+
+## 절차
+
+### 1. 생성 (로컬)
+```bash
+pnpm generate:assets            # 카드/배경 (Replicate, REPLICATE_API_KEY)
+pnpm generate:service-bg        # 서비스 배경만
+```
+→ `public/images/cards` / `public/images/backgrounds`에 생성.
+
+### 2. 새 아트 스타일 추가 시 (4종 외)
+- `src/data/cardStyles.ts`: `CardStyleId` 유니온·스타일 배열·`THEME_TO_STYLE_MAP` 갱신
+- `scripts/generate-assets/config.ts`: `STYLE_IDS`에 추가
+- `pnpm type-check`로 타입 정합 확인
+
+### 3. R2 업로드 (정본)
+```bash
+pnpm upload:assets:r2           # 전량(upsert) — etag=md5 무결성 검증 내장
+pnpm upload:assets:r2:skip      # 기존 키 스킵
+```
+- ❌ `pnpm upload:assets`(Supabase)는 정본 아님 — 쓰지 말 것(PreToolUse 훅이 확인 요청)
+- 출력의 **"✅ 전 파일 ETag=md5 무결성 검증 통과"** 확인. 불일치 시 재업로드.
+
+### 4. 수정(덮어쓰기) 시 — 캐시 퍼지 필수 ⚠️
+R2 객체는 `Cache-Control: immutable`이라 **같은 키를 덮어써도 CDN이 구버전을 최대 1년 서빙**한다.
+→ Cloudflare 대시보드(`xzawed.xyz`) → Caching → **Purge Cache**로 해당 URL 퍼지(사용자 작업).
+
+### 5. 검증
+- `pnpm type-check` 0 error
+- `cdn.xzawed.xyz/card-styles/...` GET 200 (샘플)
+- 프로덕션 `arcanainsight-production.up.railway.app`에서 카드/배경 육안 (필요 시 Playwright)
+
+## 완료 체크리스트
+
+- [ ] `.env.r2.local` 자격증명 확인
+- [ ] 로컬 생성물 존재(`public/images/cards`·`backgrounds`)
+- [ ] (새 스타일) `cardStyles.ts`·`config.ts` 갱신 + `type-check` 통과
+- [ ] `pnpm upload:assets:r2` → **ETag=md5 전량 통과**
+- [ ] (수정 시) Cloudflare 캐시 퍼지 완료
+- [ ] cdn GET 200 + 프로덕션 육안 확인
+- [ ] `docs/conventions/image-assets.md §5`와 실제 자산 정합(신규 스타일/배경 반영)

--- a/.claude/rules/workflow.md
+++ b/.claude/rules/workflow.md
@@ -239,7 +239,8 @@ PR 머지 완료 후 반드시 수행:
 | 에이전트 | 사용 시점 |
 |---------|---------|
 | `character-add` | 새 캐릭터 추가 (backup-v2/ 백업 포함) |
-| `skin-manager` | 카드 스킨 추가·이미지 생성 (backup-v2/ 백업 포함) |
+| `skin-manager` | 카드 스킨 추가·이미지 생성 (backup-v2/ 백업 포함, Supabase card-skins) |
+| `card-style-manager` | 카드 아트 스타일(4종)·카드뒷면·서비스 배경 추가/수정 (Cloudflare R2, `upload:assets:r2`) |
 | `theme-creator` | 새 테마 추가 또는 기존 테마 색상 수정 |
 | `divination-scaffold` | 새 운세 서비스 추가 (sonar exclusions 동기화 포함) |
 | `page-builder` | 새 페이지 생성 |

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -14,6 +14,7 @@
       "Bash(pnpm add*)",
       "Bash(pnpm check:*)",
       "Bash(pnpm i18n:check)",
+      "Bash(pnpm upload:assets:r2*)",
       "Bash(git status*)",
       "Bash(git diff*)",
       "Bash(git log*)",
@@ -41,6 +42,17 @@
   },
   "hooks": {
     "PreToolUse": [
+      {
+        "matcher": "Bash(pnpm upload:assets*)",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PROJECT_DIR}/scripts/hooks/upload-assets-r2-guard.sh",
+            "timeout": 10,
+            "statusMessage": "카드 자산 업로드 대상 확인(Supabase vs R2)..."
+          }
+        ]
+      },
       {
         "matcher": "Bash(git push*)",
         "hooks": [

--- a/.claude/skills/add-card-asset/SKILL.md
+++ b/.claude/skills/add-card-asset/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: add-card-asset
+description: 카드 아트 스타일·카드 뒷면·서비스 배경 이미지를 추가/수정하는 절차를 안내한다. "카드 이미지 추가", "카드 아트 수정", "카드 배경 교체", "새 카드 스타일", "서비스 배경 이미지" 등의 요청에 사용한다.
+when_to_use: 카드 앞면/뒷면 아트, 타로·사주·신점 서비스 배경 이미지를 추가하거나 수정할 때. (카드 스킨=Supabase는 skin-manager, 캐릭터는 character-add로 별도)
+allowed-tools: Read Grep Bash(pnpm type-check) Bash(pnpm generate:assets*) Bash(pnpm upload:assets:r2*)
+---
+
+# 카드 아트·배경 이미지 추가/수정 절차 (Cloudflare R2)
+
+> **정본**: [`docs/conventions/image-assets.md §5`](../../../docs/conventions/image-assets.md) · [R2 이전 계획](../../../docs/superpowers/plans/2026-06-26-supabase-storage-r2-migration.md)
+
+## 시스템 구조 (2026-07-03 R2 이전 후)
+
+카드 아트 스타일·서비스 배경은 **Cloudflare R2**(`arcana-assets` 버킷, `card-styles/` prefix)에 저장되어 **`cdn.xzawed.xyz`** 로 서빙된다. Supabase Storage `card-styles`는 **비어 있음**(이전 완료).
+
+| 자산 | R2 서빙 URL | 로컬 생성 경로 |
+|------|------------|--------------|
+| 카드 앞면 | `cdn.xzawed.xyz/card-styles/cards/{styleId}/{suit}/{n}.png` | `public/images/cards/{styleId}/{suit}/{n}.png` |
+| 카드 뒷면 | `.../card-styles/cards/{styleId}/card-back.webp` | `public/images/cards/{styleId}/card-back.webp` |
+| 서비스 배경 | `.../card-styles/backgrounds/{service}/{theme}.png` | `public/images/backgrounds/{service}/{theme}.png` |
+
+- URL 빌더: [`src/lib/storage/card-style.ts`](../../../src/lib/storage/card-style.ts) `getCardStyleImageUrl` / `getCardStyleBackUrl` / `getServiceBackgroundUrl`. `storageBase()`가 `NEXT_PUBLIC_ASSET_BASE_URL`(R2) ↔ Supabase(폴백) 분기.
+- 카드 `<Image>`는 `unoptimized`로 R2 직접 로드.
+
+## ⚠️ 사전 조건
+
+- 루트 `.env.r2.local`(gitignore)에 `R2_ACCOUNT_ID / R2_ACCESS_KEY_ID / R2_SECRET_ACCESS_KEY / R2_BUCKET` 필요.
+- **`pnpm upload:assets`(Supabase)는 이제 정본 아님** → 반드시 **`pnpm upload:assets:r2`** 사용. (PreToolUse 훅이 오사용 시 확인 요청)
+
+## A. 이미지 추가
+
+1. **생성** — 로컬 `public/images/cards` / `backgrounds`에 파일 생성.
+   ```bash
+   pnpm generate:assets           # Replicate API (REPLICATE_API_KEY 필요)
+   # 또는 서비스 배경만: pnpm generate:service-bg
+   ```
+2. **새 아트 스타일**을 추가하는 경우(4종 외):
+   - [`src/data/cardStyles.ts`](../../../src/data/cardStyles.ts): `CardStyleId`·스타일 목록·`THEME_TO_STYLE_MAP` 갱신.
+   - `scripts/generate-assets/config.ts`: `STYLE_IDS` 갱신.
+3. **R2 업로드 (etag=md5 무결성 검증 내장)**:
+   ```bash
+   pnpm upload:assets:r2           # 전량(upsert)
+   pnpm upload:assets:r2:skip      # 기존 키 스킵
+   ```
+   → 출력의 "✅ 전 파일 ETag=md5 무결성 검증 통과" 확인.
+4. **검증**: `cdn.xzawed.xyz/card-styles/...` GET 200 + 프로덕션(`arcanainsight-production.up.railway.app`) 육안.
+
+## B. 이미지 수정 (기존 키 덮어쓰기) — 캐시 주의 ⚠️
+
+1. 로컬 파일 교체 후 `pnpm upload:assets:r2`로 **같은 키에 덮어쓰기**.
+2. **🚨 Cloudflare CDN 캐시 퍼지 필수** — R2 객체는 `Cache-Control: immutable`이라, 덮어써도 **CDN이 구버전을 최대 1년 서빙**한다.
+   - Cloudflare 대시보드 → `xzawed.xyz` → **Caching → Configuration → Purge Cache** → 해당 URL(들) 개별 퍼지, 또는 전체 퍼지.
+3. 퍼지 후 `cdn.xzawed.xyz/card-styles/...` 재요청으로 신버전 확인.
+   - **대안(권장 아님)**: 키에 버전 접미사(`...-v2.png`)를 쓰고 데이터/코드의 참조를 갱신하면 캐시 문제 회피 가능하나, URL 빌더 규칙(`card-style.ts`)이 고정 경로라 실효성 낮음 → 퍼지가 표준.
+
+## 검증 체크리스트
+
+- [ ] 로컬 `public/images/cards`·`backgrounds`에 생성물 존재
+- [ ] (새 스타일 시) `cardStyles.ts`·`config.ts` `STYLE_IDS` 갱신 + `pnpm type-check` 통과
+- [ ] `pnpm upload:assets:r2` 실행 → **ETag=md5 전량 통과**
+- [ ] (수정 시) **Cloudflare 캐시 퍼지 완료**
+- [ ] `cdn.xzawed.xyz/card-styles/...` GET 200 + 프로덕션 육안 확인
+
+## 복잡한 작업은 card-style-manager 에이전트 위임
+
+새 아트 스타일 전체(79장×배경) 추가·대량 교체는:
+
+```
+card-style-manager 에이전트를 호출해서 처리해줘
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,9 +121,13 @@ pnpm check:doc-links      # 문서 링크 검증
 pnpm i18n:check           # 번역 키 drift 검출
 pnpm generate:assets      # Replicate API로 카드/배경/데코 이미지 생성 (REPLICATE_API_KEY 필요)
 pnpm generate:assets:skip # 이미 존재하는 이미지 건너뛰고 생성
-pnpm upload:assets        # 생성된 이미지를 Supabase Storage에 업로드
-pnpm upload:assets:skip   # 이미 존재하는 이미지 건너뛰고 업로드
+pnpm upload:assets:r2     # 카드/배경을 Cloudflare R2에 업로드 (정본, etag=md5 검증, .env.r2.local 필요)
+pnpm upload:assets:r2:skip # R2에 이미 있는 키 건너뛰고 업로드
+pnpm upload:assets        # (구) Supabase Storage 업로드 — card-styles는 R2로 이전됨, 정본 아님
+pnpm upload:assets:skip   # (구) 이미 존재하는 이미지 건너뛰고 Supabase 업로드
 ```
+
+> 카드 아트·서비스 배경은 Cloudflare R2(`cdn.xzawed.xyz`) 서빙. 추가/수정 절차는 `add-card-asset` 스킬·`card-style-manager` 에이전트. 정본 [`docs/conventions/image-assets.md`](docs/conventions/image-assets.md).
 
 명령어 정책은 [`docs/workflow/scripts.md`](docs/workflow/scripts.md), 테스트 정책은 [`docs/workflow/unit-testing.md`](docs/workflow/unit-testing.md), [`docs/workflow/e2e-testing.md`](docs/workflow/e2e-testing.md)를 따른다.
 

--- a/docs/conventions/image-assets.md
+++ b/docs/conventions/image-assets.md
@@ -82,7 +82,9 @@ AI 생성 타로 카드 이미지·서비스 배경은 **Cloudflare R2**(`arcana
 - URL은 `src/lib/storage/card-style.ts`의 `getCardStyleImageUrl()` / `getCardStyleBackUrl()` / `getServiceBackgroundUrl()`로 조회. `storageBase()`가 `NEXT_PUBLIC_ASSET_BASE_URL`(설정 시 R2) ↔ Supabase(폴백)를 분기 → env 정본: [`../operations/env-variables.md`](../operations/env-variables.md).
 - 카드 `<Image>`는 `unoptimized`로 R2에서 직접 로드(옵티마이저 우회). `next.config.ts` `remotePatterns`가 자산 호스트를 env에서 자동 파생.
 - 생성: `pnpm generate:assets` (Replicate API, REPLICATE_API_KEY 필요).
-- ⚠️ 업로드: 기존 `pnpm upload:assets`는 **Supabase 대상**이다. 현재 정본은 R2이므로 **신규 카드 자산은 R2에도 업로드해야 앱에 반영**된다(전용 R2 업로드 스크립트는 후속 과제 — 이전 시 사용한 S3 API PUT 방식 재사용 가능).
+- **업로드(정본)**: `pnpm upload:assets:r2` — `public/images/cards`·`backgrounds` → R2(`card-styles/` 키, `Cache-Control: immutable`), 업로드 후 **ETag=md5 무결성 검증**. `.env.r2.local`에 R2 자격증명 필요. `:r2:skip`은 기존 키 스킵. (⚠️ 기존 `pnpm upload:assets`는 **Supabase 대상=정본 아님** — PreToolUse 훅이 오사용 시 확인 요청)
+- ⚠️ **수정(덮어쓰기) 시**: R2 객체가 `immutable` 캐시라 같은 키를 덮어써도 CDN이 구버전을 최대 1년 서빙 → **Cloudflare 캐시 퍼지 필수**.
+- 절차/에이전트: [`.claude/skills/add-card-asset/SKILL.md`](../../.claude/skills/add-card-asset/SKILL.md), `card-style-manager` 에이전트.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -39,6 +39,8 @@
     "generate:service-bg:skip": "npx tsx scripts/generate-service-backgrounds.ts --skip",
     "upload:assets": "npx tsx scripts/generate-assets/upload-to-supabase.ts",
     "upload:assets:skip": "npx tsx scripts/generate-assets/upload-to-supabase.ts --skip-existing",
+    "upload:assets:r2": "npx tsx scripts/generate-assets/upload-to-r2.ts",
+    "upload:assets:r2:skip": "npx tsx scripts/generate-assets/upload-to-r2.ts --skip-existing",
     "enhance:images": "node scripts/enhance-character-images.mjs",
     "polish:images": "python scripts/polish-character-images.py"
   },
@@ -58,6 +60,7 @@
   },
   "devDependencies": {
     "@anthropic-ai/sdk": "^0.92.0",
+    "@aws-sdk/client-s3": "^3.1079.0",
     "@playwright/test": "^1.59.1",
     "@tailwindcss/postcss": "^4",
     "@types/node": "^20",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
       '@anthropic-ai/sdk':
         specifier: ^0.92.0
         version: 0.92.0(zod@4.3.6)
+      '@aws-sdk/client-s3':
+        specifier: ^3.1079.0
+        version: 3.1079.0
       '@playwright/test':
         specifier: ^1.59.1
         version: 1.59.1
@@ -130,6 +133,78 @@ packages:
         optional: true
       nodemailer:
         optional: true
+
+  '@aws-sdk/checksums@3.1000.12':
+    resolution: {integrity: sha512-RgNDWfhNRIlNEzePIRrYTNi/6q+wwRMMapojn8YVzw4ZcJRa/gxVMtUbeZARR1gmopuv6oIhMbY7J66qIQ0ynw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/client-s3@3.1079.0':
+    resolution: {integrity: sha512-di9U/7Po7qlVYb2dq58ULsbBAE1pBIk53rux+50LQCvH1X+/l1Ys+BIk/QLBtdaK1nADk0xRNEBbA1QWVnMccw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/core@3.974.27':
+    resolution: {integrity: sha512-WRWEgIq6vx+NU6ot3VrRu4Jovj9MIObitSi6of/GV5THDDPccBhivCRNkWJutMM+m3GvdeI3l/UbGNcoOobxOA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-env@3.972.53':
+    resolution: {integrity: sha512-+KDA3uc/HZ1vIneGu5QMQb0gAXDYrm2vOE60+BJ7lS0YinMQ5i2oV4PR1A16XkF6K1IbSwjEHd1hQIIgMsK48w==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-http@3.972.55':
+    resolution: {integrity: sha512-1gBfkWY3RWeBlCoB9lIJjXMx45/54wxcgfzv6BY9otTmMrZPcNPi1v+MwZxxaCUg441NV3jsr1efnFNCXiW70g==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-ini@3.972.60':
+    resolution: {integrity: sha512-CV2md+PXvABwRjApWGhQ0wACy9WSFIhnUGrovLcjnjBCd/46TbuivLADtkF8IWNjtCQmQ+2IagSaxqBYqXBNAQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-login@3.972.59':
+    resolution: {integrity: sha512-JG4S9yyA1GFzJdJXqLKrUzZbyK+VDp2QIsJD7YOicJHAhqymfHpDJIok2dLnhOdVB0I37RjdC53uOwCMVS00gw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-node@3.972.62':
+    resolution: {integrity: sha512-S6Slq3Tx7bvFk5yc34XNADyZYTX2HUXvaFAnowGRQnhjBO8J/mP62Fn7lxvJwjaDyYm/7gh9h6HEHaltRyMFXw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-process@3.972.53':
+    resolution: {integrity: sha512-EhfH+MQlqOMCkXIVa8MMObPzAQqwTTtxA7KhEJiyPeuNVA8PLOOUpgK7nBrgaDaGiIDLN/9LpGdaHuDjomeRTw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-sso@3.972.59':
+    resolution: {integrity: sha512-h8793pOjcImx0SB+VcLONcaQQ57VAvKVuqyewQMRKqqH+CSXsG2dwOeLMUJPMxLdNvL7dXOM0ueTukyNUnu5mA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-web-identity@3.972.59':
+    resolution: {integrity: sha512-VoyO9+vl3XVmpZwn4obskrWIkrA/Jf3lSe1E3ZERlaN9u0D4YZ6+HywC3+L98QOXqZesEfedk67gRER8tK8+8w==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-sdk-s3@3.972.58':
+    resolution: {integrity: sha512-6uaWRRYJGhOqc9EoTSbLDf9nI/doSAb5vAwGshs5/Hlv5Ce25b246lBkbRd/77fLAi+uMI1a70mJzVyLyCEufQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/nested-clients@3.997.27':
+    resolution: {integrity: sha512-A8PIePF9NIIOJ/4Lg1rl9xm/+QaKkHGetq+Z9wb5B+3Da31YYXRo8n7IDMh5C+HQI5eyEmjrwkGWVdYtnLtbXQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/signature-v4-multi-region@3.996.38':
+    resolution: {integrity: sha512-C379Sk+MiFZCfWZphKlMyLHKxV22OjoGM5KJjj5IJNJcOCWL4IGIpnEGzv1FQiRwhYXfq55SJMfxlqPE08JJ9g==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/token-providers@3.1079.0':
+    resolution: {integrity: sha512-cbietrLlHPhhmbnMPTuDS4Zj/KNGhY+3vVhn6dwjO6Dqzrwothzg2srtcY34T9mlICsTXn34avDoWLHSntP54A==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/types@3.973.15':
+    resolution: {integrity: sha512-IULn8uBV/SMtmOIANsm4WHXIOtVPBWfOWs3WGL0j/sI+KhaYehvOw0ET+9urnn8MBpiijuU/0JOpuwKOE451PQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/xml-builder@3.972.33':
+    resolution: {integrity: sha512-ezbwz9WpuLctm6o7P2t2naDhVVPI5jFGrVefVybhcKGjU57VIyT46pQVO0RI2RYkUdhdj2Z9uSIlAzGZE9NW9A==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws/lambda-invoke-store@0.3.0':
+    resolution: {integrity: sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==}
+    engines: {node: '>=18.0.0'}
 
   '@babel/code-frame@7.29.7':
     resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
@@ -1136,6 +1211,30 @@ packages:
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
 
+  '@smithy/core@3.29.1':
+    resolution: {integrity: sha512-qoiY4nrk5OCu1+eIR1VB8l5DmON/oKiqrd5zZFAhXJXjJlLWQusKEW/SkBDAtGDcPaz86m9kfcE1lngU0GlM6A==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/credential-provider-imds@4.4.6':
+    resolution: {integrity: sha512-B2WQ/PV/H6Jeg3lrIq6bKUfa6Hy01mtK7CGs6lhjzHA6k4aagldH6T6eEjnzKl4HI0cJnAsxfJ19pgb5PV+CVQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/fetch-http-handler@5.6.3':
+    resolution: {integrity: sha512-CwCc/7SMTj45y97MUnDTbTaxvtAsiNNRm81z3abROIuMbMsC2Iy5EKfkkVdsKrz8WExQAAMx1EJapq+9j4fFTQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/node-http-handler@4.9.3':
+    resolution: {integrity: sha512-qZTa4gQFUo8RM02rk6q5UVTDLNrQ1oS20LsepBzqq1QBVc/EHJ03OOUADcqMZiXHArW+Y7+OGY0BpdTwZRq/Yg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/signature-v4@5.6.2':
+    resolution: {integrity: sha512-QgHflghMoPxCJ9axiCVh8KZfbC9fuP6vkXXyK//E3cq7nLaSSyyLj0GAoqVWezYeDQmXIZhmlRvLE16jsqDK6g==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/types@4.15.1':
+    resolution: {integrity: sha512-x3L0XSACF6UYzKpa9biqiRMgvH5+wnFFew9Tm/grFYqgaupPwx/+ojDPpPJM8dZON3S9tjz5U+PQYsCBd1Mw5Q==}
+    engines: {node: '>=18.0.0'}
+
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
@@ -1601,6 +1700,9 @@ packages:
     resolution: {integrity: sha512-Asa2krT+XTPZINCS+2QcyS8WTkObE77RwkydwF7h6DmnKqbvlalz93m/dnphUyCa6SWSP51VgtEUf2FN+gelFQ==}
     engines: {node: '>=6.0.0'}
     hasBin: true
+
+  bowser@2.14.1:
+    resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
 
   brace-expansion@1.1.13:
     resolution: {integrity: sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==}
@@ -3229,6 +3331,171 @@ snapshots:
       preact: 10.24.3
       preact-render-to-string: 6.5.11(preact@10.24.3)
 
+  '@aws-sdk/checksums@3.1000.12':
+    dependencies:
+      '@aws-sdk/core': 3.974.27
+      '@aws-sdk/types': 3.973.15
+      '@smithy/core': 3.29.1
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@aws-sdk/client-s3@3.1079.0':
+    dependencies:
+      '@aws-sdk/checksums': 3.1000.12
+      '@aws-sdk/core': 3.974.27
+      '@aws-sdk/credential-provider-node': 3.972.62
+      '@aws-sdk/middleware-sdk-s3': 3.972.58
+      '@aws-sdk/signature-v4-multi-region': 3.996.38
+      '@aws-sdk/types': 3.973.15
+      '@smithy/core': 3.29.1
+      '@smithy/fetch-http-handler': 5.6.3
+      '@smithy/node-http-handler': 4.9.3
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@aws-sdk/core@3.974.27':
+    dependencies:
+      '@aws-sdk/types': 3.973.15
+      '@aws-sdk/xml-builder': 3.972.33
+      '@aws/lambda-invoke-store': 0.3.0
+      '@smithy/core': 3.29.1
+      '@smithy/signature-v4': 5.6.2
+      '@smithy/types': 4.15.1
+      bowser: 2.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-env@3.972.53':
+    dependencies:
+      '@aws-sdk/core': 3.974.27
+      '@aws-sdk/types': 3.973.15
+      '@smithy/core': 3.29.1
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-http@3.972.55':
+    dependencies:
+      '@aws-sdk/core': 3.974.27
+      '@aws-sdk/types': 3.973.15
+      '@smithy/core': 3.29.1
+      '@smithy/fetch-http-handler': 5.6.3
+      '@smithy/node-http-handler': 4.9.3
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-ini@3.972.60':
+    dependencies:
+      '@aws-sdk/core': 3.974.27
+      '@aws-sdk/credential-provider-env': 3.972.53
+      '@aws-sdk/credential-provider-http': 3.972.55
+      '@aws-sdk/credential-provider-login': 3.972.59
+      '@aws-sdk/credential-provider-process': 3.972.53
+      '@aws-sdk/credential-provider-sso': 3.972.59
+      '@aws-sdk/credential-provider-web-identity': 3.972.59
+      '@aws-sdk/nested-clients': 3.997.27
+      '@aws-sdk/types': 3.973.15
+      '@smithy/core': 3.29.1
+      '@smithy/credential-provider-imds': 4.4.6
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-login@3.972.59':
+    dependencies:
+      '@aws-sdk/core': 3.974.27
+      '@aws-sdk/nested-clients': 3.997.27
+      '@aws-sdk/types': 3.973.15
+      '@smithy/core': 3.29.1
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-node@3.972.62':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.53
+      '@aws-sdk/credential-provider-http': 3.972.55
+      '@aws-sdk/credential-provider-ini': 3.972.60
+      '@aws-sdk/credential-provider-process': 3.972.53
+      '@aws-sdk/credential-provider-sso': 3.972.59
+      '@aws-sdk/credential-provider-web-identity': 3.972.59
+      '@aws-sdk/types': 3.973.15
+      '@smithy/core': 3.29.1
+      '@smithy/credential-provider-imds': 4.4.6
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-process@3.972.53':
+    dependencies:
+      '@aws-sdk/core': 3.974.27
+      '@aws-sdk/types': 3.973.15
+      '@smithy/core': 3.29.1
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-sso@3.972.59':
+    dependencies:
+      '@aws-sdk/core': 3.974.27
+      '@aws-sdk/nested-clients': 3.997.27
+      '@aws-sdk/token-providers': 3.1079.0
+      '@aws-sdk/types': 3.973.15
+      '@smithy/core': 3.29.1
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-web-identity@3.972.59':
+    dependencies:
+      '@aws-sdk/core': 3.974.27
+      '@aws-sdk/nested-clients': 3.997.27
+      '@aws-sdk/types': 3.973.15
+      '@smithy/core': 3.29.1
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-sdk-s3@3.972.58':
+    dependencies:
+      '@aws-sdk/core': 3.974.27
+      '@aws-sdk/signature-v4-multi-region': 3.996.38
+      '@aws-sdk/types': 3.973.15
+      '@smithy/core': 3.29.1
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@aws-sdk/nested-clients@3.997.27':
+    dependencies:
+      '@aws-sdk/core': 3.974.27
+      '@aws-sdk/signature-v4-multi-region': 3.996.38
+      '@aws-sdk/types': 3.973.15
+      '@smithy/core': 3.29.1
+      '@smithy/fetch-http-handler': 5.6.3
+      '@smithy/node-http-handler': 4.9.3
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@aws-sdk/signature-v4-multi-region@3.996.38':
+    dependencies:
+      '@aws-sdk/types': 3.973.15
+      '@smithy/signature-v4': 5.6.2
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@aws-sdk/token-providers@3.1079.0':
+    dependencies:
+      '@aws-sdk/core': 3.974.27
+      '@aws-sdk/nested-clients': 3.997.27
+      '@aws-sdk/types': 3.973.15
+      '@smithy/core': 3.29.1
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@aws-sdk/types@3.973.15':
+    dependencies:
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@aws-sdk/xml-builder@3.972.33':
+    dependencies:
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@aws/lambda-invoke-store@0.3.0': {}
+
   '@babel/code-frame@7.29.7':
     dependencies:
       '@babel/helper-validator-identifier': 7.29.7
@@ -3903,6 +4170,39 @@ snapshots:
 
   '@rtsao/scc@1.1.0': {}
 
+  '@smithy/core@3.29.1':
+    dependencies:
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@smithy/credential-provider-imds@4.4.6':
+    dependencies:
+      '@smithy/core': 3.29.1
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@smithy/fetch-http-handler@5.6.3':
+    dependencies:
+      '@smithy/core': 3.29.1
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@smithy/node-http-handler@4.9.3':
+    dependencies:
+      '@smithy/core': 3.29.1
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@smithy/signature-v4@5.6.2':
+    dependencies:
+      '@smithy/core': 3.29.1
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@smithy/types@4.15.1':
+    dependencies:
+      tslib: 2.8.1
+
   '@standard-schema/spec@1.1.0': {}
 
   '@supabase/auth-js@2.100.1':
@@ -4385,6 +4685,8 @@ snapshots:
     optional: true
 
   baseline-browser-mapping@2.10.29: {}
+
+  bowser@2.14.1: {}
 
   brace-expansion@1.1.13:
     dependencies:

--- a/scripts/generate-assets/upload-to-r2.ts
+++ b/scripts/generate-assets/upload-to-r2.ts
@@ -1,0 +1,191 @@
+/**
+ * 카드 아트 스타일·서비스 배경 이미지를 Cloudflare R2에 업로드한다.
+ *
+ * `public/images/cards` + `public/images/backgrounds`의 로컬 생성물을
+ * R2 버킷(`R2_BUCKET`)의 `card-styles/...` 키로 업로드하며, 각 파일마다
+ * 업로드 후 ETag(단일 PUT=md5)와 로컬 md5를 대조해 무결성을 검증한다.
+ *
+ * 자격증명은 루트 `.env.r2.local`(gitignore)에서 로드:
+ *   R2_ACCOUNT_ID / R2_ACCESS_KEY_ID / R2_SECRET_ACCESS_KEY / R2_BUCKET
+ *
+ * 사용:
+ *   pnpm upload:assets:r2            # 전량 업로드(upsert)
+ *   pnpm upload:assets:r2:skip       # R2에 이미 있는 키는 건너뜀
+ *
+ * ⚠️ 기존 키를 덮어쓴 경우(수정), Cloudflare CDN이 immutable 캐시로
+ *    구버전을 계속 서빙한다 → cdn 커스텀 도메인에서 해당 URL 캐시 퍼지 필요.
+ *
+ * 정본: docs/conventions/image-assets.md §5,
+ *       docs/superpowers/plans/2026-06-26-supabase-storage-r2-migration.md
+ */
+import { config } from 'dotenv';
+config({ path: '.env.r2.local' });
+
+import * as fs from 'fs';
+import * as path from 'path';
+import * as crypto from 'crypto';
+import { S3Client, PutObjectCommand, HeadObjectCommand } from '@aws-sdk/client-s3';
+import { ProgressTracker, runConcurrent } from './progress';
+
+const DEST_PREFIX = 'card-styles'; // R2 키 = card-styles/<storagePath>
+const CONCURRENT_UPLOADS = 6;
+const SKIP_EXISTING = process.argv.includes('--skip-existing');
+
+const CARDS_DIR = 'public/images/cards';
+const BACKGROUNDS_DIR = 'public/images/backgrounds';
+
+function getR2() {
+  const { R2_ACCOUNT_ID, R2_ACCESS_KEY_ID, R2_SECRET_ACCESS_KEY, R2_BUCKET } = process.env;
+  if (!R2_ACCOUNT_ID || !R2_ACCESS_KEY_ID || !R2_SECRET_ACCESS_KEY || !R2_BUCKET) {
+    throw new Error(
+      '.env.r2.local에 R2_ACCOUNT_ID / R2_ACCESS_KEY_ID / R2_SECRET_ACCESS_KEY / R2_BUCKET가 필요합니다.',
+    );
+  }
+  const client = new S3Client({
+    region: 'auto',
+    endpoint: `https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com`,
+    credentials: { accessKeyId: R2_ACCESS_KEY_ID, secretAccessKey: R2_SECRET_ACCESS_KEY },
+  });
+  return { client, bucket: R2_BUCKET };
+}
+
+interface UploadTarget {
+  localPath: string;
+  storagePath: string; // card-styles/ prefix 제외한 상대 키
+}
+
+function collectCardTargets(): UploadTarget[] {
+  const targets: UploadTarget[] = [];
+  if (!fs.existsSync(CARDS_DIR)) return targets;
+
+  for (const styleId of fs.readdirSync(CARDS_DIR)) {
+    const styleDir = path.join(CARDS_DIR, styleId);
+    if (!fs.statSync(styleDir).isDirectory()) continue;
+
+    for (const item of fs.readdirSync(styleDir)) {
+      const itemPath = path.join(styleDir, item);
+      const stat = fs.statSync(itemPath);
+      if (stat.isDirectory()) {
+        for (const file of fs.readdirSync(itemPath)) {
+          if (!file.endsWith('.png') && !file.endsWith('.webp')) continue;
+          targets.push({ localPath: path.join(itemPath, file), storagePath: `cards/${styleId}/${item}/${file}` });
+        }
+      } else if (item.endsWith('.png') || item.endsWith('.webp')) {
+        targets.push({ localPath: itemPath, storagePath: `cards/${styleId}/${item}` });
+      }
+    }
+  }
+  return targets;
+}
+
+function collectBackgroundTargets(): UploadTarget[] {
+  const targets: UploadTarget[] = [];
+  if (!fs.existsSync(BACKGROUNDS_DIR)) return targets;
+
+  function walk(dir: string, prefix: string): void {
+    for (const item of fs.readdirSync(dir)) {
+      const fullPath = path.join(dir, item);
+      const stat = fs.statSync(fullPath);
+      if (stat.isDirectory()) {
+        walk(fullPath, `${prefix}/${item}`);
+      } else if (item.endsWith('.png') || item.endsWith('.webp') || item.endsWith('.jpg')) {
+        targets.push({ localPath: fullPath, storagePath: `backgrounds${prefix}/${item}` });
+      }
+    }
+  }
+  walk(BACKGROUNDS_DIR, '');
+  return targets;
+}
+
+function contentTypeFor(p: string): string {
+  const ext = path.extname(p).slice(1).toLowerCase();
+  if (ext === 'png') return 'image/png';
+  if (ext === 'jpg' || ext === 'jpeg') return 'image/jpeg';
+  return 'image/webp';
+}
+
+async function keyExists(client: S3Client, bucket: string, key: string): Promise<boolean> {
+  try {
+    await client.send(new HeadObjectCommand({ Bucket: bucket, Key: key }));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function uploadOne(client: S3Client, bucket: string, t: UploadTarget): Promise<boolean> {
+  const buf = fs.readFileSync(t.localPath);
+  const md5 = crypto.createHash('md5').update(buf).digest('hex').toLowerCase();
+  const key = `${DEST_PREFIX}/${t.storagePath}`;
+  const res = await client.send(
+    new PutObjectCommand({
+      Bucket: bucket,
+      Key: key,
+      Body: buf,
+      ContentType: contentTypeFor(t.localPath),
+      CacheControl: 'public, max-age=31536000, immutable',
+    }),
+  );
+  const etag = (res.ETag ?? '').replace(/"/g, '').toLowerCase();
+  return etag === md5; // 단일 PUT ETag == 콘텐츠 md5 → 바이트 무결성
+}
+
+async function main(): Promise<void> {
+  console.log('=== Cloudflare R2 업로드 시작 ===');
+  const { client, bucket } = getR2();
+  console.log(`버킷: ${bucket} · prefix: ${DEST_PREFIX}/ · 기존 스킵: ${SKIP_EXISTING}`);
+
+  const allTargets = [...collectCardTargets(), ...collectBackgroundTargets()];
+  console.log(`\n총 대상: ${allTargets.length}개 (cards + backgrounds)`);
+  if (allTargets.length === 0) {
+    console.log(`업로드할 파일이 없습니다. ${CARDS_DIR} / ${BACKGROUNDS_DIR}에 생성물이 있는지 확인하세요.`);
+    return;
+  }
+
+  let toUpload = allTargets;
+  if (SKIP_EXISTING) {
+    console.log('R2 기존 키 확인 중...');
+    const flags = await Promise.all(
+      allTargets.map((t) => keyExists(client, bucket, `${DEST_PREFIX}/${t.storagePath}`)),
+    );
+    toUpload = allTargets.filter((_, i) => !flags[i]);
+    console.log(`스킵: ${allTargets.length - toUpload.length}개 | 업로드 예정: ${toUpload.length}개`);
+    if (toUpload.length === 0) return;
+  }
+
+  const tracker = new ProgressTracker(toUpload.length);
+  const etagMismatch: string[] = [];
+  console.log('업로드 시작...\n');
+
+  const tasks = toUpload.map((t) => async () => {
+    try {
+      const ok = await uploadOne(client, bucket, t);
+      if (!ok) etagMismatch.push(t.storagePath);
+      tracker.tick(ok, t.storagePath);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      process.stderr.write(`\nERROR [${t.storagePath}]: ${msg}\n`);
+      tracker.tick(false, t.storagePath);
+    }
+  });
+
+  await runConcurrent(tasks, CONCURRENT_UPLOADS);
+  tracker.summary();
+
+  if (etagMismatch.length > 0) {
+    process.stderr.write(`\n⚠️ ETag≠md5 (무결성 확인 필요) ${etagMismatch.length}개:\n`);
+    etagMismatch.slice(0, 20).forEach((k) => process.stderr.write(`   ${k}\n`));
+    process.exitCode = 1;
+  } else {
+    console.log('\n✅ 전 파일 ETag=md5 무결성 검증 통과');
+  }
+
+  const base = process.env.NEXT_PUBLIC_ASSET_BASE_URL ?? '(NEXT_PUBLIC_ASSET_BASE_URL 미설정)';
+  console.log(`\nCDN base: ${base}/${DEST_PREFIX}`);
+  console.log('⚠️ 기존 키를 덮어썼다면 Cloudflare에서 해당 URL 캐시 퍼지 필요(immutable 캐시).');
+}
+
+main().catch((err) => {
+  console.error('업로드 중 치명적 오류:', err);
+  process.exit(1);
+});

--- a/scripts/hooks/upload-assets-r2-guard.sh
+++ b/scripts/hooks/upload-assets-r2-guard.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# PreToolUse 가드: 카드 아트(card-styles)는 2026-07-03 Cloudflare R2로 이전됨.
+# `pnpm upload:assets`(:r2 없음)는 이제 정본 아닌 Supabase 대상이라, 카드/배경을
+# R2에 반영하려면 `pnpm upload:assets:r2`를 써야 한다. 오사용 시 사용자에게 확인을 요청한다.
+#
+# 매처는 `Bash(pnpm upload:assets*)` — r2 변형까지 포함되므로, 여기서 명령에
+# `:r2`가 없을 때만 경고한다. stdin의 PreToolUse JSON을 raw grep으로 판별(파서 무의존).
+set -euo pipefail
+
+input="$(cat)"
+
+if printf '%s' "$input" | grep -q "upload:assets" && ! printf '%s' "$input" | grep -q "upload:assets:r2"; then
+  cat <<'JSON'
+{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"ask","permissionDecisionReason":"⚠️ 카드 아트(card-styles)는 Cloudflare R2로 이전됨(2026-07-03). `pnpm upload:assets`는 이제 정본이 아닌 Supabase Storage 대상입니다.\n→ 카드 앞면/뒷면/서비스 배경을 실서비스에 반영하려면 `pnpm upload:assets:r2`(또는 :skip)를 사용하세요.\n정본: docs/conventions/image-assets.md §5. Supabase 업로드가 정말 의도한 작업이면 그대로 진행하세요."}}
+JSON
+fi
+
+exit 0


### PR DESCRIPTION
## 배경
R2 이전 완료 후, 향후 카드 아트/배경 **추가·수정** 시 `pnpm upload:assets`(Supabase, 이제 정본 아님)로 잘못 올릴 위험이 있었다. R2 업로드 경로를 표준화하고 오사용을 방지하는 도구 세트.

## 변경 (4종 + 문서)
| 항목 | 내용 |
|---|---|
| ① 스크립트 [upload-to-r2.ts](scripts/generate-assets/upload-to-r2.ts) | `public/images/cards`·`backgrounds` → R2(`card-styles/` 키, immutable 캐시). **업로드 후 ETag=md5 무결성 검증**. `pnpm upload:assets:r2` / `:skip`. `@aws-sdk/client-s3` devDep |
| ② 스킬 [add-card-asset](.claude/skills/add-card-asset/SKILL.md) | 카드 아트/배경 추가·수정 절차(생성→R2업로드→검증→**수정 시 캐시 퍼지**) |
| ③ 에이전트 [card-style-manager](.claude/agents/card-style-manager.md) | 카드 아트(4종)·배경 R2 관리 (skin-manager=스킨/Supabase와 별개) |
| ④ 가드 훅 [settings.json](.claude/settings.json) + [guard.sh](scripts/hooks/upload-assets-r2-guard.sh) | `pnpm upload:assets`(`:r2` 없음) 실행 시 "R2로 이전됨 → upload:assets:r2" 확인 요청 |
| 📄 문서 | image-assets.md §5·CLAUDE.md 명령어·workflow.md 에이전트 표 |

## 검증
| 게이트 | 결과 |
|---|---|
| type-check | ✅ 0 |
| lint | ✅ 0 errors |
| 훅 동작 | ✅ `upload:assets`→`ask`(경고), `upload:assets:r2`→통과 |
| settings.json 유효성 | ✅ valid JSON |
| check:doc-links | ✅ 통과 |

> ⚠️ 이 PR은 `.claude/settings.json`에 **PreToolUse 훅**을 추가합니다 (카드 자산 업로드 대상 가드). 프로덕션 런타임 무관, 앱 코드 무변경.

🤖 Generated with [Claude Code](https://claude.com/claude-code)