### PR TITLE
perf(deploy): Railway 배포 이미지 최소화 — standalone Dockerfile + 경량 헬스체크

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,31 @@
+# Railway/nixpacks 빌드 컨텍스트 슬림화 — 배포 이미지·업로드 시간 축소.
+# 런타임(next start/standalone)·빌드(next build)에 불필요한 것만 제외한다.
+# 유지: src/, public/, package.json, pnpm-lock.yaml, next.config.ts, tsconfig.json,
+#       postcss.config.*, middleware.ts, nixpacks.toml, railway.toml
+
+.git
+node_modules
+.next
+
+# 테스트·E2E (배포 불필요)
+e2e
+coverage
+playwright-report
+test-results
+**/*.test.ts
+**/*.test.tsx
+
+# 개발 스크립트·도구 (빌드/런타임 미참조)
+scripts
+n8n
+.claude
+.vscode
+.github
+
+# 문서·DB 마이그레이션 (런타임 미참조)
+docs
+supabase
+
+# 시크릿·로컬 env (이미지에 포함 금지). Railway는 대시보드 변수를 주입한다.
+.env
+.env.*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,46 @@
+# 멀티스테이지 빌드 — Next.js standalone 출력으로 런타임 이미지를 최소화한다.
+# 목적: Railway 배포 이미지 축소(전체 node_modules 580MB·빌드 툴 제외) → export/push/pull·배포 가속.
+# 참고: output:"standalone"(next.config.ts)이 런타임 필요한 의존성만 추적해 .next/standalone에 담는다.
+
+# ── 1) 의존성 설치 ─────────────────────────────────────────────
+FROM node:20-slim AS deps
+RUN corepack enable && corepack prepare pnpm@10.33.0 --activate
+WORKDIR /app
+COPY package.json pnpm-lock.yaml ./
+RUN pnpm install --frozen-lockfile
+
+# ── 2) 빌드 ────────────────────────────────────────────────────
+FROM node:20-slim AS build
+RUN corepack enable && corepack prepare pnpm@10.33.0 --activate
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+# NEXT_PUBLIC_* 는 next build 시 클라이언트 번들에 "인라인"되므로 빌드 인자로 주입해야 한다.
+# Railway는 서비스 변수를 Dockerfile 빌드 ARG로 제공한다(각 변수를 대시보드에 설정).
+ARG NEXT_PUBLIC_SUPABASE_URL
+ARG NEXT_PUBLIC_SUPABASE_ANON_KEY
+ARG NEXT_PUBLIC_SITE_URL
+ARG NEXT_PUBLIC_ASSET_BASE_URL
+ENV NEXT_PUBLIC_SUPABASE_URL=$NEXT_PUBLIC_SUPABASE_URL \
+    NEXT_PUBLIC_SUPABASE_ANON_KEY=$NEXT_PUBLIC_SUPABASE_ANON_KEY \
+    NEXT_PUBLIC_SITE_URL=$NEXT_PUBLIC_SITE_URL \
+    NEXT_PUBLIC_ASSET_BASE_URL=$NEXT_PUBLIC_ASSET_BASE_URL \
+    NEXT_TELEMETRY_DISABLED=1
+RUN pnpm build
+
+# ── 3) 런타임 (슬림) ───────────────────────────────────────────
+FROM node:20-slim AS runtime
+WORKDIR /app
+ENV NODE_ENV=production \
+    HOSTNAME=0.0.0.0 \
+    NEXT_TELEMETRY_DISABLED=1
+# 비루트 실행
+RUN addgroup --system --gid 1001 nodejs && adduser --system --uid 1001 nextjs
+# standalone 서버 + 정적 자산 + public 만 복사 (전체 node_modules·빌드 툴 제외)
+COPY --from=build --chown=nextjs:nodejs /app/.next/standalone ./
+COPY --from=build --chown=nextjs:nodejs /app/.next/static ./.next/static
+COPY --from=build --chown=nextjs:nodejs /app/public ./public
+USER nextjs
+EXPOSE 3000
+# PORT는 Railway가 런타임에 주입(standalone server.js가 process.env.PORT 사용)
+CMD ["node", "server.js"]

--- a/docs/operations/deployment.md
+++ b/docs/operations/deployment.md
@@ -10,17 +10,30 @@ ArcanaInsight는 Railway를 사용하여 자동 배포됩니다.
 ## 자동 배포 흐름
 
 ```
-PR 머지 → main push → Railway 자동 빌드 → 배포 완료 (약 2~3분)
+PR 머지 → main push → Railway 자동 빌드(Dockerfile) → /api/health 통과 → 트래픽 스왑
 ```
 
 Railway는 `main` 브랜치의 모든 push에 자동으로 반응합니다. 수동 배포 트리거는 필요하지 않습니다.
+**헬스체크(`/api/health`)가 통과해야만 새 배포로 트래픽이 넘어가므로**, 빌드/기동 실패 시 기존 배포가 계속 서빙됩니다(무중단·안전 스왑).
+
+### 빌드 최적화 (배포 이미지 최소화 → 배포 가속)
+
+`next.config.ts`의 `output: "standalone"` + 멀티스테이지 `Dockerfile`로 런타임 이미지를 최소화한다:
+- standalone이 런타임 필요한 의존성만 추적 → 런타임 `node_modules` 580MB → ~38MB
+- 슬림 런타임 스테이지에 `.next/standalone` + `.next/static` + `public`만 복사 (전체 node_modules·빌드 툴 제외)
+- `.dockerignore`로 빌드 컨텍스트 슬림화 (e2e·docs·scripts·supabase·테스트·.env 제외)
+- 실측(amd64): 전체 이미지 ~1.1GB(nixpacks 추정) → **~416MB**. 캐릭터 이미지 R2 이전 시 public 축소로 추가 감소.
+
+> ⚠️ **NEXT_PUBLIC_* 빌드 인자 필수**: `NEXT_PUBLIC_SUPABASE_URL`·`NEXT_PUBLIC_SUPABASE_ANON_KEY`·`NEXT_PUBLIC_SITE_URL`·`NEXT_PUBLIC_ASSET_BASE_URL`은 `next build` 시 클라이언트 번들에 인라인되므로, Railway 서비스 변수로 설정되어 있어야 Dockerfile `ARG`로 주입된다. 누락 시 빌드는 되지만 클라이언트가 잘못된 값(예: R2 base 미설정 → 이미지 깨짐)으로 동작한다.
 
 ---
 
 ## 설정 파일
 
-- `railway.toml` — 빌드/배포 설정 (nixpacks 빌더)
-- `.github/workflows/deploy.yml` — PR CI 워크플로우 (Railway 배포 전 게이트)
+- `Dockerfile` — 멀티스테이지 빌드 (deps → build → 슬림 runtime, standalone 서버 기동)
+- `.dockerignore` — 빌드 컨텍스트 제외 목록
+- `railway.toml` — 빌드/배포 설정 (`builder = "dockerfile"`, `healthcheckPath = "/api/health"`)
+- `.github/workflows/deploy.yml` — PR CI 워크플로우 (Railway 배포 전 게이트, CI는 `next start` 사용)
 
 ### GitHub Secrets (CI 전용)
 

--- a/middleware.ts
+++ b/middleware.ts
@@ -24,6 +24,6 @@ export async function middleware(request: NextRequest) {
 
 export const config = {
   matcher: [
-    "/((?!_next/static|_next/image|favicon.ico|images/|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)",
+    "/((?!_next/static|_next/image|favicon.ico|images/|api/health|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)",
   ],
 }

--- a/next.config.ts
+++ b/next.config.ts
@@ -39,6 +39,9 @@ const securityHeaders = [
 ];
 
 const nextConfig: NextConfig = {
+  // 런타임에 필요한 의존성만 추적해 최소 서버 번들 생성 → Railway 배포 이미지 대폭 축소·배포 가속.
+  // 배포: railway.toml이 빌드 후 public·.next/static을 .next/standalone에 복사하고 server.js로 기동.
+  output: "standalone",
   async headers() {
     return [{ source: "/:path*", headers: securityHeaders }];
   },

--- a/railway.toml
+++ b/railway.toml
@@ -1,9 +1,10 @@
 [build]
-builder = "nixpacks"
-buildCommand = "pnpm install --frozen-lockfile && pnpm build"
+# Dockerfile 멀티스테이지 빌드 — Next.js standalone으로 런타임 이미지 최소화 (배포 가속).
+# NEXT_PUBLIC_* 서비스 변수는 Railway가 Dockerfile 빌드 ARG로 제공하므로 대시보드에 설정되어 있어야 한다.
+builder = "dockerfile"
 
 [deploy]
-startCommand = "pnpm start"
-healthcheckPath = "/"
+# 홈(/) 대신 경량 /api/health로 기동 판정 → 무거운 홈 SSR 대기·불필요한 재기동 방지.
+healthcheckPath = "/api/health"
 restartPolicyType = "on_failure"
 restartPolicyMaxRetries = 3

--- a/src/__tests__/api/health.test.ts
+++ b/src/__tests__/api/health.test.ts
@@ -1,0 +1,11 @@
+import { describe, it, expect } from "vitest";
+import { GET } from "@/app/api/health/route";
+
+describe("GET /api/health", () => {
+  it("200과 {status:'ok'}를 반환한다 (배포 헬스체크)", async () => {
+    const res = GET();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({ status: "ok" });
+  });
+});

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -1,0 +1,10 @@
+import { NextResponse } from "next/server";
+
+// 배포 헬스체크 전용 경량 엔드포인트. railway.toml healthcheckPath가 이걸 가리켜,
+// 무거운 홈(/) SSR·이미지 최적화로 기동 판정이 지연·재기동되는 것을 피한다.
+// 미들웨어 matcher에서 제외되어 Supabase 세션 호출 없이 즉시 200을 반환한다.
+export const dynamic = "force-dynamic";
+
+export function GET() {
+  return NextResponse.json({ status: "ok" });
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -48,6 +48,7 @@ export default defineConfig({
         "src/app/api/shinjeom/result/[id]/route.ts",  // PR-L
         "src/app/api/sessions/claim/route.ts",        // 익명 세션 claim
         "src/app/api/internal/reading-dlq/retry/route.ts", // A-1 dead-letter 재처리
+        "src/app/api/health/route.ts",                // 배포 헬스체크 — 테스트 있음
         "src/lib/supabase/admin.ts",  // Admin client — 테스트 있음
         "src/lib/db/index.ts",        // DB provider 팩토리 — 테스트 있음
         "src/i18n/config.ts",         // PR-1 i18n config — 테스트 있음


### PR DESCRIPTION
## 배경 — 배포 지연 분석
\"Railway 배포가 문서상 2~3분인데 ~15분 걸린다\"를 분석. **`next build`는 로컬 실측 19초로 병목이 아님.** 지연은 배포 이미지 크기·install·헬스체크에서 발생.

측정 근거:
- `node_modules` **580MB** (playwright·aws-sdk·anthropic·vitest 등 런타임 불필요 포함)
- `public/` **317MB** (캐릭터 이미지 283MB — PR B에서 R2 이전 예정)
- `output:standalone` 미설정, `.dockerignore` 없음, healthcheck가 무거운 홈(`/`)

## 변경 (이미지 최소화 → 배포 가속)
- **`next.config`: `output: "standalone"`** — 런타임 필요한 의존성만 추적 (node_modules 580MB → **38MB**, 로컬 실측)
- **멀티스테이지 `Dockerfile`** — 슬림 런타임에 `.next/standalone`+`.next/static`+`public`만 복사. `NEXT_PUBLIC_*`는 빌드 시 인라인되므로 `ARG`로 주입
- **`railway.toml`**: `builder` nixpacks→dockerfile, `healthcheckPath` `/`→`/api/health`
- **`.dockerignore`** — 빌드 컨텍스트 슬림화 (e2e·docs·scripts·supabase·테스트·.env 제외)
- **`/api/health`** 경량 라우트 + 미들웨어 matcher 제외(Supabase 세션 호출 회피)

## 검증 (로컬 Docker 실측)
- 컨테이너 기동 → **`/api/health` 200**, **`/` 200**(130KB) — standalone 서버·HOSTNAME/PORT 정상
- **이미지 amd64 실측 416MB** (현재 nixpacks 추정 ~1.1GB 대비 −62%). PR B(캐릭터 R2)로 public 축소 시 ~120MB 예상
- type-check · lint · test:coverage(임계값 전 통과) · doc-links 통과

## ⚠️ 배포 전 확인
- **Railway 서비스 변수**에 `NEXT_PUBLIC_SUPABASE_URL`·`NEXT_PUBLIC_SUPABASE_ANON_KEY`·`NEXT_PUBLIC_SITE_URL`·`NEXT_PUBLIC_ASSET_BASE_URL`이 설정되어 있어야 Dockerfile `ARG`로 주입됨 (누락 시 클라이언트 값 깨짐)
- 헬스체크(`/api/health`) 통과 전 트래픽 미스왑 → 빌드/기동 실패해도 기존 배포 유지(안전)
- CI는 `next start`(standalone 아님)로 E2E 실행 — standalone은 Railway 런타임 전용

🤖 Generated with [Claude Code](https://claude.com/claude-code)