### PR TITLE
docs(e2e): 외부 CDN 배경 이미지 페이지 load 대기 플레이키 대응 가이드

### DIFF
--- a/.claude/rules/e2e-testing.md
+++ b/.claude/rules/e2e-testing.md
@@ -75,6 +75,26 @@ Cloudflare R2/CDN(`cdn.xzawed.xyz`)·Supabase Storage 등 외부 URL을 `src`로
 느리면 `waitForLoadState("load")` 가 20-30s 블로킹 → E2E 타임아웃 유발.  
 LCP 요소(히어로 이미지 등)가 아닌 배경·데코 이미지에는 절대 사용하지 않는다. (PR #412 2차 실패 원인)
 
+## 테스트 측: `waitForLoadState("load")` 대신 web-first 대기
+
+외부 CDN(R2) 배경 이미지가 있는 페이지(`ServiceBackground`가 있는 `/tarot`·`/saju`·`/shinjeom`·홈)는
+`priority`를 안 붙여도 **풀스크린(in-viewport) 배경이라 `window.load`를 게이트**한다. 따라서 테스트에서
+`waitForLoadState("load")`(및 `waitForURL`의 기본 `waitUntil:'load'`)를 쓰면 Mobile Android CI에서 타임아웃이 재발한다.
+
+```ts
+// ❌ 금지 — 외부 배경 이미지가 window.load 를 지연시켜 타임아웃
+await page.goto("/tarot");
+await page.waitForLoadState("load");
+
+// ✅ 권장 — web-first 준비 신호 + load 비의존 네비게이션
+await page.goto("/tarot", { waitUntil: "domcontentloaded" });
+await expect(page.locator("button").filter({ hasText: /아르카나|미코/ }).first()).toBeVisible();
+await page.waitForURL(/\/$/, { waitUntil: "commit" }); // 또는 expect(page).toHaveURL(...)
+```
+
+`networkidle`은 Playwright 공식 **DISCOURAGED**(eslint `no-networkidle`)이므로 신규 코드에 쓰지 않는다.
+(PR #455 — navigation 스크롤-리셋 플레이키(#121~#428 재발 계열) 영구 해소)
+
 ## 텍스트 변경 시 E2E 동시 수정 규칙
 
 버튼·레이블 텍스트를 변경할 때는 **같은 커밋**에 E2E 셀렉터도 수정한다.

--- a/docs/workflow/e2e-testing.md
+++ b/docs/workflow/e2e-testing.md
@@ -227,12 +227,12 @@ Mobile iOS 프로젝트(WebKit)는 `page.mouse.wheel()`을 지원하지 않는�
 
 | 상황 | 사용 |
 |------|------|
-| 페이지 이동 완료 대기 | `page.waitForURL("**/tarot/session**")` |
+| 페이지 이동 완료 대기 | `page.waitForURL("**/tarot/session**")` (외부 CDN 배경 이미지 페이지는 `{ waitUntil: "commit" }`로 `load` 의존 제거) |
 | 특정 요소 표시 대기 | `expect(locator).toBeVisible({ timeout: 10_000 })` |
 | SSE 응답 완료 대기 | `page.waitForTimeout(2000)` (mock 완료 후 렌더링 보장) |
 | 레이아웃/정적 UI 준비 | `page.goto(path, { waitUntil: "domcontentloaded" })` 후 핵심 요소 `toBeVisible()` |
 | API·이미지까지 포함한 로딩 완료 | `page.waitForLoadState("networkidle")` (외부 API를 mock한 경우에만 권장) |
-| 사용 금지 | `waitForTimeout` 단독 의존 — 대신 명시적 상태 체크 우선 |
+| 사용 금지 | `waitForTimeout` 단독 의존 — 명시적 상태 체크 우선. `waitForLoadState("load")` — 외부 CDN(R2) 배경 이미지가 `window.load`를 지연시켜 Mobile Android CI 타임아웃 유발(#455), web-first(`domcontentloaded`+`toBeVisible`)로 대체 |
 
 ---
 


### PR DESCRIPTION
## 배경
PR #455에서 확인한 학습을 문서에 반영(전역 포스트-머지 문서 최신화 규칙).

외부 R2 `ServiceBackground`(풀스크린 in-viewport)는 `priority` 미부착이어도 `window.load`를 게이트한다. 따라서 테스트에서 `waitForLoadState("load")`·`waitForURL` 기본 `load` 대기를 쓰면 Mobile Android CI 타임아웃이 재발한다(#121~#428 계열, #455에서 해소).

## 변경
- `.claude/rules/e2e-testing.md`: "테스트 측 web-first 대기" 섹션 추가 — 앱측 `priority 금지` 규칙의 테스트측 짝. `goto(domcontentloaded)`+`toBeVisible` / `waitUntil:"commit"` 권장, `networkidle` 금지 명시.
- `docs/workflow/e2e-testing.md`: 대기 전략 표에 `waitForLoadState("load")` 금지·`commit` 권장 반영.

## 검증
`pnpm check:doc-links` ✅ (29파일 0건, 이제 enforce)

🤖 Generated with [Claude Code](https://claude.com/claude-code)