### PR TITLE
fix(e2e): immersive 페이지 networkidle → web-first 대기 (#455 후속 sweep)

### DIFF
--- a/e2e/helpers/service-navigation.ts
+++ b/e2e/helpers/service-navigation.ts
@@ -14,7 +14,7 @@ export async function selectFirstCharacter(
 // ── 사주 ──
 
 export async function navigateToSajuForm(page: Page) {
-  await page.goto("/saju");
+  await page.goto("/saju", { waitUntil: "domcontentloaded" });
   await selectFirstCharacter(page);
   await expect(page.locator("text=생년월일").first()).toBeVisible({ timeout: 5_000 });
 }
@@ -42,8 +42,7 @@ export async function submitSajuForm(page: Page) {
 }
 
 export async function enterSajuSession(page: Page) {
-  await page.goto("/saju");
-  await page.waitForLoadState("networkidle");
+  await page.goto("/saju", { waitUntil: "domcontentloaded" });
   await selectFirstCharacter(page);
 
   const birthInput = page.locator("input[type='date']");
@@ -75,7 +74,7 @@ export async function enterSajuSession(page: Page) {
 // ── 신점 ──
 
 export async function navigateToShinjeomSession(page: Page) {
-  await page.goto("/shinjeom");
+  await page.goto("/shinjeom", { waitUntil: "domcontentloaded" });
   await selectFirstCharacter(page);
   await page.locator("text=신수").first().click();
   // user-info 스텝: 건너뛰기로 즉시 세션 진입
@@ -84,8 +83,7 @@ export async function navigateToShinjeomSession(page: Page) {
 }
 
 export async function enterShinjeomSession(page: Page) {
-  await page.goto("/shinjeom");
-  await page.waitForLoadState("networkidle");
+  await page.goto("/shinjeom", { waitUntil: "domcontentloaded" });
   await selectFirstCharacter(page);
   await page.locator("text=신수").first().click();
   // user-info 스텝: 건너뛰기로 즉시 세션 진입
@@ -97,8 +95,7 @@ export async function enterShinjeomSession(page: Page) {
 // ── 타로 ──
 
 export async function enterTarotSession(page: Page) {
-  await page.goto("/tarot");
-  await page.waitForLoadState("networkidle");
+  await page.goto("/tarot", { waitUntil: "domcontentloaded" });
   await selectFirstCharacter(page);
   await expect(page.locator("[data-testid='topic-btn-general']")).toBeVisible({ timeout: 5_000 });
   await page.locator("[data-testid='topic-btn-general']").click();

--- a/e2e/ui-quality.spec.ts
+++ b/e2e/ui-quality.spec.ts
@@ -31,15 +31,10 @@ test.describe("UI 품질 — 텍스트 깨짐 감지", () => {
     test(`${p.name} (${p.path}) — JSON 잔여물 없음 + 콘솔 에러 없음`, async ({ page }) => {
       const errors: string[] = [];
       page.on("pageerror", (err) => errors.push(err.message));
-      await page.goto(p.path);
-      if (p.path === "/") {
-        // 홈 페이지는 StyleSelector가 외부 CDN(Cloudflare R2, cdn.xzawed.xyz) 카드 이미지를 next/image로 로드함.
-        // CI에서 외부 CDN 응답이 느리면 networkidle 30s를 초과하므로 load + 콘텐츠 대기로 대체.
-        await page.waitForLoadState("load");
-        await page.waitForFunction(() => (document.body.textContent?.length ?? 0) > 100, { timeout: 15_000 });
-      } else {
-        await page.waitForLoadState("networkidle");
-      }
+      // 외부 CDN(R2) 배경/카드 이미지가 window.load·networkidle을 지연시키므로(Mobile Android 타임아웃)
+      // load 이벤트가 아닌 콘텐츠 렌더 자체를 대기한다 (web-first).
+      await page.goto(p.path, { waitUntil: "domcontentloaded" });
+      await page.waitForFunction(() => (document.body.textContent?.length ?? 0) > 100, { timeout: 15_000 });
       const bodyText = await page.textContent("body");
 
       for (const pattern of JSON_ARTIFACTS) {
@@ -63,22 +58,22 @@ test.describe("UI 품질 — 핵심 텍스트 존재 확인", () => {
   });
 
   test("타로 — 캐릭터 선택 텍스트", async ({ page }) => {
-    await page.goto("/tarot");
-    await page.waitForLoadState("networkidle");
+    await page.goto("/tarot", { waitUntil: "domcontentloaded" });
+    await page.waitForFunction(() => document.body.textContent?.includes("상담사"), { timeout: 15_000 });
     const body = await page.textContent("body");
     expect(body).toContain("상담사");
   });
 
   test("사주 — 캐릭터 선택 텍스트", async ({ page }) => {
-    await page.goto("/saju");
-    await page.waitForLoadState("networkidle");
+    await page.goto("/saju", { waitUntil: "domcontentloaded" });
+    await page.waitForFunction(() => document.body.textContent?.includes("상담사"), { timeout: 15_000 });
     const body = await page.textContent("body");
     expect(body).toContain("상담사");
   });
 
   test("신점 — 캐릭터 선택 + 주제", async ({ page }) => {
-    await page.goto("/shinjeom");
-    await page.waitForLoadState("networkidle");
+    await page.goto("/shinjeom", { waitUntil: "domcontentloaded" });
+    await page.waitForFunction(() => document.body.textContent?.includes("상담사"), { timeout: 15_000 });
     const body = await page.textContent("body");
     expect(body).toContain("신점");
     expect(body).toContain("상담사");
@@ -129,8 +124,8 @@ test.describe("UI 품질 — 레이아웃 깨짐 감지", () => {
   });
 
   test("타로 — 가로 스크롤 없음", async ({ page }) => {
-    await page.goto("/tarot");
-    await page.waitForLoadState("networkidle");
+    await page.goto("/tarot", { waitUntil: "domcontentloaded" });
+    await page.waitForFunction(() => document.body.textContent?.includes("상담사"), { timeout: 15_000 });
     const scrollWidth = await page.evaluate(() => document.documentElement.scrollWidth);
     const clientWidth = await page.evaluate(() => document.documentElement.clientWidth);
     expect(scrollWidth).toBeLessThanOrEqual(clientWidth + 1);
@@ -178,16 +173,15 @@ test.describe("UI 품질 — 의도하지 않은 동작 감지", () => {
   test("빈 페이지 감지 — body 텍스트가 100자 이상", async ({ page }) => {
     const paths = ["/", "/tarot", "/saju", "/shinjeom", "/settings", "/terms", "/privacy"];
     for (const path of paths) {
-      await page.goto(path);
-      await page.waitForLoadState("networkidle");
+      await page.goto(path, { waitUntil: "domcontentloaded" });
+      await page.waitForFunction(() => (document.body.textContent?.length ?? 0) > 100, { timeout: 15_000 });
       const text = await page.textContent("body");
       expect(text?.length ?? 0, `${path} 페이지가 비어있음`).toBeGreaterThan(100);
     }
   });
 
   test("무한 로딩 감지 — 로딩 스피너가 5초 내 사라짐", async ({ page }) => {
-    await page.goto("/tarot");
-    await page.waitForLoadState("networkidle");
+    await page.goto("/tarot", { waitUntil: "domcontentloaded" });
     // 로딩 인디케이터가 있다면 5초 내 사라져야 함
     const spinner = page.locator("[class*='animate-spin'], [class*='animate-pulse']");
     if (await spinner.count() > 0) {
@@ -201,8 +195,8 @@ test.describe("UI 품질 — 의도하지 않은 동작 감지", () => {
   });
 
   test("에러 경계 — 존재하지 않는 캐릭터 → 에러 메시지", async ({ page }) => {
-    await page.goto("/character/nonexistent");
-    await page.waitForLoadState("networkidle");
+    await page.goto("/character/nonexistent", { waitUntil: "domcontentloaded" });
+    await page.waitForFunction(() => /찾을 수 없|404|not found/i.test(document.body.textContent ?? ""), { timeout: 15_000 });
     const text = await page.textContent("body");
     expect(text).toMatch(/찾을 수 없|404|not found/i);
   });


### PR DESCRIPTION
## 배경 (회고에서 발견)
#455가 `navigation.spec.ts`만 고치고 "영구 해소"로 규칙화(#456)했으나, **동일 근본원인**(외부 R2 배경/카드 이미지가 `window.load`·`networkidle`을 지연)이 공유 헬퍼와 `ui-quality`에 잔존 → Mobile Android 잠재 플래키. 특히 `service-navigation.ts`는 규칙이 "먼저 수정"이라던 공유 헬퍼.

## 변경
### `e2e/helpers/service-navigation.ts` (공유 헬퍼, blast radius 큼)
- `enter{Saju,Shinjeom,Tarot}Session`의 `waitForLoadState("networkidle")` 3건 **제거** — 직후 `selectFirstCharacter`의 `toBeVisible`가 이미 준비를 보장하므로 **중복 대기**였음.
- immersive `goto`를 `{ waitUntil: "domcontentloaded" }`로 전환.

### `e2e/ui-quality.spec.ts`
- `/tarot`·`/saju`·`/shinjeom`(및 혼합 루프)의 `networkidle` → `goto(domcontentloaded)` + `waitForFunction(콘텐츠 렌더)` **web-first**로 전환. 파일 내 기존 홈 테스트(line 58)의 검증된 패턴 재사용.
- **저위험 `(site)` 페이지**(settings/login/terms/privacy/home)의 networkidle은 **로컬 자산이라 현행 유지**(별도 추적 예정).

## 안전성
service-navigation의 networkidle은 web-first 어서션이 뒤따르는 순수 중복이라 제거가 strictly safer. ui-quality 전환은 각 테스트가 이미 단언하는 콘텐츠를 대기 신호로 사용 → 통과 조건 불변, load/networkidle 의존만 제거.

## 검증
- `pnpm type-check` ✅ / `pnpm lint` ✅
- CI `E2E — Mobile Android`로 검증 (플로우 테스트 다수가 service-navigation 헬퍼 사용)

🤖 Generated with [Claude Code](https://claude.com/claude-code)