### PR TITLE
chore: lint 경고 정리 + doc-links 검사 동결 스냅샷 제외·enforce 전환

### DIFF
--- a/docs/workflow/scripts.md
+++ b/docs/workflow/scripts.md
@@ -11,7 +11,7 @@
 |---|---|---|
 | `pre-push-checks.sh` | `.claude/settings.json` PreToolUse hook | `tsc --noEmit` + `eslint` + `next build` 통과 확인 후 push 허용 |
 | `hooks/upload-assets-r2-guard.sh` | `.claude/settings.json` PreToolUse `Bash(pnpm upload:assets*)` | `upload:assets`(`:r2` 없음=Supabase) 실행 시 "card-styles는 R2로 이전됨 → `upload:assets:r2` 사용" 확인 요청 |
-| `check-doc-links.ts` | `.github/workflows/docs-sync.yml` + `pnpm check:doc-links` | docs/ 내 상대 링크·앵커 검증, 깨진 링크 보고 |
+| `check-doc-links.ts` | `.github/workflows/docs-sync.yml` + `pnpm check:doc-links` | docs/ 내 상대 링크(파일 존재) 검증. 동결 스냅샷(`superpowers/plans/archive`·`superpowers/specs`)은 제외, 깨진 링크 발견 시 exit 1(push·CI 차단) |
 | `check-translation-keys.ts` | `.github/workflows/docs-sync.yml` + `pnpm i18n:check` | 번역 키 drift 검출 (ko/en/ja 동기화 검증) |
 | `e2e-full/orchestrator.ts` | `pnpm test:e2e:full` / `pnpm test:e2e:full:ci` | 252 조합 멀티 에이전트 E2E (CI 자동 미연동, 수동 또는 별도 트리거) |
 

--- a/scripts/check-doc-links.ts
+++ b/scripts/check-doc-links.ts
@@ -4,8 +4,12 @@
  * 사용법:
  *   pnpm exec tsx scripts/check-doc-links.ts          # 검사 (깨진 링크 시 exit 1)
  *
- * PR-1 단계에서는 docs/ 구조가 완성되지 않아 "파일 미존재" 경고가 많이 나옴.
- * PR-5에서 docs/ 구조 완성 후 enforce 전환.
+ * 링크는 마크다운 표준대로 "파일 위치 기준 상대경로"로 해석한다.
+ *
+ * 제외 대상(EXCLUDED_DIRS): docs/superpowers/plans/archive/ 와 docs/superpowers/specs/ 는
+ * 과거 설계·계획을 그대로 보존하는 동결(frozen) 스냅샷이라 링크 rot(구 파일 경로·상대 depth 오차)이
+ * 예상되며 손으로 고치지 않는다. 살아있는 정본 문서(architecture/conventions/workflow/operations 등)만
+ * 검사 대상으로 두어 신뢰할 수 있는 신호를 유지하고, 깨진 링크 발견 시 exit 1로 CI를 실패시킨다.
  */
 
 import * as fs from "node:fs";
@@ -13,6 +17,16 @@ import * as path from "node:path";
 
 const ROOT = path.resolve(__dirname, "..");
 const DOCS_DIR = path.join(ROOT, "docs");
+
+// 동결 스냅샷 디렉터리 — 링크 검사에서 제외 (본문 편집 금지 대상)
+const EXCLUDED_DIRS = [
+  path.join(DOCS_DIR, "superpowers", "plans", "archive"),
+  path.join(DOCS_DIR, "superpowers", "specs"),
+];
+
+function isExcluded(dir: string): boolean {
+  return EXCLUDED_DIRS.some((ex) => dir === ex || dir.startsWith(ex + path.sep));
+}
 
 interface BrokenLink {
   file: string;
@@ -27,6 +41,7 @@ function getAllMarkdownFiles(dir: string): string[] {
   for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
     const full = path.join(dir, entry.name);
     if (entry.isDirectory()) {
+      if (isExcluded(full)) continue;
       results.push(...getAllMarkdownFiles(full));
     } else if (entry.name.endsWith(".md")) {
       results.push(full);
@@ -79,12 +94,11 @@ if (allBroken.length === 0) {
   process.exit(0);
 }
 
-// PR-1~4 기간에는 경고만 출력 (exit 0). PR-5에서 아래를 exit(1)로 변경.
-console.warn(`[check-doc-links] 깨진 링크 ${allBroken.length}개 발견 (현재 경고만):`);
+console.error(`[check-doc-links] 깨진 링크 ${allBroken.length}개 발견:`);
 for (const b of allBroken) {
-  console.warn(`  ${b.file}:${b.line} → [${b.text}](${b.target})`);
+  console.error(`  ${b.file}:${b.line} → [${b.text}](${b.target})`);
 }
-console.warn(
-  "\n  [check-doc-links] PR-5에서 docs/ 구조 완성 후 이 경고를 오류로 전환 예정."
+console.error(
+  "\n  [check-doc-links] 정본 문서의 링크를 수정하거나, 대상이 이동했으면 경로를 갱신하세요."
 );
-process.exit(0);
+process.exit(1);

--- a/src/hooks/useTarotCardSelection.ts
+++ b/src/hooks/useTarotCardSelection.ts
@@ -74,15 +74,18 @@ export function useTarotCardSelection() {
   }, []);
 
   // unmount cleanup: 진행 중인 SSE abort + 자동 시작 타이머 clear (saju/shinjeom과 동일 패턴)
+  // readingAbortRef는 useTarotReading가 소유한 stable ref이므로 deps에 명시(재구독 없음).
   useEffect(() => {
     return () => {
+      // 의도된 패턴: cleanup 시점의 최신 AbortController를 abort (in-flight SSE 중단)
+      // eslint-disable-next-line react-hooks/exhaustive-deps
       readingAbortRef.current?.abort();
       if (autoStartTimerRef.current) {
         clearTimeout(autoStartTimerRef.current);
         autoStartTimerRef.current = null;
       }
     };
-  }, []);
+  }, [readingAbortRef]);
 
   // phase가 초기화되면 reveal 상태도 리셋
   useEffect(() => {


### PR DESCRIPTION
## 배경

잔여작업 감사에서 확인된 LOW 우선순위 hygiene 2건을 묶어 처리합니다.

## 변경

### 1. `useTarotCardSelection.ts` — lint 경고 2건 해소 (#7)
unmount cleanup effect만 형제 effect 5개와 달리 suppression이 없어 `react-hooks/exhaustive-deps` 경고 2건 발생 (PR #437 훅 분리 잔재).
- `readingAbortRef`(`useTarotReading` 소유 **stable ref**)를 deps에 명시 → `missing dependency` 경고 해소. stable ref이므로 재구독 없음 → **동작 verbatim 유지**.
- cleanup의 `readingAbortRef.current` 접근은 in-flight SSE를 abort하는 **의도된 패턴**(값 캡처 시 오히려 깨짐)이라 해당 라인에 targeted `eslint-disable`.

### 2. `check-doc-links.ts` — 동결 스냅샷 제외 + enforce 전환 (#6)
`pnpm check:doc-links`가 경고 40건을 계속 뱉었는데 **전부** `docs/superpowers/plans/archive/`·`docs/superpowers/specs/`(동결 스냅샷) 내부였음. ~34건은 상대 depth/root-relative 오차 false-positive, ~6건은 아카이브에 박제된 구 경로. 살아있는 정본 문서(architecture/conventions/workflow/operations)는 원래 0건.
- 두 동결 디렉터리를 스캔에서 제외 → 노이즈 40건 제거 (본문 편집 없이).
- 남은 정본 셋이 clean이므로 경고전용(exit 0) → **exit 1 enforce** 전환. `scripts.md`가 이미 "push·CI 차단"으로 기술하던 **코드-문서 드리프트를 해소**(코드가 문서를 따라감).
- 스캔 파일 36 → 29개, 깨진 링크 0건.

### 3. `docs/workflow/scripts.md`
`check-doc-links` 설명을 제외 규칙·exit 1 동작으로 정정.

## 검증
- `pnpm type-check` ✅
- `pnpm lint` (전체) ✅ — 경고 0
- `pnpm check:doc-links` ✅ — 29파일 0건, exit 0
- 커버리지 영향 없음: 두 파일 모두 `coverage.include` 화이트리스트 밖(패치/프로젝트 커버리지 무영향)
- CI: `docs-sync.yml`은 PR에서 실행되며 이 PR의 정본 셋이 clean이라 통과. enforce는 **향후** 정본 문서의 깨진 링크만 차단(의도된 동작)

## 참고
별개 local hygiene로 병합 완료된 로컬 브랜치 3개(`chore/gitignore-env-r2-local`, `docs/r2-migration-complete`, `docs/r2-reflection-fixes`)도 삭제했습니다(원격 무영향).

🤖 Generated with [Claude Code](https://claude.com/claude-code)