### PR TITLE
fix(reading): 사주·신점 리딩 간헐적 무결과 근본 수정 — JSON 형식 위반 내성

### DIFF
--- a/.claude/rules/services.md
+++ b/.claude/rules/services.md
@@ -43,6 +43,16 @@ parseResult(aiResponse: string): ReadingResult {
 **parseError 시그널 4종**: `truncated` | `invalid_json` | `fallback_text` | `missing_fields`  
 누락 시 클라이언트가 빈 결과를 정상으로 판정 → DB에 빈 리딩 저장됨.
 
+### 리딩 안정성 내성 (2026-07-06)
+
+사주·신점 리딩의 간헐적 JSON 형식 위반(트레일링 콤마·flat 필드를 섹션 객체 내부에 중첩)이 무결과를 유발했다. 파서·라우트에 3중 내성:
+
+1. **`parseJsonSafe`** — 3차 파싱 시도에 **트레일링 콤마 제거** 포함 (`,}`·`,]` → `JSON.parse` 실패 방지).
+2. **`promoteNestedFields(parsed, "sajuSections"|"shinjeomSections", [...])`** — 사주·신점 `parseResult`에서 파싱 직후 호출. 모델이 `overallReading`·`advice` 등을 섹션 객체 **내부**에 잘못 넣은 경우 top-level로 승격 (`missing_fields` 복구).
+3. **`streamReadingWithParseRetry`** (`reading-generator.ts`) — 3개 리딩 라우트가 `for await streamReading` 대신 이 헬퍼 사용. 1차 파싱이 `parseError`면 **1회 non-stream 재생성** 후 재파싱(성공 시 채택, 실패 시 원본 유지).
+
+클라이언트: 사주도 타로·신점과 동일 계약 — `invalid_json`/`missing_fields`만 무결과, `truncated`/`fallback_text`는 부분 표시. SSE 종단 이벤트(done/error) 없이 스트림이 끝나면 3훅 모두 명시적 에러로 전환(무한 스피너 방지). 클라 hard timeout 280s(서버 `AI_TIMEOUT_MS` 240s 대비 양의 마진).
+
 ## FallbackProvider 사용법
 
 ```typescript

--- a/docs/architecture/ai-infrastructure.md
+++ b/docs/architecture/ai-infrastructure.md
@@ -71,9 +71,11 @@ new CircuitBreaker({ prefix: "FallbackProvider/Grok", globalKey: "__arcanaFallba
 
 | 유틸 | 위치 | 역할 |
 |------|------|------|
-| `parseJsonSafe(raw)` | `src/services/core/text-cleaner.ts` | thinking 토큰 제거 → 코드블록 추출 → 문자열-aware 괄호 카운터로 JSON 추출 → 2차 파싱 시도 |
+| `parseJsonSafe(raw)` | `src/services/core/text-cleaner.ts` | thinking 토큰 제거 → 코드블록 추출 → 문자열-aware 괄호 카운터로 JSON 추출 → 3단 파싱 시도(원본 → 문자열 내 개행 이스케이프 → **트레일링 콤마 제거**) |
+| `promoteNestedFields(parsed, sectionKey, fields)` | `src/services/core/text-cleaner.ts` | 모델이 flat 필드(overallReading·advice 등)를 `sajuSections`/`shinjeomSections` **내부**에 잘못 중첩한 경우 top-level로 승격 (missing_fields 복구) |
 | `extractFallbackText(raw)` | `src/services/core/text-cleaner.ts` | JSON 파싱 완전 실패 시 본문 회수 (tarot/saju 공용, ReDoS-safe) |
 | `cleanReadingText(text)` | `src/services/core/text-cleaner.ts` | 파싱 후 JSON 잔여물·이스케이프 정리 |
+| `streamReadingWithParseRetry(...)` | `src/services/core/reading-generator.ts` | 1차 streamReading → 파싱 실패(parseError) 시 **1회 non-stream 재생성** 후 재파싱. 3개 리딩 라우트 공통 |
 | `buildCharacterHeader(character, subtitle?)` | `src/services/core/prompt-builder.ts` | 3 서비스 공통 캐릭터 system-prompt 헤더 |
 
 ---
@@ -91,12 +93,17 @@ AI 스트리밍 응답 (fullResponse 누적)
     │      3. findOutermostObjectEnd() — 문자열-aware 괄호 카운팅
     │      4. JSON.parse 1차 시도
     │      5. 문자열 내 리터럴 개행 이스케이프 후 2차 시도
+    │      6. 트레일링 콤마 제거 후 3차 시도 (LLM 흔한 형식 위반)
     │      → 성공: Record<string, unknown>
     │      → 실패: null
     │
-    ├─ 성공 → cleanReadingText(field) 후 ReadingResult 반환
+    ├─ 성공 → promoteNestedFields()(섹션 내부 잘못 중첩 필드 승격) → cleanReadingText(field) → ReadingResult
     └─ 실패 → extractFallbackText(raw) 또는 원문 텍스트 반환
+
+파싱 결과에 parseError가 있으면 라우트는 streamReadingWithParseRetry로 1회 재생성한다.
 ```
+
+> **리딩 안정성 (2026-07-06)**: 사주·신점 리딩이 간헐적으로 JSON 형식 위반을 냈다. 실측 재현(프로덕션 반복 호출) 결과 원인은 타임아웃·절단이 아니라 **`sajuSections`/`shinjeomSections` 중첩 스키마**로, 모델이 (1) flat 필드를 섹션 객체 내부에 중첩(`missing_fields`)하거나 (2) 섹션 끝에 트레일링 콤마를 남겨(`JSON.parse` 실패 → `fallback_text`) 결과가 폐기됐다(사주 ~21%, 신점 ~67% 실패, 타로 0%). 대응: ① `parseJsonSafe` 트레일링 콤마 내성, ② `promoteNestedFields` 승격, ③ 파싱 실패 시 1회 재생성, ④ 프롬프트에 "flat 필드는 섹션 밖 top-level·트레일링 콤마 금지" 명시, ⑤ 사주 클라이언트 `parseError` 처리를 타로·신점과 동일 계약으로(fallback_text 부분 표시), ⑥ 클라 hard timeout 240→280s(서버 대비 양의 마진)·SSE 종단 이벤트 부재 시 영구 스피너 방지 가드.
 
 ### 핵심 주의사항 — 문자열 내 중괄호
 

--- a/src/__tests__/api/tarot-reading.test.ts
+++ b/src/__tests__/api/tarot-reading.test.ts
@@ -366,6 +366,8 @@ describe("POST /api/tarot/reading", () => {
         streamReading: vi.fn().mockImplementation(async function* () {
           yield "카드들이 말하는 핵심은 지금의 불안을 정리하고 다음 선택을 차분히 보라는 것입니다.";
         }),
+        // 재생성도 동일하게 비-JSON → parseError 유지(재시도 경로 명시적 모델링)
+        generateReading: vi.fn().mockResolvedValue("카드들이 말하는 핵심은 지금의 불안을 정리하고 다음 선택을 차분히 보라는 것입니다."),
       }); }),
     }));
 
@@ -392,6 +394,8 @@ describe("POST /api/tarot/reading", () => {
         streamReading: vi.fn().mockImplementation(async function* () {
           yield "JSON 아닌 텍스트 응답 — parseError 유발";
         }),
+        // 재생성도 동일하게 비-JSON → parseError 유지(재시도 경로 명시적 모델링)
+        generateReading: vi.fn().mockResolvedValue("JSON 아닌 텍스트 응답 — parseError 유발"),
       }); }),
     }));
 

--- a/src/app/api/saju/reading/route.ts
+++ b/src/app/api/saju/reading/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest } from "next/server";
 import { SajuService, detectSajuTimeHorizon, type SajuQuestionHorizon } from "@/services/saju/saju-service";
 import { FallbackProvider } from "@/services/core/fallback-provider";
+import { streamReadingWithParseRetry } from "@/services/core/reading-generator";
 import { calculateSaju } from "@/services/saju/saju-calculator";
 import { Topic, SajuTimeRange } from "@/types/session";
 import { sajuTimeOptions } from "@/data/saju/categories";
@@ -124,15 +125,19 @@ export async function POST(request: NextRequest) {
     const encoder = new TextEncoder();
     const stream = new ReadableStream({
       async start(controller) {
-        let fullResponse = "";
         try {
           // timeRange·includeMonthly 기반 동적 max_tokens (truncated 방지)
           const sajuMaxTokens = computeSajuReadingMaxTokens(timeRange, includeMonthly ?? false);
-          for await (const chunk of grokProvider.streamReading(systemPrompt + memoryPrompt, readingPrompt, sajuMaxTokens)) {
-            fullResponse += chunk;
-            controller.enqueue(encoder.encode(`data: ${JSON.stringify({ chunk })}\n\n`));
-          }
-          const result = sajuService.parseResult(fullResponse);
+          // 파싱 실패 시 1회 재생성 (간헐적 JSON 형식 위반 흡수)
+          const { result } = await streamReadingWithParseRetry({
+            provider: grokProvider,
+            systemPrompt: systemPrompt + memoryPrompt,
+            userPrompt: readingPrompt,
+            maxTokens: sajuMaxTokens,
+            parse: (raw) => sajuService.parseResult(raw),
+            onChunk: (chunk) => controller.enqueue(encoder.encode(`data: ${JSON.stringify({ chunk })}\n\n`)),
+            logTag: "saju-reading",
+          });
 
           // 부분 파싱(누락/잘림)은 운영 로그로 명시 추적
           if (result.parseError) {

--- a/src/app/api/shinjeom/message/route.ts
+++ b/src/app/api/shinjeom/message/route.ts
@@ -1,7 +1,9 @@
 import { NextRequest } from "next/server";
 import { ShinjeomService } from "@/services/shinjeom/shinjeom-service";
 import { FallbackProvider } from "@/services/core/fallback-provider";
+import { streamReadingWithParseRetry } from "@/services/core/reading-generator";
 import { Topic, ChatMessage } from "@/types/session";
+import type { ReadingResult } from "@/types/service";
 import { getAdminDb } from "@/lib/db";
 import { assertSessionOwnership } from "@/lib/auth";
 import { fetchMemoryPrompt } from "@/lib/db/character-context";
@@ -27,13 +29,11 @@ const SHINJEOM_TOKENS_CHAT = 6000;
 async function emitShinjeomFinalResult(
   controller: ReadableStreamDefaultController,
   encoder: TextEncoder,
-  fullResponse: string,
+  result: ReadingResult,
   db: DbClient | null,
   sessionId: string | null | undefined,
   locale: string,
 ): Promise<void> {
-  const result = shinjeomService.parseResult(fullResponse);
-
   if (result.parseError) {
     console.warn("[shinjeom-message] 부분 파싱:", {
       parseError: result.parseError,
@@ -109,18 +109,28 @@ export async function POST(request: NextRequest) {
     const encoder = new TextEncoder();
     const stream = new ReadableStream({
       async start(controller) {
-        let fullResponse = "";
         try {
-          const shinjeomMaxTokens = isFinalTurn ? SHINJEOM_TOKENS_FINAL : SHINJEOM_TOKENS_CHAT;
-          for await (const chunk of aiProvider.streamReading(systemPrompt + memoryPrompt, userPrompt, shinjeomMaxTokens)) {
-            fullResponse += chunk;
-            controller.enqueue(encoder.encode(`data: ${JSON.stringify({ chunk })}\n\n`));
-          }
-
+          const enqueueChunk = (chunk: string) => controller.enqueue(encoder.encode(`data: ${JSON.stringify({ chunk })}\n\n`));
           if (isFinalTurn) {
-            await emitShinjeomFinalResult(controller, encoder, fullResponse, db, sessionId, locale);
+            // 최종 결과만 JSON 파싱 대상 — 파싱 실패 시 1회 재생성 (간헐적 형식 위반 흡수)
+            const { result } = await streamReadingWithParseRetry({
+              provider: aiProvider,
+              systemPrompt: systemPrompt + memoryPrompt,
+              userPrompt,
+              maxTokens: SHINJEOM_TOKENS_FINAL,
+              parse: (raw) => shinjeomService.parseResult(raw),
+              onChunk: enqueueChunk,
+              logTag: "shinjeom-message",
+            });
+            await emitShinjeomFinalResult(controller, encoder, result, db, sessionId, locale);
           } else {
-            // 중간 대화 — 응답 먼저 전송, DB 저장은 비동기 fire-and-forget (3회 retry). 실패는 구조적 로깅만.
+            // 중간 대화 — 일반 텍스트 스트리밍 (JSON 파싱 없음, 재생성 불필요)
+            let fullResponse = "";
+            for await (const chunk of aiProvider.streamReading(systemPrompt + memoryPrompt, userPrompt, SHINJEOM_TOKENS_CHAT)) {
+              fullResponse += chunk;
+              enqueueChunk(chunk);
+            }
+            // 응답 먼저 전송, DB 저장은 비동기 fire-and-forget (3회 retry). 실패는 구조적 로깅만.
             controller.enqueue(encoder.encode(`data: ${JSON.stringify({ done: true, isFinal: false, message: fullResponse })}\n\n`));
             if (db && sessionId && currentMessage && messageIndex !== undefined) {
               void saveShinjeomMessages(db, sessionId, currentMessage, fullResponse, messageIndex).catch(

--- a/src/app/api/tarot/reading/route.ts
+++ b/src/app/api/tarot/reading/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest } from "next/server";
 import { TarotService } from "@/services/tarot/tarot-service";
 import { FallbackProvider } from "@/services/core/fallback-provider";
+import { streamReadingWithParseRetry } from "@/services/core/reading-generator";
 import { DeckManager } from "@/services/tarot/deck-manager";
 import { SpreadResolver } from "@/services/tarot/spread-resolver";
 import { Topic, SpreadType } from "@/types/session";
@@ -87,15 +88,19 @@ export async function POST(request: NextRequest) {
     const encoder = new TextEncoder();
     const stream = new ReadableStream({
       async start(controller) {
-        let fullResponse = "";
         try {
           const cardCount = cards.length;
           const maxTokens = computeReadingMaxTokens(cardCount);
-          for await (const chunk of grokProvider.streamReading(systemPrompt + memoryPrompt, readingPrompt + userInfoPrompt + freeQuestionPrompt, maxTokens)) {
-            fullResponse += chunk;
-            controller.enqueue(encoder.encode(`data: ${JSON.stringify({ chunk })}\n\n`));
-          }
-          const result = tarotService.parseResult(fullResponse, cardCount);
+          // 파싱 실패 시 1회 재생성 (간헐적 JSON 형식 위반 흡수)
+          const { result } = await streamReadingWithParseRetry({
+            provider: grokProvider,
+            systemPrompt: systemPrompt + memoryPrompt,
+            userPrompt: readingPrompt + userInfoPrompt + freeQuestionPrompt,
+            maxTokens,
+            parse: (raw) => tarotService.parseResult(raw, cardCount),
+            onChunk: (chunk) => controller.enqueue(encoder.encode(`data: ${JSON.stringify({ chunk })}\n\n`)),
+            logTag: "tarot-reading",
+          });
 
           // 부분 파싱(누락/잘림)은 운영 로그로 명시 추적
           if (result.parseError) {

--- a/src/hooks/useSajuReading.ts
+++ b/src/hooks/useSajuReading.ts
@@ -97,8 +97,8 @@ export function useSajuReading() {
     });
     const stopTimers = () => timers.forEach(clearTimeout);
 
-    // 클라이언트 hard timeout (240초). 서버 AI_TIMEOUT_MS와 동조 — full-fortune/includeMonthly(max_tokens
-    // 17000~20000)는 reasoning 흡수까지 200~400s 소요 가능. 120s/180s에서는 본문 잘림 빈발.
+    // 클라이언트 hard timeout (280초). 서버 AI_TIMEOUT_MS(240s)보다 크게 잡아 양의 마진 확보 —
+    // 서버가 240s 근처에서 done을 보내도 클라가 먼저 abort하지 않도록 한다(마진 0 회귀 방지).
     const abortController = new AbortController();
     readingAbortRef.current = abortController;
     let finished = false;
@@ -107,12 +107,12 @@ export function useSajuReading() {
       finished = true;
       abortController.abort();
       stopTimers();
-      console.warn("[saju-session] 클라이언트 타임아웃 240s");
+      console.warn("[saju-session] 클라이언트 타임아웃 280s");
       setMood("default");
       setReadingErrorReason("timeout");
       setReadingError(true);
       setLoading(false);
-    }, 240_000);
+    }, 280_000);
 
     void fetchSSEStream({
       url: "/api/saju/reading",
@@ -135,8 +135,9 @@ export function useSajuReading() {
           return;
         }
 
-        // 결과 표시 불가 — DB 저장도 차단된 상태이므로 사용자에게 재시도 안내
-        if (result.parseError) {
+        // 표시 불가 — 본문 salvage조차 없는 경우만 무결과 처리 (타로·신점과 동일 계약).
+        // truncated/fallback_text는 overallReading에 정제 본문이 있으므로 아래에서 부분 표시한다.
+        if (result.parseError === "invalid_json" || result.parseError === "missing_fields") {
           console.warn("[saju-session] 결과 표시 불가:", { parseError: result.parseError });
           const errLines = (charId && wl.characterErrorLines[charId]) ? wl.characterErrorLines[charId] : wl.defaultErrorLines;
           addChatMessage({ id: crypto.randomUUID(), role: "character",
@@ -168,7 +169,17 @@ export function useSajuReading() {
         setMood("default"); setReadingError(true); setLoading(false);
       },
     }).then(() => {
-      if (!finished) clearTimeout(timeoutId);
+      // 스트림이 종단 이벤트(done/error) 없이 종료된 경우(프록시 idle-drop·배포 재시작 등)
+      // 워치독만 해제하면 무한 스피너로 영구 정지 → 명시적 에러로 전환해 복구 가능하게 한다.
+      if (finished) return;
+      finished = true;
+      clearTimeout(timeoutId);
+      stopTimers();
+      console.warn("[saju-session] 스트림이 종단 이벤트 없이 종료됨");
+      const errLines = (charId && wl.characterErrorLines[charId]) ? wl.characterErrorLines[charId] : wl.defaultErrorLines;
+      addChatMessage({ id: crypto.randomUUID(), role: "character",
+        content: errLines.reading, mood: "default", timestamp: new Date() });
+      setMood("default"); setReadingError(true); setLoading(false);
     });
 
     return () => { clearTimeout(timeoutId); abortController.abort(); };

--- a/src/hooks/useShinjeomChat.ts
+++ b/src/hooks/useShinjeomChat.ts
@@ -130,7 +130,7 @@ export function useShinjeomChat() {
       updateMessageContent(msgId, getErrorMsg(characterId, "api", locale));
       setMood("default");
       setLoading(false);
-    }, 240_000);
+    }, 280_000);
 
     void fetchSSEStream({
       url: "/api/shinjeom/message",
@@ -162,7 +162,13 @@ export function useShinjeomChat() {
         setLoading(false);
       },
     }).then(() => {
-      if (!finished) clearTimeout(timeoutId);
+      // 스트림이 종단 이벤트(done/error) 없이 종료된 경우 → 무한 스피너 방지, 명시적 에러로 전환
+      if (finished) return;
+      finished = true;
+      clearTimeout(timeoutId);
+      updateMessageContent(msgId, getErrorMsg(characterId, "reading", locale));
+      setMood("default");
+      setLoading(false);
     });
   };
 
@@ -192,7 +198,7 @@ export function useShinjeomChat() {
       updateMessageContent(msgId, getErrorMsg(characterId, "reading", locale));
       setMood("default");
       setLoading(false);
-    }, 240_000);
+    }, 280_000);
 
     void fetchSSEStream({
       url: "/api/shinjeom/message",
@@ -244,7 +250,13 @@ export function useShinjeomChat() {
         setLoading(false);
       },
     }).then(() => {
-      if (!finished) clearTimeout(timeoutId);
+      // 스트림이 종단 이벤트(done/error) 없이 종료된 경우 → 무한 스피너 방지, 명시적 에러로 전환
+      if (finished) return;
+      finished = true;
+      clearTimeout(timeoutId);
+      updateMessageContent(msgId, getErrorMsg(characterId, "reading", locale));
+      setMood("default");
+      setLoading(false);
     });
   };
 

--- a/src/hooks/useTarotReading.ts
+++ b/src/hooks/useTarotReading.ts
@@ -190,8 +190,8 @@ export function useTarotReading({ setRevealedPositions, setPendingConfirm }: Use
 
     setIsConnecting(false);
 
-    // 클라이언트 hard timeout (240초). 서버 AI_TIMEOUT_MS와 동조 — 10장+ 카드 리딩(max_tokens 24500+)은
-    // reasoning 흡수 + 한국어 비효율 + JSON stream으로 200~400s 소요 가능. 120s/180s에서는 본문 잘림 빈발.
+    // 클라이언트 hard timeout (280초). 서버 AI_TIMEOUT_MS(240s)보다 크게 잡아 양의 마진 확보 —
+    // 서버가 240s 근처에서 done을 보내도 클라가 먼저 abort하지 않도록 한다(마진 0 회귀 방지).
     const abortController = new AbortController();
     readingAbortRef.current = abortController;
     let finished = false;
@@ -200,14 +200,14 @@ export function useTarotReading({ setRevealedPositions, setPendingConfirm }: Use
       finished = true;
       abortController.abort();
       stopSequence();
-      console.warn("[tarot-session] 클라이언트 타임아웃 (240s)");
+      console.warn("[tarot-session] 클라이언트 타임아웃 (280s)");
       setMood("default");
       setReadingErrorReason("timeout");
       setReadingError(true);
       setLoading(false);
       setReadingStartedAt(null);
       readingInFlightRef.current = false;
-    }, 240_000);
+    }, 280_000);
 
     await fetchSSEStream({
       url: "/api/tarot/reading",
@@ -271,7 +271,20 @@ export function useTarotReading({ setRevealedPositions, setPendingConfirm }: Use
         readingInFlightRef.current = false;
       },
     });
-    if (!finished) clearTimeout(timeoutId);
+    // 스트림이 종단 이벤트(done/error) 없이 종료된 경우(프록시 idle-drop·배포 재시작 등)
+    // phase=reading에 스피너만 꺼진 채 영구 정지 → 명시적 에러로 전환해 복구 가능하게 한다.
+    if (!finished) {
+      finished = true;
+      clearTimeout(timeoutId);
+      stopSequence();
+      console.warn("[tarot-session] 스트림이 종단 이벤트 없이 종료됨");
+      addChatMessage({
+        id: crypto.randomUUID(), role: "character",
+        content: getReadingErrorText(translate("tarot.session.msg.connection-failed", locale), characterId),
+        mood: "default", timestamp: new Date(),
+      });
+      setMood("default"); setReadingError(true);
+    }
     useSessionStore.getState().setLoading(false);
     setReadingStartedAt(null);
     readingInFlightRef.current = false;

--- a/src/services/CLAUDE.md
+++ b/src/services/CLAUDE.md
@@ -12,7 +12,8 @@ services/
 │   ├── grok-provider.ts       # Grok API 호출, RateLimitError / AuthError 정의
 │   ├── claude-provider.ts     # Claude API 호출 (fallback 전용)
 │   ├── prompt-builder.ts      # buildCharacterHeader / buildSystemPrompt / buildReadingPrompt / buildUserInfoPrompt / buildFreeQuestionPrompt / buildDirectAnswerContract(질문 직답 answer-first 계약) / buildReadabilityContract(쉬운 말 계약, 3서비스 공통) / buildCharacterMemoryPrompt / getLanguageFooter
-│   └── text-cleaner.ts        # cleanReadingText / parseJsonSafe / extractFallbackText
+│   ├── reading-generator.ts   # streamReadingWithParseRetry — 1차 스트리밍 → parseError 시 1회 non-stream 재생성 (3 리딩 라우트 공통)
+│   └── text-cleaner.ts        # cleanReadingText / parseJsonSafe(트레일링 콤마 내성) / promoteNestedFields(섹션 내부 필드 승격) / extractFallbackText
 ├── tarot/
 │   ├── tarot-service.ts       # DivinationService 구현체
 │   ├── deck-manager.ts        # 카드 덱 셔플·뽑기

--- a/src/services/core/reading-generator.test.ts
+++ b/src/services/core/reading-generator.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi } from "vitest";
+import { streamReadingWithParseRetry } from "./reading-generator";
+import type { AIProvider } from "@/types/service";
+
+/** 테스트용 mock provider — streamReading은 청크 배열을 yield, generateReading은 지정 문자열 반환 */
+function makeProvider(streamChunks: string[], generateResponses: string[]): AIProvider {
+  let genCall = 0;
+  return {
+    async *streamReading() {
+      for (const c of streamChunks) yield c;
+    },
+    async generateReading() {
+      const r = generateResponses[genCall] ?? generateResponses.at(-1) ?? "";
+      genCall++;
+      return r;
+    },
+  } as AIProvider;
+}
+
+const parse = (raw: string) =>
+  raw.includes("BAD") ? { parseError: "invalid_json" as const, text: raw } : { text: raw };
+
+describe("streamReadingWithParseRetry", () => {
+  it("1차 파싱 성공 시 재생성하지 않고 결과를 반환한다", async () => {
+    const provider = makeProvider(["OK"], ["should-not-be-used"]);
+    const genSpy = vi.spyOn(provider, "generateReading");
+    const onChunk = vi.fn();
+    const { result, retried } = await streamReadingWithParseRetry({
+      provider, systemPrompt: "s", userPrompt: "u", maxTokens: 100, parse, onChunk,
+    });
+    expect(result.parseError).toBeUndefined();
+    expect(retried).toBe(false);
+    expect(genSpy).not.toHaveBeenCalled();
+    expect(onChunk).toHaveBeenCalledWith("OK");
+  });
+
+  it("1차 파싱 실패 시 1회 재생성하고 성공하면 재생성 결과를 채택한다", async () => {
+    const provider = makeProvider(["BAD"], ["GOOD"]);
+    const { result, retried, fullResponse } = await streamReadingWithParseRetry({
+      provider, systemPrompt: "s", userPrompt: "u", maxTokens: 100, parse, onChunk: () => {},
+    });
+    expect(retried).toBe(true);
+    expect(result.parseError).toBeUndefined();
+    expect(fullResponse).toBe("GOOD");
+  });
+
+  it("재생성도 실패하면 1차(원본) 결과를 유지한다", async () => {
+    const provider = makeProvider(["BAD1"], ["BAD2"]);
+    const { result, retried } = await streamReadingWithParseRetry({
+      provider, systemPrompt: "s", userPrompt: "u", maxTokens: 100, parse, onChunk: () => {},
+    });
+    expect(retried).toBe(true);
+    expect(result.parseError).toBe("invalid_json");
+    expect(result.text).toBe("BAD1");
+  });
+
+  it("재생성 호출 자체가 throw하면 1차 결과를 유지한다(가용성 우선)", async () => {
+    const provider = makeProvider(["BAD"], []);
+    vi.spyOn(provider, "generateReading").mockRejectedValue(new Error("network"));
+    const { result, retried } = await streamReadingWithParseRetry({
+      provider, systemPrompt: "s", userPrompt: "u", maxTokens: 100, parse, onChunk: () => {},
+    });
+    expect(retried).toBe(true);
+    expect(result.parseError).toBe("invalid_json");
+  });
+
+  it("maxRetries=0이면 재생성하지 않는다", async () => {
+    const provider = makeProvider(["BAD"], ["GOOD"]);
+    const genSpy = vi.spyOn(provider, "generateReading");
+    const { result, retried } = await streamReadingWithParseRetry({
+      provider, systemPrompt: "s", userPrompt: "u", maxTokens: 100, parse, onChunk: () => {}, maxRetries: 0,
+    });
+    expect(retried).toBe(false);
+    expect(result.parseError).toBe("invalid_json");
+    expect(genSpy).not.toHaveBeenCalled();
+  });
+
+  it("스트리밍된 모든 청크를 onChunk로 순서대로 전달한다", async () => {
+    const provider = makeProvider(["a", "b", "c"], ["x"]);
+    const chunks: string[] = [];
+    await streamReadingWithParseRetry({
+      provider, systemPrompt: "s", userPrompt: "u", maxTokens: 100, parse, onChunk: (c) => chunks.push(c),
+    });
+    expect(chunks).toEqual(["a", "b", "c"]);
+  });
+});

--- a/src/services/core/reading-generator.ts
+++ b/src/services/core/reading-generator.ts
@@ -1,0 +1,54 @@
+import type { AIProvider } from "@/types/service";
+
+/**
+ * 리딩 생성 + 파싱 실패 시 1회 재생성.
+ *
+ * 배경(2026-07-06 조사): 사주·신점 리딩이 간헐적으로 JSON 형식 위반(트레일링 콤마·필드 중첩)을 내
+ * parseResult가 parseError를 반환 → 사용자 무결과/부실 결과. 모델이 ~⅓만 실패하므로, 첫 시도가
+ * parseError면 **한 번 더** 생성해 대부분을 흡수한다.
+ *
+ * - 1차: streamReading (청크는 onChunk로 클라이언트에 전달 — 대기 연출/스트리밍 표시용).
+ * - 재시도: generateReading (non-stream) — 중복 청크 이벤트를 보내지 않기 위해 스트리밍하지 않는다.
+ *   (3개 리딩 라우트 모두 최종 결과는 done 이벤트로만 소비하므로 재시도 청크 미표시는 UX에 무해.)
+ * - 재시도 결과가 parseError 없으면 채택, 아니면 1차 결과를 유지(결정론적).
+ * - 재시도 생성 자체가 throw하면 1차 결과를 유지(가용성 우선).
+ */
+export async function streamReadingWithParseRetry<T extends { parseError?: string }>(opts: {
+  provider: AIProvider;
+  systemPrompt: string;
+  userPrompt: string;
+  maxTokens: number;
+  parse: (raw: string) => T;
+  onChunk: (chunk: string) => void;
+  maxRetries?: number;
+  logTag?: string;
+}): Promise<{ result: T; fullResponse: string; retried: boolean }> {
+  const { provider, systemPrompt, userPrompt, maxTokens, parse, onChunk, maxRetries = 1, logTag = "reading" } = opts;
+
+  let fullResponse = "";
+  for await (const chunk of provider.streamReading(systemPrompt, userPrompt, maxTokens)) {
+    fullResponse += chunk;
+    onChunk(chunk);
+  }
+  let result = parse(fullResponse);
+  let retried = false;
+
+  for (let i = 0; i < maxRetries && result.parseError; i++) {
+    retried = true;
+    console.warn(`[${logTag}] parseError=${result.parseError} → 재생성 ${i + 1}/${maxRetries}`);
+    try {
+      const retryResponse = await provider.generateReading(systemPrompt, userPrompt, maxTokens);
+      const retryResult = parse(retryResponse);
+      if (!retryResult.parseError) {
+        result = retryResult;
+        fullResponse = retryResponse;
+        break;
+      }
+    } catch (e) {
+      console.warn(`[${logTag}] 재생성 실패:`, e instanceof Error ? e.message : String(e));
+      break;
+    }
+  }
+
+  return { result, fullResponse, retried };
+}

--- a/src/services/core/text-cleaner.test.ts
+++ b/src/services/core/text-cleaner.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { cleanReadingText, parseJsonSafe, extractFallbackText } from "./text-cleaner";
+import { cleanReadingText, parseJsonSafe, extractFallbackText, promoteNestedFields } from "./text-cleaner";
 
 describe("cleanReadingText", () => {
   it("빈 문자열 입력 시 빈 문자열을 반환한다", () => {
@@ -323,5 +323,87 @@ describe("extractFallbackText", () => {
 
   it("일반 텍스트는 trim 후 그대로 반환한다", () => {
     expect(extractFallbackText("  해석 결과  ")).toBe("해석 결과");
+  });
+});
+
+// 2026-07-06 조사: 사주·신점 리딩 간헐 무결과 근본원인(트레일링 콤마·필드 중첩) 회귀 방지
+describe("parseJsonSafe — LLM 형식 위반 내성", () => {
+  it("객체 마지막 필드 뒤 트레일링 콤마를 허용해 파싱한다", () => {
+    const input = `{"overallReading": "종합 해석", "advice": "조언",}`;
+    const result = parseJsonSafe(input);
+    expect(result).not.toBeNull();
+    expect(result?.overallReading).toBe("종합 해석");
+    expect(result?.advice).toBe("조언");
+  });
+
+  it("중첩 객체 마지막 필드 뒤 트레일링 콤마(실측 신점 fallback_text 패턴)를 복구한다", () => {
+    const input = `{
+      "shinjeomSections": {
+        "spiritual": "기운",
+        "future": "앞날",
+      },
+      "overallReading": "종합",
+      "advice": "조언"
+    }`;
+    const result = parseJsonSafe(input);
+    expect(result).not.toBeNull();
+    expect(result?.overallReading).toBe("종합");
+    expect((result?.shinjeomSections as Record<string, unknown>)?.future).toBe("앞날");
+  });
+
+  it("배열 마지막 요소 뒤 트레일링 콤마도 허용한다", () => {
+    const input = `{"items": ["a", "b",]}`;
+    const result = parseJsonSafe(input);
+    expect(result).not.toBeNull();
+    expect(result?.items).toEqual(["a", "b"]);
+  });
+
+  it("트레일링 콤마 + 문자열 내 실제 개행이 동시에 있어도 파싱한다", () => {
+    const input = "{\n\"overallReading\": \"문단1\n문단2\",\n\"advice\": \"조언\",\n}";
+    const result = parseJsonSafe(input);
+    expect(result).not.toBeNull();
+    expect(result?.advice).toBe("조언");
+  });
+
+  it("문자열 값 안의 콤마+중괄호는 트레일링 콤마로 오인하지 않는다", () => {
+    const input = `{"advice": "먼저 A, 그다음 B}", "overallReading": "정상"}`;
+    const result = parseJsonSafe(input);
+    expect(result).not.toBeNull();
+    expect(result?.advice).toBe("먼저 A, 그다음 B}");
+    expect(result?.overallReading).toBe("정상");
+  });
+});
+
+describe("promoteNestedFields", () => {
+  it("섹션 내부에 잘못 중첩된 flat 필드를 top-level로 승격한다(실측 missing_fields 패턴)", () => {
+    const parsed: Record<string, unknown> = {
+      sajuSections: { structure: "구조", overallReading: "종합", advice: "조언" },
+    };
+    promoteNestedFields(parsed, "sajuSections", ["overallReading", "advice", "directAnswer"]);
+    expect(parsed.overallReading).toBe("종합");
+    expect(parsed.advice).toBe("조언");
+  });
+
+  it("top-level에 이미 값이 있으면 섹션 값으로 덮어쓰지 않는다", () => {
+    const parsed: Record<string, unknown> = {
+      overallReading: "원본",
+      sajuSections: { overallReading: "섹션내부" },
+    };
+    promoteNestedFields(parsed, "sajuSections", ["overallReading"]);
+    expect(parsed.overallReading).toBe("원본");
+  });
+
+  it("섹션 내부 값이 빈 문자열이면 승격하지 않는다", () => {
+    const parsed: Record<string, unknown> = { overallReading: "", sajuSections: { overallReading: "   " } };
+    promoteNestedFields(parsed, "sajuSections", ["overallReading"]);
+    expect(parsed.overallReading).toBe("");
+  });
+
+  it("섹션 키가 없거나 객체가 아니면 아무것도 하지 않는다", () => {
+    const parsed: Record<string, unknown> = { overallReading: "" };
+    promoteNestedFields(parsed, "sajuSections", ["overallReading"]);
+    expect(parsed.overallReading).toBe("");
+    const parsed2: Record<string, unknown> = { sajuSections: "문자열" };
+    expect(() => promoteNestedFields(parsed2, "sajuSections", ["overallReading"])).not.toThrow();
   });
 });

--- a/src/services/core/text-cleaner.ts
+++ b/src/services/core/text-cleaner.ts
@@ -57,6 +57,30 @@ function findOutermostObjectEnd(text: string, start: number): number {
 }
 
 /**
+ * 객체·배열 닫힘 앞의 트레일링 콤마를 제거한다 (`,}` / `,]`).
+ * LLM이 마지막 필드 뒤에 콤마를 남기는 매우 흔한 형식 위반을 교정. (문자열 내부는 건드리지 않음)
+ */
+function stripTrailingCommas(text: string): string {
+  let out = "";
+  let inString = false;
+  let escape = false;
+  for (let i = 0; i < text.length; i++) {
+    const ch = text[i];
+    if (escape) { out += ch; escape = false; continue; }
+    if (ch === "\\") { out += ch; escape = true; continue; }
+    if (ch === '"') { inString = !inString; out += ch; continue; }
+    if (!inString && ch === ",") {
+      // 다음 비공백 문자가 } 또는 ] 이면 트레일링 콤마 → 제거
+      let j = i + 1;
+      while (j < text.length && /\s/.test(text[j])) j++;
+      if (j < text.length && (text[j] === "}" || text[j] === "]")) continue;
+    }
+    out += ch;
+  }
+  return out;
+}
+
+/**
  * AI 응답 raw 문자열에서 JSON 객체를 안전하게 추출·파싱.
  *
  * 처리 순서:
@@ -65,7 +89,8 @@ function findOutermostObjectEnd(text: string, start: number): number {
  * 3. 가장 바깥 { ... } 추출 (문자열 내부 { } 무시)
  * 4. JSON.parse 1차 시도
  * 5. 문자열 값 내 리터럴 개행·탭 이스케이프 후 2차 시도
- * 6. 실패 시 null 반환
+ * 6. 트레일링 콤마 제거 후 3차 시도 (LLM 흔한 형식 위반)
+ * 7. 실패 시 null 반환
  */
 export function parseJsonSafe(raw: string): Record<string, unknown> | null {
   let text = raw.trim();
@@ -93,12 +118,42 @@ export function parseJsonSafe(raw: string): Record<string, unknown> | null {
 
   // 2차 시도: 문자열 리터럴 내 개행·탭 이스케이프
   // "..." 패턴 내부의 비이스케이프 개행만 교체
+  const escaped = text.replace(/("(?:[^"\\]|\\.)*")/g, (m) =>
+    m.replaceAll("\n", String.raw`\n`).replaceAll("\r", "").replaceAll("\t", String.raw`\t`)
+  );
   try {
-    const sanitized = text.replace(/("(?:[^"\\]|\\.)*")/g, (m) =>
-      m.replaceAll("\n", String.raw`\n`).replaceAll("\r", "").replaceAll("\t", String.raw`\t`)
-    );
-    return JSON.parse(sanitized) as Record<string, unknown>;
+    return JSON.parse(escaped) as Record<string, unknown>;
   } catch { /* 다음 파싱 방법으로 계속 */ } // NOSONAR
 
+  // 3차 시도: 트레일링 콤마 제거 (2차의 개행 교정과 합쳐 적용)
+  try {
+    return JSON.parse(stripTrailingCommas(escaped)) as Record<string, unknown>;
+  } catch { /* 최종 실패 */ } // NOSONAR
+
   return null;
+}
+
+/**
+ * 모델이 flat 필드(overallReading·advice 등)를 섹션 객체(sajuSections/shinjeomSections) *내부*에
+ * 잘못 중첩한 경우 top-level로 승격한다. (실측: 사주·신점 리딩의 흔한 형식 위반으로, 내용은
+ * 생성됐으나 위치가 틀려 missing_fields로 폐기되던 결함을 복구.)
+ *
+ * parsed[sectionKey][field]가 비지 않은 문자열이고 parsed[field]가 없거나 빈 문자열일 때만 끌어올린다.
+ * parsed 객체를 in-place로 수정한다.
+ */
+export function promoteNestedFields(
+  parsed: Record<string, unknown>,
+  sectionKey: string,
+  fields: readonly string[],
+): void {
+  const section = parsed[sectionKey];
+  if (!section || typeof section !== "object") return;
+  const s = section as Record<string, unknown>;
+  for (const f of fields) {
+    const cur = parsed[f];
+    const nested = s[f];
+    if ((cur === undefined || cur === null || cur === "") && typeof nested === "string" && nested.trim()) {
+      parsed[f] = nested;
+    }
+  }
 }

--- a/src/services/saju/saju-service.ts
+++ b/src/services/saju/saju-service.ts
@@ -4,7 +4,7 @@ import { Session, Topic, SajuTimeRange } from "@/types/session";
 import { getCharacterById } from "@/data/characters";
 import { SajuResult } from "./saju-types";
 import { OhaengType, OHAENG } from "@/data/saju/constants";
-import { cleanReadingText, parseJsonSafe, extractFallbackText } from "@/services/core/text-cleaner";
+import { cleanReadingText, parseJsonSafe, extractFallbackText, promoteNestedFields } from "@/services/core/text-cleaner";
 import { buildCharacterHeader, getLanguageFooter, buildDirectAnswerContract, buildReadabilityContract } from "@/services/core/prompt-builder";
 import { sajuTimeOptions } from "@/data/saju/categories";
 
@@ -249,6 +249,8 @@ ${contract.systemSpec}
 - 내부 reasoning·생각·계획 단계를 출력하지 마세요. 첫 토큰부터 곧바로 JSON을 시작합니다.
 - <think> 같은 태그·메타 텍스트도 출력 금지 (응답 토큰 한도 내에 JSON 본문이 모두 들어가야 함).
 - JSON 문자열 값 안의 줄바꿈은 반드시 \\n 이스케이프로 표현합니다. 실제 줄바꿈 문자를 사용하지 않습니다.
+- overallReading·topicReading·advice·directAnswer는 sajuSections **바깥**의 최상위(top-level) 필드입니다. 절대 sajuSections 객체 안에 넣지 마세요.
+- 각 객체·배열의 마지막 항목 뒤에는 쉼표(,)를 넣지 않습니다 (트레일링 콤마 금지).
 {
   "sajuSections": {
     "structure": "일간 특성·신강신약·격국 분석. 타고난 기질, 삶의 방향성, 에너지 구조를 5~6문단으로 깊이 있게 서술.",
@@ -321,6 +323,8 @@ ${instruction}${horizonNote}
     const parsed = parseJsonSafe(aiResponse);
 
     if (parsed) {
+      // 모델이 flat 필드를 sajuSections 내부에 잘못 중첩한 경우 top-level로 승격 (missing_fields 복구)
+      promoteNestedFields(parsed, "sajuSections", ["overallReading", "topicReading", "advice", "directAnswer"]);
       const overallReading = cleanReadingText(typeof parsed.overallReading === "string" ? parsed.overallReading : "");
       const advice = cleanReadingText(typeof parsed.advice === "string" ? parsed.advice : "");
       const result: ReadingResult = {

--- a/src/services/shinjeom/shinjeom-service.ts
+++ b/src/services/shinjeom/shinjeom-service.ts
@@ -2,7 +2,7 @@ import { DivinationService, ReadingResult, SessionContext } from "@/types/servic
 import { CharacterConfig } from "@/types/character";
 import { Session, Topic, ChatMessage } from "@/types/session";
 import { getCharacterById } from "@/data/characters";
-import { cleanReadingText, parseJsonSafe, extractFallbackText } from "@/services/core/text-cleaner";
+import { cleanReadingText, parseJsonSafe, extractFallbackText, promoteNestedFields } from "@/services/core/text-cleaner";
 import { buildCharacterHeader, buildUserInfoPrompt, getLanguageFooter, buildDirectAnswerContract, buildReadabilityContract } from "@/services/core/prompt-builder";
 import { UserInfo } from "@/types/user-info";
 
@@ -133,6 +133,8 @@ ${contract.schemaLine}
 
 JSON 문자열 값 안의 줄바꿈은 반드시 \\n으로 표현합니다.
 JSON 앞뒤에 어떤 텍스트도 추가하지 않습니다.
+overallReading·topicReading·advice·directAnswer는 shinjeomSections 바깥의 최상위(top-level) 필드입니다. 절대 shinjeomSections 객체 안에 넣지 마세요.
+각 객체·배열의 마지막 항목 뒤에는 쉼표(,)를 넣지 않습니다 (트레일링 콤마 금지).
 내부 reasoning·생각·계획 단계를 출력하지 마세요 — 첫 토큰부터 곧바로 JSON을 시작하고 <think> 같은 태그도 출력 금지.
 ${contract.footerReminder}`;
   }
@@ -149,6 +151,8 @@ ${contract.footerReminder}`;
   parseResult(aiResponse: string): ReadingResult {
     const parsed = parseJsonSafe(aiResponse);
     if (parsed) {
+      // 모델이 flat 필드를 shinjeomSections 내부에 잘못 중첩한 경우 top-level로 승격 (missing_fields 복구)
+      promoteNestedFields(parsed, "shinjeomSections", ["overallReading", "topicReading", "advice", "directAnswer"]);
       const overallReading = cleanReadingText(typeof parsed.overallReading === "string" ? parsed.overallReading : "");
       const advice = cleanReadingText(typeof parsed.advice === "string" ? parsed.advice : "");
       const result: ReadingResult = {


### PR DESCRIPTION
## 배경 — 전수조사 + 실측 재현

\"타로·사주·신점 리딩 결과가 간헐적으로 안 나온다\"는 서비스 품질 이슈를 조사. **프로덕션 엔드포인트 익명 반복 호출 40회 + 원시 응답 캡처**로 근본원인을 확정.

### 실측 실패율 (완료 15~40초 — 타임아웃/절단 무관)
| 서비스 | 실패율 | 유형 |
|---|---|---|
| 타로 | **0%** (0/8) | 정상 (flat·비중복 스키마) |
| 사주 | **~21%** (3/14) | `missing_fields` → 완전 무결과 |
| 신점 | **~67%** (6/9) | `fallback_text`·`missing_fields` → 깨진/부실 결과 |

### 근본원인 (원시 응답으로 확정, 모든 실패가 `endsBrace=true`=잘림 아님)
`sajuSections`/`shinjeomSections` **중첩 스키마가 flat 필드(overallReading/topicReading/advice)와 내용이 중복** → 모델 혼란으로 두 가지 형식 위반:
1. **트레일링 콤마** (`"future":"...",` 다음 `}`) → `JSON.parse` 실패 → `fallback_text`
2. **필드 중첩** (flat 필드를 섹션 객체 *내부*에 배치) → top-level 빈값 → `missing_fields`

타로가 0%인 이유는 flat·비중복 스키마이기 때문.

## 수정 (근본 + 방어 + 잠재위험)
- **`parseJsonSafe`**: 트레일링 콤마 제거 3차 파싱 시도
- **`promoteNestedFields`**: 섹션 내부 flat 필드를 top-level로 승격 (saju/shinjeom `parseResult`)
- **`streamReadingWithParseRetry`** (`reading-generator.ts`): `parseError` 시 1회 non-stream 재생성 (3 라우트 공통)
- **프롬프트**: flat 필드는 섹션 밖 top-level·트레일링 콤마 금지 명시
- **사주 클라이언트**: `parseError` 처리를 타로·신점과 동일 계약으로 완화 (`fallback_text` 부분 표시)
- **잠재위험**: SSE 종단 이벤트(done/error) 부재 시 영구 스피너 방지 가드(3훅), 클라 hard timeout 240→280s (서버 `AI_TIMEOUT_MS` 240s 대비 양의 마진)

## 검증
- **실측 프로덕션 실패 5건 원시 응답 → 수정 파서로 전부 파싱 복구 확인** (4건 완전 복구, 1건은 재시도가 흡수)
- 신규 단위 테스트: `text-cleaner`(트레일링 콤마·`promoteNestedFields`), `reading-generator`(재시도 6케이스)
- `type-check` · `lint` · `test:coverage`(statements 98.8/branches 91.4/functions 98.7/lines 99.6 — 임계값 전 통과) · `i18n:check` · `check:doc-links` 통과
- 문서 갱신: `ai-infrastructure.md`, `src/services/CLAUDE.md`, `.claude/rules/services.md`

> Claude fallback(ANTHROPIC_API_KEY) 프로덕션 설정 확인됨. DOM/셀렉터 변경 없어 E2E 영향 없음 (CI 검증).
> 남은 잠재 개선(추후): 스키마 중복 자체 제거(섹션 vs flat 택일, UX 결정 필요), parseError 실패의 계량용 dead-letter 기록.

🤖 Generated with [Claude Code](https://claude.com/claude-code)