### PR TITLE
docs: R2 이전 파생 문서 드리프트 정정 (심층검증 반영)

### DIFF
--- a/.claude/rules/e2e-testing.md
+++ b/.claude/rules/e2e-testing.md
@@ -61,7 +61,7 @@ testId가 발견되면 새 컴포넌트에 동일한 testId를 유지하거나 E
 
 ## 외부 URL Image에 priority 금지
 
-Supabase Storage 등 외부 URL을 `src`로 쓰는 `<Image>`에는 **`priority` 속성을 붙이지 않는다.**
+Cloudflare R2/CDN(`cdn.xzawed.xyz`)·Supabase Storage 등 외부 URL을 `src`로 쓰는 `<Image>`에는 **`priority` 속성을 붙이지 않는다.**
 
 ```tsx
 // ❌ 금지 — <link rel="preload"> 가 window.load 를 블로킹

--- a/.claude/rules/workflow.md
+++ b/.claude/rules/workflow.md
@@ -86,7 +86,8 @@
    - 새 페이지: page-builder 에이전트
    - 새 캐릭터: character-add 에이전트
    - 새 DivinationService: divination-scaffold 에이전트
-   - 새 카드 스킨: skin-manager 에이전트
+   - 새 카드 스킨: skin-manager 에이전트 (Supabase card-skins)
+   - 새 카드 아트 스타일/서비스 배경: card-style-manager 에이전트 (Cloudflare R2, `upload:assets:r2`)
    - 새 테마 추가/색상 수정: theme-creator 에이전트
 
 4. 구현 (Codex 위임 가능)

--- a/docs/architecture/data-model.md
+++ b/docs/architecture/data-model.md
@@ -171,9 +171,10 @@ export interface EffectTheme {
 - `resolvedStyle(activeTheme)` — 최종 적용 스타일 ID 반환. 스킨 모드면 `null` 반환(consumer는 `?? undefined`로 변환해 `CardFace`/`CardBack`에 전달)
 - `persist` key: `'arcana-card-style'` (localStorage)
 
-**이미지 URL 헬퍼** (`src/lib/storage/card-style.ts`):
-- `getCardStyleImageUrl(styleId, cardId)` — Supabase Storage `card-styles` 버킷의 카드 앞면 URL
+**이미지 URL 헬퍼** (`src/lib/storage/card-style.ts`) — `storageBase()`가 `NEXT_PUBLIC_ASSET_BASE_URL`(설정 시 Cloudflare R2 `cdn.xzawed.xyz`) ↔ Supabase Storage(폴백)를 분기(DB_PROVIDER와 독립). `next.config.ts` remotePatterns가 자산 호스트를 env에서 동적 파생. **card-styles는 2026-07-03 R2로 무손실 이전, Supabase card-styles 버킷 삭제(0객체)** — 정본 [`../conventions/image-assets.md`](../conventions/image-assets.md) §5:
+- `getCardStyleImageUrl(styleId, cardId)` — 카드 앞면 URL (`{base}/card-styles/cards/{styleId}/{suit}/{n}.png`)
 - `getCardStyleBackUrl(styleId)` — 스타일별 카드 뒷면 URL (`card-back.webp`)
+- `getServiceBackgroundUrl(service, theme)` — 서비스 배경 URL (`backgrounds/{service}/{theme}.png`)
 
 ---
 

--- a/docs/architecture/system-overview.md
+++ b/docs/architecture/system-overview.md
@@ -44,7 +44,8 @@ ArcanaInsight의 3개 운세 서비스(타로·사주·신점) 사용자 흐름 
             └─ core/prompt-builder, text-cleaner, circuit-breaker
 
 데이터 레이어
-  ├─ Supabase (기본)     — Auth + PostgreSQL + Storage(card-styles 버킷)
+  ├─ Supabase (기본)     — Auth + PostgreSQL + Storage(card-skins 버킷, 팔레트 스킨)
+  ├─ Cloudflare R2       — card-styles 카드아트·서비스배경 (cdn.xzawed.xyz, NEXT_PUBLIC_ASSET_BASE_URL, 2026-07-03 이전)
   └─ PostgreSQL 모드     — NextAuth.js v5 + Drizzle (DB_PROVIDER=postgres 시)
 ```
 

--- a/docs/conventions/cross-platform.md
+++ b/docs/conventions/cross-platform.md
@@ -28,7 +28,7 @@ md:min-h-[calc(100dvh-3.5rem)]
 
 - **콘텐츠 페이지 래퍼에는 viewport 높이 min을 두지 않는다.** `body`(`min-h-dvh flex flex-col`) + `main`(`flex-1`) + `Footer`(`mt-auto`)의 sticky-footer 구조가 짧은 콘텐츠에서도 화면을 채우므로, 페이지 래퍼의 `min-h-screen`은 중복이며 위의 유령 스크롤을 유발한다.
 - **중앙정렬이 필요한 래퍼**(로그인 등)만 `min-h-[calc(100dvh-7rem)] md:min-h-[calc(100dvh-3.5rem)]`로 chrome을 차감해 채운다.
-- ⚠️ **`dvh` 기반 `min-height` + 외부 lazy 이미지 동거 금지 (E2E load 지연 회귀)**: `ServiceBackground`처럼 외부(Supabase) URL `loading="lazy"` 이미지를 렌더하는 페이지의 래퍼에 `min-h-[calc(100dvh-…)]`(dvh) 를 쓰면, lazy 이미지의 load 가 ~수십초 지연되어 Playwright `waitForLoadState("load")` 가 타임아웃한다(PR #428에서 `(immersive)` 진입 페이지·`PageSpinner` 적용 시 `navigation.spec.ts` 회귀로 확인). 외부 이미지 페이지는 **dvh 래퍼를 두지 말고** 스테이지 자체(`h-[calc(100dvh-7rem)]`)로 높이를 지배한다(몰입형 진입 페이지는 outer min-height **제거**로 해소 — PR #431, §6). 외부 lazy 이미지가 없는 페이지(중앙정렬 로그인=로컬 bg, `PageSpinner`)만 `min-h-[calc(100dvh-…)]` 허용.
+- ⚠️ **`dvh` 기반 `min-height` + 외부 lazy 이미지 동거 금지 (E2E load 지연 회귀)**: `ServiceBackground`처럼 외부(Cloudflare R2/CDN `cdn.xzawed.xyz`) URL `loading="lazy"` 이미지를 렌더하는 페이지의 래퍼에 `min-h-[calc(100dvh-…)]`(dvh) 를 쓰면, lazy 이미지의 load 가 ~수십초 지연되어 Playwright `waitForLoadState("load")` 가 타임아웃한다(PR #428에서 `(immersive)` 진입 페이지·`PageSpinner` 적용 시 `navigation.spec.ts` 회귀로 확인). 외부 이미지 페이지는 **dvh 래퍼를 두지 말고** 스테이지 자체(`h-[calc(100dvh-7rem)]`)로 높이를 지배한다(몰입형 진입 페이지는 outer min-height **제거**로 해소 — PR #431, §6). 외부 lazy 이미지가 없는 페이지(중앙정렬 로그인=로컬 bg, `PageSpinner`)만 `min-h-[calc(100dvh-…)]` 허용.
 
 ---
 

--- a/docs/operations/deployment.md
+++ b/docs/operations/deployment.md
@@ -71,6 +71,14 @@ git push origin main
 
 ---
 
+## 자산 서빙 (Cloudflare R2)
+
+- 카드 아트·카드 뒷면·서비스 배경(`card-styles`)은 **Cloudflare R2**에서 `NEXT_PUBLIC_ASSET_BASE_URL=https://cdn.xzawed.xyz` 기준으로 `unoptimized` 직접 서빙된다(2026-07-03 이전, Supabase 폴백). 프로덕션 `arcanainsight-production` 서비스에 설정됨.
+- `NEXT_PUBLIC_`은 빌드 타임 인라인 → 변경 시 **재빌드 필요**.
+- ⚠️ **자산 수정 배포**: 기존 R2 키를 덮어쓴 경우 `Cache-Control: immutable`이라 Cloudflare가 구버전을 계속 서빙 → 해당 URL **Cloudflare 캐시 퍼지 필요**. 업로드는 `pnpm upload:assets:r2`. 상세: [`../conventions/image-assets.md`](../conventions/image-assets.md) §5.
+
+---
+
 ## Rate-Limit Redis 활성화 (Upstash)
 
 현재 rate-limit은 서버 메모리 기반 fallback으로 동작합니다 (단일 인스턴스에서는 정상).

--- a/docs/operations/env-variables.md
+++ b/docs/operations/env-variables.md
@@ -36,15 +36,17 @@
 
 ## 자산 CDN (선택 — Cloudflare R2)
 
-카드·배경 이미지(`card-styles` 버킷)의 서빙 베이스를 전환하는 선택 변수입니다. DB 모드와 무관하게 적용됩니다.
+카드·배경 이미지의 서빙 베이스를 전환하는 선택 변수입니다. DB 모드와 무관하게 적용됩니다. **card-styles 카드아트·서비스배경은 2026-07-03 R2로 무손실 이전됐고, 프로덕션(`arcanainsight-production`)에는 설정돼 R2 서빙이 활성 상태입니다.**
 
 | 변수 | 설명 | 기본값 |
 |------|------|--------|
-| `NEXT_PUBLIC_ASSET_BASE_URL` | 자산 CDN 루트. 설정 시 `{base}/card-styles/...`로 서빙(예: Cloudflare R2 커스텀 도메인). 미설정 시 Supabase Storage로 폴백 | 미설정(Supabase 사용) |
+| `NEXT_PUBLIC_ASSET_BASE_URL` | 자산 CDN 루트. 설정 시 `{base}/card-styles/...`로 서빙 (R2 버킷 `arcana-assets`의 `card-styles/` prefix — `card-styles`는 Supabase 폴백 시에만 버킷명). 미설정 시 Supabase Storage로 폴백 | 코드 기본값 미설정 / **프로덕션은 `https://cdn.xzawed.xyz` 설정됨(R2 활성)** |
 
 - 예시: `NEXT_PUBLIC_ASSET_BASE_URL=https://cdn.xzawed.xyz`
-- `NEXT_PUBLIC_` 접두사라 **빌드 타임에 인라인**됩니다 → Railway에 설정 후 재배포해야 반영. 변수 제거 + 재배포로 즉시 Supabase 롤백.
-- 코드: [`src/lib/storage/card-style.ts`](../../src/lib/storage/card-style.ts) `storageBase()`, [`next.config.ts`](../../next.config.ts) `images.remotePatterns`(호스트 자동 파생).
+- `NEXT_PUBLIC_` 접두사라 **빌드 타임에 인라인**됩니다 → Railway에 설정 후 재배포해야 반영.
+- ⚠️ **롤백 주의**: 코드 폴백 경로는 존재하나 Supabase `card-styles` 버킷이 **삭제(2026-07-03, 0객체)**돼 변수만 제거하면 **전량 404**가 됩니다. Supabase로 롤백하려면 먼저 버킷에 자산을 재업로드해야 합니다(현 정본은 R2).
+- ⚠️ 자산 **수정(기존 키 덮어쓰기)** 시 R2 `immutable` 캐시로 인해 Cloudflare 캐시 퍼지 필요.
+- 코드: [`src/lib/storage/card-style.ts`](../../src/lib/storage/card-style.ts) `storageBase()`, [`next.config.ts`](../../next.config.ts) `images.remotePatterns`(호스트 자동 파생). 업로드: `pnpm upload:assets:r2`(`.env.r2.local` 자격증명).
 - 설계·이전 절차 정본: [`../superpowers/plans/2026-06-26-supabase-storage-r2-migration.md`](../superpowers/plans/2026-06-26-supabase-storage-r2-migration.md)
 
 ---
@@ -169,3 +171,4 @@ i18n 자체에는 신규 환경변수 없음 — 쿠키(`ai_locale`)와 헤더(`
 | 변수 | 설명 | 비고 |
 |------|------|------|
 | `REPLICATE_API_KEY` | Replicate API 인증 키 | 이미지 생성 스크립트(`generate:assets`) 실행 시 필수. 런타임에는 불필요. |
+| `R2_ACCOUNT_ID` / `R2_ACCESS_KEY_ID` / `R2_SECRET_ACCESS_KEY` / `R2_BUCKET` | Cloudflare R2 S3 자격증명 | 루트 `.env.r2.local`(gitignore)에서 로드. `pnpm upload:assets:r2` 실행 시 필수. 런타임에는 불필요(`NEXT_PUBLIC_` 아님). |

--- a/docs/operations/known-issues.md
+++ b/docs/operations/known-issues.md
@@ -54,7 +54,7 @@ Quality Gate: **PASSED** | Bugs: 0 | Vulnerabilities: 0 | CRITICAL: **0건**
 
 | Phase | 내용 | 상태 | 비고 |
 |-------|------|------|------|
-| Phase 1 | AI 생성 카드 이미지 (Replicate API) — 4종 스타일 × 78장 앞면 + 뒷면 | ✅ 완료 | 341장 생성 및 Supabase Storage(`card-styles` 버킷) 업로드 완료 (2026-05-14) |
+| Phase 1 | AI 생성 카드 이미지 (Replicate API) — 4종 스타일 × 78장 앞면 + 뒷면 | ✅ 완료 | 341장 생성·업로드 (2026-05-14). **이후 2026-07-03 Cloudflare R2(`arcana-assets/card-styles`, `cdn.xzawed.xyz`)로 무손실 이전, Supabase `card-styles` 버킷 삭제(PR #450~#452)** |
 | Phase 2 (카드 스타일) | `CardStyleSelector` UI, `useCardStyleStore`, `CardFace`/`CardBack` styleId 지원 | ✅ 완료 | 코드 구현 완료. 이미지 없으면 SVG fallback 렌더링 |
 | Phase 3 (카드 스타일) | 설정 페이지 CardStyleSelector 통합, SkinGallery 연동, 테마 자동 매핑 표시 | ✅ 완료 | `/settings` 카드 스킨 섹션에 11개 버튼 통합 |
 | Effect Phase 2 | 5-레이어 테마 이펙트 시스템 — `ThemeEffectEngine`, `ThemeAtmosphereLayer`, `InteractionClickParticles`, `theme-effects.css`, CSS variable 주입 | ✅ 완료 (PR #361) | 글로우·파티클·대기층·클릭 이펙트. `document.addEventListener` 방식으로 pointer-events 충돌 없음. PR #362(Phase 3)는 phase2 브랜치에 스택 후 PR #361로 main 통합 |

--- a/docs/workflow/scripts.md
+++ b/docs/workflow/scripts.md
@@ -10,6 +10,7 @@
 | 스크립트 | 호출 위치 | 용도 |
 |---|---|---|
 | `pre-push-checks.sh` | `.claude/settings.json` PreToolUse hook | `tsc --noEmit` + `eslint` + `next build` 통과 확인 후 push 허용 |
+| `hooks/upload-assets-r2-guard.sh` | `.claude/settings.json` PreToolUse `Bash(pnpm upload:assets*)` | `upload:assets`(`:r2` 없음=Supabase) 실행 시 "card-styles는 R2로 이전됨 → `upload:assets:r2` 사용" 확인 요청 |
 | `check-doc-links.ts` | `.github/workflows/docs-sync.yml` + `pnpm check:doc-links` | docs/ 내 상대 링크·앵커 검증, 깨진 링크 보고 |
 | `check-translation-keys.ts` | `.github/workflows/docs-sync.yml` + `pnpm i18n:check` | 번역 키 drift 검출 (ko/en/ja 동기화 검증) |
 | `e2e-full/orchestrator.ts` | `pnpm test:e2e:full` / `pnpm test:e2e:full:ci` | 252 조합 멀티 에이전트 E2E (CI 자동 미연동, 수동 또는 별도 트리거) |
@@ -24,9 +25,13 @@
 | `pnpm sync:test-count` | `sync-test-count.ts` | vitest 실제 테스트 수 측정 후 CLAUDE.md·unit-testing.md 자동 갱신 |
 | `pnpm generate:assets` | `generate-assets/index.ts` | Replicate API로 카드·배경·데코 이미지 생성 (`REPLICATE_API_KEY` 필요) |
 | `pnpm generate:assets:skip` | `generate-assets/index.ts --skip-existing` | 이미 존재하는 이미지를 건너뛰고 생성 |
+| `pnpm generate:service-bg` | `generate-service-backgrounds.ts` | 서비스(타로/사주/신점) 배경 이미지 생성 |
+| `pnpm generate:service-bg:skip` | `generate-service-backgrounds.ts --skip` | 기존 서비스 배경 건너뛰고 생성 |
 | `pnpm download:skins` | `download-skin-images.ts` | Supabase Storage 스킨 이미지 로컬 다운로드 (관리자) |
-| `pnpm upload:assets` | `generate-assets/upload-to-supabase.ts` | 로컬 카드·배경·데코 이미지를 Supabase Storage 업로드 |
-| `pnpm upload:assets:skip` | `generate-assets/upload-to-supabase.ts --skip-existing` | 이미 존재하는 이미지를 건너뛰고 업로드 |
+| `pnpm upload:assets:r2` | `generate-assets/upload-to-r2.ts` | **(정본)** 로컬 카드·배경 → Cloudflare R2(`cdn.xzawed.xyz/card-styles`), ETag=md5 무결성 검증. `.env.r2.local` 필요 |
+| `pnpm upload:assets:r2:skip` | `generate-assets/upload-to-r2.ts --skip-existing` | R2에 이미 있는 키 건너뛰고 업로드 |
+| `pnpm upload:assets` | `generate-assets/upload-to-supabase.ts` | (레거시) Supabase Storage 업로드 — card-styles는 R2로 이전됨, **정본 아님**(가드 훅이 확인 요청) |
+| `pnpm upload:assets:skip` | `generate-assets/upload-to-supabase.ts --skip-existing` | (레거시) Supabase 업로드, 기존 건너뜀 |
 | `pnpm test:e2e:full` | `e2e-full/orchestrator.ts --mode=full --workers=6` | 전수 E2E (실서버 + 실 API 키 필요) |
 | `pnpm test:e2e:full:ci` | `e2e-full/orchestrator.ts --mode=ci` | CI 대표 12 조합 |
 | `pnpm enhance:images` | `enhance-character-images.mjs` | 캐릭터 이미지 보정 (Node.js) |

--- a/docs/workflow/task-playbooks.md
+++ b/docs/workflow/task-playbooks.md
@@ -64,13 +64,15 @@
 
 ## 카드 아트 스타일 이미지 생성·업로드 `[Codex]`
 
+> **card-styles 자산은 Cloudflare R2(`cdn.xzawed.xyz`) 서빙**(2026-07-03 이전). `card-style-manager` 에이전트·`add-card-asset` 스킬을 우선 활용한다.
+
 1. `src/data/cardStyles.ts` — `CardStyleId` 4종 및 `THEME_TO_STYLE_MAP` 확인
 2. `src/hooks/useCardStyleStore.ts` — `styleOverride`, `useSkinMode`, `resolvedStyle()` 스토어 확인
-3. `src/lib/storage/card-style.ts` — `getCardStyleImageUrl()` / `getCardStyleBackUrl()` 헬퍼
+3. `src/lib/storage/card-style.ts` — `getCardStyleImageUrl()` / `getCardStyleBackUrl()` / `getServiceBackgroundUrl()` 헬퍼 (`storageBase()` env 분기)
 4. `src/components/card/CardStyleSelector.tsx` — 스타일 선택 UI (설정 페이지)
 5. `scripts/generate-assets/` — Replicate API 생성 오케스트레이터
 6. 생성: `pnpm generate:assets` 또는 `pnpm generate:assets:skip`
-7. 업로드: `pnpm upload:assets` 또는 `pnpm upload:assets:skip`
+7. 업로드(정본): `pnpm upload:assets:r2` 또는 `pnpm upload:assets:r2:skip` (R2 `card-styles/`, ETag=md5 검증). ⚠️ 기존 키 덮어쓰기(수정) 시 Cloudflare immutable 캐시 퍼지 필요. (구 `pnpm upload:assets`는 Supabase 대상=정본 아님, 가드 훅이 경고)
 
 이미지 경로 규칙: [`docs/conventions/image-assets.md`](../conventions/image-assets.md) §5
 

--- a/e2e/ui-quality.spec.ts
+++ b/e2e/ui-quality.spec.ts
@@ -33,8 +33,8 @@ test.describe("UI 품질 — 텍스트 깨짐 감지", () => {
       page.on("pageerror", (err) => errors.push(err.message));
       await page.goto(p.path);
       if (p.path === "/") {
-        // 홈 페이지는 StyleSelector가 Supabase Storage 카드 이미지를 next/image로 로드함.
-        // CI에서 외부 Storage 응답이 느리면 networkidle 30s를 초과하므로 load + 콘텐츠 대기로 대체.
+        // 홈 페이지는 StyleSelector가 외부 CDN(Cloudflare R2, cdn.xzawed.xyz) 카드 이미지를 next/image로 로드함.
+        // CI에서 외부 CDN 응답이 느리면 networkidle 30s를 초과하므로 load + 콘텐츠 대기로 대체.
         await page.waitForLoadState("load");
         await page.waitForFunction(() => (document.body.textContent?.length ?? 0) > 100, { timeout: 15_000 });
       } else {


### PR DESCRIPTION
## 배경
7-에이전트 **다이나믹 워크플로우 문서 반영 감사**로 전체 문서가 R2 이전을 정확히 반영하는지 심층 검증. 결과: **정본(코드·도구·계획서)은 정확**(41개 항목 반영 확인), 그러나 **파생 문서 11건이 옛 'card-styles = Supabase Storage' 서술로 스테일**. 이 PR이 그 11건을 정정한다.

## 정정 (11개 파일)
### high
- **data-model.md** §6-1: `getCardStyle*` 헬퍼를 `storageBase()` env 분기(R2↔Supabase 폴백)로 정정 + `getServiceBackgroundUrl` 추가
- **system-overview.md**: 데이터 레이어 `Supabase Storage(card-styles)` → `card-skins`, `Cloudflare R2` 라인 추가
- **scripts.md**: `upload:assets:r2`(정본)·`generate:service-bg`·가드 훅 등재, `upload:assets`는 레거시 표기
- **task-playbooks.md**: 카드 아트 업로드를 `upload:assets:r2`로, `card-style-manager`/`add-card-asset`·캐시 퍼지 안내

### medium
- **env-variables.md**: 자산 CDN 롤백 오도(Supabase 삭제→404) 경고·버킷명 정정·프로덕션 R2 활성 명시 + dev-tools `R2_*` 자격증명
- **known-issues.md**: Phase 1 비고에 R2 이전(2026-07-03) 명시

### low
- **deployment.md** 자산 서빙·캐시 퍼지 섹션 신설
- **cross-platform.md·e2e-testing.md·ui-quality.spec.ts** 외부 호스트 라벨 (Supabase → R2/CDN)
- **workflow.md** §3 스캐폴딩에 `card-style-manager`

## 검증
`type-check` 0 · `check:doc-links` exit 0 · `check:env-docs` 통과.

> 별도 발견(범위 밖, R2 무관): `README.en.md`가 한글 README 대비 선행 드리프트(테스트 수 19→27파일, 이미지 규격 등). 이 PR엔 미포함 — 별도 정리 대상.

🤖 Generated with [Claude Code](https://claude.com/claude-code)