### PR TITLE
chore(quality): SonarLint 2차 정리 — replaceAll 리터럴화·SSR 가드·캔버스 role 자가결함

### DIFF
--- a/src/components/common/LocaleConfirmModal.tsx
+++ b/src/components/common/LocaleConfirmModal.tsx
@@ -26,7 +26,7 @@ export function LocaleConfirmModal() {
   const [suggested, setSuggested] = useState<Locale | null>(null);
 
   useEffect(() => {
-    if (typeof globalThis.window === "undefined") return;
+    if (globalThis.window === undefined) return;
     let alreadyShown = false;
     try {
       alreadyShown = globalThis.localStorage.getItem(STORAGE_KEY) === "1";

--- a/src/components/common/ReadingText.tsx
+++ b/src/components/common/ReadingText.tsx
@@ -8,10 +8,10 @@ interface ReadingTextProps {
 /** AI 응답 텍스트의 리터럴 이스케이프·JSON 잔여물을 제거하고 단락 구분 힌트를 추가 */
 function normalizeText(text: string): string {
   let result = text
-    .replaceAll(/\\n/g, "\n")
-    .replaceAll(/\\r/g, "")
-    .replaceAll(/\\t/g, " ")
-    .replaceAll(/\\"/g, '"');
+    .replaceAll("\\n", "\n")
+    .replaceAll("\\r", "")
+    .replaceAll("\\t", " ")
+    .replaceAll('\\"', '"');
 
   result = result
     .replaceAll(/"(cardInterpretations|cardId|position|interpretation|overallReading|advice|isReversed)":\s*/g, "")

--- a/src/components/common/ReadingText.tsx
+++ b/src/components/common/ReadingText.tsx
@@ -8,10 +8,10 @@ interface ReadingTextProps {
 /** AI 응답 텍스트의 리터럴 이스케이프·JSON 잔여물을 제거하고 단락 구분 힌트를 추가 */
 function normalizeText(text: string): string {
   let result = text
-    .replaceAll("\\n", "\n")
-    .replaceAll("\\r", "")
-    .replaceAll("\\t", " ")
-    .replaceAll('\\"', '"');
+    .replaceAll(String.raw`\n`, "\n")
+    .replaceAll(String.raw`\r`, "")
+    .replaceAll(String.raw`\t`, " ")
+    .replaceAll(String.raw`\"`, '"');
 
   result = result
     .replaceAll(/"(cardInterpretations|cardId|position|interpretation|overallReading|advice|isReversed)":\s*/g, "")

--- a/src/components/common/Toast.tsx
+++ b/src/components/common/Toast.tsx
@@ -10,7 +10,7 @@ interface ToastEvent {
 const TOAST_EVENT = "arcana:toast";
 
 export function showToast(message: string, duration = 2400): void {
-  if (typeof window === "undefined") return;
+  if (globalThis.window === undefined) return;
   globalThis.dispatchEvent(new CustomEvent<ToastEvent>(TOAST_EVENT, { detail: { message, duration } }));
 }
 

--- a/src/components/effects/CanvasParticleLayer.tsx
+++ b/src/components/effects/CanvasParticleLayer.tsx
@@ -114,9 +114,9 @@ export function CanvasParticleLayer({ density = "medium", className = "" }: Canv
   if (shouldReduceMotion) return null;
 
   return (
+    // 장식용 파티클 캔버스 — 내용/이벤트 없는 빈 캔버스라 스크린리더가 무시(role·aria-hidden 불필요)
     <canvas
       ref={canvasRef}
-      role="presentation"
       className={`absolute inset-0 w-full h-full pointer-events-none ${className}`}
     />
   );

--- a/src/hooks/useTarotCardSelection.ts
+++ b/src/hooks/useTarotCardSelection.ts
@@ -201,8 +201,8 @@ export function useTarotCardSelection() {
           content: isLast
             ? t("tarot.session.msg.confirm-final").replace("{n}", String(required))
             : t("tarot.session.msg.confirm-card")
-                .replaceAll(/\{current\}/g, String(currentCount))
-                .replaceAll(/\{total\}/g, String(required)),
+                .replaceAll("{current}", String(currentCount))
+                .replaceAll("{total}", String(required)),
           mood: "mystical", timestamp: new Date(),
         });
       }, 500);


### PR DESCRIPTION
## 개요

PR #472 후속. 머지 후 SonarCloud main 재분석 결과 **240 → 48**(80% 해소). 남은 48건 중 순수 기계적 항목과 **#472가 새로 유발한 자가결함 1건**을 추가 정리합니다. 나머지는 정당한 행동보존 skip(프롬프트 `\n` 이스케이프·hash 래핑·정규식 백트래킹·force-click·계약 테스트 등).

## 변경 (9건)

- **S7781 (6)**: `replaceAll`의 전역 정규식을 문자열 리터럴로 — `ReadingText`의 `\n\r\t\"` 언이스케이프, `useTarotCardSelection`의 `{current}{total}` 치환. 리터럴 패턴이라 **동작 동일**.
- **S7764/S7741 (2)**: `Toast`·`LocaleConfirmModal`의 SSR 가드를 `globalThis.window === undefined`로 — SSR/브라우저 동치, 안전.
- **S6843 (1)**: `CanvasParticleLayer`의 `role="presentation"` 제거 — #472의 S6825 수정(aria-hidden→role)이 SonarCloud상 canvas=interactive 판정으로 **새로 유발한 자가결함**. 이벤트 없는 빈 장식 캔버스라 role·aria-hidden 불필요(스크린리더가 무시).

## 검증

- ✅ type-check / lint / **test:coverage 1060 tests** / build 그린. 런타임 동작 변경 없음.

머지 후 남는 이슈는 대부분 행동보존을 위한 정당 skip(약 39건)입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)