### PR TITLE
perf(deploy): 캐릭터 이미지 R2 이전 — 배포 이미지에서 283MB 제외

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -26,6 +26,11 @@ n8n
 docs
 supabase
 
+# 캐릭터 이미지 283MB — 프로덕션은 R2(cdn.xzawed.xyz/characters)로 서빙하므로 배포 이미지에서 제외.
+# repo/로컬/CI는 유지(getCharacterImageUrl이 env 미설정 시 이 폴더로 폴백). 배포 이미지만 슬림화.
+# ⚠️ 프로덕션은 NEXT_PUBLIC_ASSET_BASE_URL 필수(미설정 시 이미지 폴더가 이미지에 없어 404).
+public/images/characters
+
 # 시크릿·로컬 env (이미지에 포함 금지). Railway는 대시보드 변수를 주입한다.
 .env
 .env.*

--- a/docs/conventions/image-assets.md
+++ b/docs/conventions/image-assets.md
@@ -23,8 +23,8 @@
 
 **12캐릭터** (arcana, miko, seonhwa, hoshi, luna, rei, cairn, zero, haru, ren, lix, ethan):
 - 운영 표시용 이미지: `nukki-enhanced/` 폴더 (2816×1536). **이 2배(원본 1408×768의 2x) 규격은 고DPI 대형 디스플레이·캐릭터 상세(모바일 100vw) 대응을 위한 의도적 선택이며 다운스케일 금지.**
-- 예: `/images/characters/arcana/nukki-enhanced/default.png`
 - 7가지 mood: `default`, `idle`, `smile`, `serious`, `surprised`, `wink`, `mystical`
+- **서빙(2026-07-06~)**: 컴포넌트는 `src/lib/storage/character-image.ts`의 `getCharacterImageUrl(id, fileName)`으로 URL을 조회한다. `NEXT_PUBLIC_ASSET_BASE_URL`(cdn.xzawed.xyz) 설정 시 R2(`characters/[id]/nukki-enhanced/[mood].png`), 미설정 시 로컬 `/images/characters/...` 폴백. **배포 이미지는 `.dockerignore`로 `public/images/characters`(283MB)를 제외**하고 프로덕션은 R2로 서빙 → 배포 이미지 슬림화. 로컬/CI는 repo public 폴백. (⚠️ 프로덕션 `NEXT_PUBLIC_ASSET_BASE_URL` 필수)
 - ⚠️ 소스·백업 폴더(`nukki/`, `nukki/backup-v2/`)는 용량 절감을 위해 리포지토리에서 제거(#447)되어 현재는 `nukki-enhanced/`만 존재한다. 운영본 재생성 시에만 외부 백업(1408×768 색상 소스)을 참조한다.
 - 원본은 보존하고, UI에서는 `nukki-enhanced`를 우선 사용한다.
 - Next.js 이미지 optimizer 출력은 WebP를 사용한다. 대형 투명 PNG를 AVIF로 즉석 변환하면 일부 모바일 Chromium 환경에서 첫 요청이 지연될 수 있다.
@@ -75,7 +75,9 @@ AI 생성 타로 카드 이미지·서비스 배경은 **Cloudflare R2**(`arcana
 | 카드 앞면 | `card-styles/cards/{styleId}/{suit}/{number}.png` | 4종 스타일 × 카드 수 (`.png`) |
 | 카드 뒷면 | `card-styles/cards/{styleId}/card-back.webp` | 스타일별 전용 뒷면 (`.webp`) |
 | 서비스 배경 | `card-styles/backgrounds/{service}/{theme}.png` | 타로/사주/신점 × 테마 |
+| 캐릭터 이미지 | `characters/{id}/nukki-enhanced/{mood}.png` | 12명 × 7 mood = 84개 (2026-07-06 배포 슬림화로 R2 이전) |
 
+- 캐릭터 URL은 `src/lib/storage/character-image.ts`의 `getCharacterImageUrl(id, fileName)`로 조회(`NEXT_PUBLIC_ASSET_BASE_URL` 설정 시 R2, 미설정 시 로컬 public 폴백). 업로드: `pnpm upload:characters:r2`(`:skip` 지원) — `public/images/characters` → R2(`characters/` 키), ETag=md5 검증.
 - URL은 `src/lib/storage/card-style.ts`의 `getCardStyleImageUrl()` / `getCardStyleBackUrl()` / `getServiceBackgroundUrl()`로 조회. `storageBase()`가 `NEXT_PUBLIC_ASSET_BASE_URL`(설정 시 R2) ↔ Supabase(폴백)를 분기 → env 정본: [`../operations/env-variables.md`](../operations/env-variables.md).
 - 카드 `<Image>`는 `unoptimized`로 R2에서 직접 로드(옵티마이저 우회). `next.config.ts` `remotePatterns`가 자산 호스트를 env에서 자동 파생.
 - 생성: `pnpm generate:assets` (Replicate API, REPLICATE_API_KEY 필요).

--- a/package.json
+++ b/package.json
@@ -42,6 +42,8 @@
     "upload:assets:skip": "npx tsx scripts/generate-assets/upload-to-supabase.ts --skip-existing",
     "upload:assets:r2": "npx tsx scripts/generate-assets/upload-to-r2.ts",
     "upload:assets:r2:skip": "npx tsx scripts/generate-assets/upload-to-r2.ts --skip-existing",
+    "upload:characters:r2": "npx tsx scripts/generate-assets/upload-characters-r2.ts",
+    "upload:characters:r2:skip": "npx tsx scripts/generate-assets/upload-characters-r2.ts --skip-existing",
     "enhance:images": "node scripts/enhance-character-images.mjs",
     "polish:images": "python scripts/polish-character-images.py"
   },

--- a/scripts/generate-assets/upload-characters-r2.ts
+++ b/scripts/generate-assets/upload-characters-r2.ts
@@ -1,0 +1,108 @@
+/**
+ * 캐릭터 이미지(nukki-enhanced)를 Cloudflare R2에 업로드한다.
+ *
+ * `public/images/characters/<id>/nukki-enhanced/*.png`를 R2 버킷(`R2_BUCKET`)의
+ * `characters/<id>/nukki-enhanced/*.png` 키로 업로드하며, 업로드 후 ETag(단일 PUT=md5)와
+ * 로컬 md5를 대조해 무결성을 검증한다. (upload-to-r2.ts와 동일 패턴)
+ *
+ * 배경: 캐릭터 이미지 283MB가 Railway 배포 이미지에 번들되어 배포를 느리게 했다.
+ *   R2로 서빙하고 배포 이미지(.dockerignore)에서 제외해 배포를 가속한다. 로컬/CI는
+ *   public 폴더 폴백을 유지한다(getCharacterImageUrl).
+ *
+ * 자격증명: 루트 `.env.r2.local`(gitignore) — R2_ACCOUNT_ID / R2_ACCESS_KEY_ID / R2_SECRET_ACCESS_KEY / R2_BUCKET
+ *
+ * 사용:
+ *   pnpm upload:characters:r2         # 전량 업로드(upsert)
+ *   pnpm upload:characters:r2:skip    # R2에 이미 있는 키는 건너뜀
+ *
+ * ⚠️ 기존 키 덮어쓰기 시 Cloudflare CDN immutable 캐시 퍼지 필요.
+ */
+import { config } from 'dotenv';
+config({ path: '.env.r2.local' });
+
+import * as fs from 'fs';
+import * as path from 'path';
+import * as crypto from 'crypto';
+import { S3Client, PutObjectCommand, HeadObjectCommand } from '@aws-sdk/client-s3';
+
+const DEST_PREFIX = 'characters';
+const SRC_DIR = 'public/images/characters';
+const CONCURRENT = 6;
+const SKIP_EXISTING = process.argv.includes('--skip-existing');
+
+function getR2() {
+  const { R2_ACCOUNT_ID, R2_ACCESS_KEY_ID, R2_SECRET_ACCESS_KEY, R2_BUCKET } = process.env;
+  if (!R2_ACCOUNT_ID || !R2_ACCESS_KEY_ID || !R2_SECRET_ACCESS_KEY || !R2_BUCKET) {
+    throw new Error('.env.r2.local에 R2_ACCOUNT_ID / R2_ACCESS_KEY_ID / R2_SECRET_ACCESS_KEY / R2_BUCKET가 필요합니다.');
+  }
+  const client = new S3Client({
+    region: 'auto',
+    endpoint: `https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com`,
+    credentials: { accessKeyId: R2_ACCESS_KEY_ID, secretAccessKey: R2_SECRET_ACCESS_KEY },
+  });
+  return { client, bucket: R2_BUCKET };
+}
+
+function walk(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of fs.readdirSync(dir)) {
+    const p = path.join(dir, entry);
+    const stat = fs.statSync(p);
+    if (stat.isDirectory()) out.push(...walk(p));
+    else if (p.endsWith('.png') || p.endsWith('.webp')) out.push(p);
+  }
+  return out;
+}
+
+function md5(buf: Buffer): string {
+  return crypto.createHash('md5').update(buf).digest('hex');
+}
+
+async function keyExists(client: S3Client, bucket: string, key: string): Promise<boolean> {
+  try {
+    await client.send(new HeadObjectCommand({ Bucket: bucket, Key: key }));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function main() {
+  if (!fs.existsSync(SRC_DIR)) throw new Error(`${SRC_DIR} 없음`);
+  const { client, bucket } = getR2();
+  const files = walk(SRC_DIR);
+  console.log(`캐릭터 이미지 ${files.length}개 → R2(${bucket}) '${DEST_PREFIX}/' 업로드 (skip-existing=${SKIP_EXISTING})`);
+
+  let done = 0, skipped = 0, failed = 0;
+  const queue = [...files];
+  async function worker() {
+    while (queue.length) {
+      const local = queue.shift()!;
+      const rel = path.relative(SRC_DIR, local).split(path.sep).join('/');
+      const key = `${DEST_PREFIX}/${rel}`;
+      try {
+        if (SKIP_EXISTING && (await keyExists(client, bucket, key))) { skipped++; continue; }
+        const body = fs.readFileSync(local);
+        const contentType = local.endsWith('.webp') ? 'image/webp' : 'image/png';
+        const res = await client.send(new PutObjectCommand({ Bucket: bucket, Key: key, Body: body, ContentType: contentType }));
+        const etag = (res.ETag ?? '').replace(/"/g, '');
+        const local5 = md5(body);
+        if (etag && etag !== local5) {
+          failed++;
+          console.error(`✗ ETag 불일치 ${key}: r2=${etag} local=${local5}`);
+        } else {
+          done++;
+          if (done % 10 === 0) console.log(`  ...${done}/${files.length}`);
+        }
+      } catch (e) {
+        failed++;
+        console.error(`✗ 업로드 실패 ${key}:`, e instanceof Error ? e.message : String(e));
+      }
+    }
+  }
+  await Promise.all(Array.from({ length: CONCURRENT }, () => worker()));
+  console.log(`\n완료: 업로드 ${done} / 스킵 ${skipped} / 실패 ${failed}`);
+  if (failed > 0) process.exit(1);
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/src/app/(immersive)/character/[id]/page.tsx
+++ b/src/app/(immersive)/character/[id]/page.tsx
@@ -9,6 +9,7 @@ import { useLocaleStore } from "@/hooks/useLocaleStore";
 import { useT } from "@/i18n/useT";
 import { ParticleOverlay } from "@/components/effects/ParticleOverlay";
 import { getCharacterCutoutImageStyle } from "@/components/character/SpriteAnimator";
+import { getCharacterImageUrl } from "@/lib/storage/character-image";
 import { ThemeAtmosphere } from "@/components/effects/MysticBackground";
 import { useThemeStore } from "@/hooks/useTheme";
 
@@ -76,7 +77,7 @@ export default function CharacterPage() {
           }}
         >
           <Image
-            src={`/images/characters/${character.id}/nukki-enhanced/idle.png`}
+            src={getCharacterImageUrl(character.id, "idle")}
             alt={character.name}
             fill
             sizes="(max-width: 768px) 100vw, 50vw"

--- a/src/components/character/CharacterCard.tsx
+++ b/src/components/character/CharacterCard.tsx
@@ -3,6 +3,7 @@
 import Image from "next/image";
 import { motion } from "framer-motion";
 import { CharacterConfig } from "@/types/character";
+import { getCharacterImageUrl } from "@/lib/storage/character-image";
 
 interface CharacterCardProps {
   readonly character: CharacterConfig;
@@ -28,7 +29,7 @@ export function CharacterCard({ character, isSelected, onClick, index }: Charact
     >
       <div className="relative w-full aspect-[2/3] mb-3 overflow-hidden rounded-xl">
         <Image
-          src={`/images/characters/${character.id}/nukki-enhanced/idle.png`}
+          src={getCharacterImageUrl(character.id, "idle")}
           alt={character.name}
           fill
           sizes="(max-width: 768px) 33vw, (max-width: 1024px) 13vw, 9vw"

--- a/src/components/character/SpriteAnimator.tsx
+++ b/src/components/character/SpriteAnimator.tsx
@@ -5,6 +5,7 @@ import Image from "next/image";
 import { motion, AnimatePresence, type Easing, type TargetAndTransition, type Transition } from "framer-motion";
 import { Mood, IdleAnimationType, CharacterId } from "@/types/character";
 import { hexToRgba } from "@/lib/color-utils";
+import { getCharacterImageUrl } from "@/lib/storage/character-image";
 
 interface MoodConfig {
   loop: boolean;
@@ -132,7 +133,7 @@ interface SpriteAnimatorProps {
 export const SpriteAnimator = React.memo(function SpriteAnimator({ characterId, mood, idleAnimation = "float", primaryColor, onAnimationEnd, className = "" }: SpriteAnimatorProps) {
   const config = MOOD_CONFIGS[mood];
   const fileName = MOOD_TO_FILE[mood];
-  const imageSrc = `/images/characters/${characterId}/nukki-enhanced/${fileName}.png`;
+  const imageSrc = getCharacterImageUrl(characterId, fileName);
 
   // 첫 등장이면 입장 시그니처, 이후 무드 전환은 표준 페이드
   const entrance = CHAR_ENTRANCE[characterId];

--- a/src/components/home/BottomCTA.tsx
+++ b/src/components/home/BottomCTA.tsx
@@ -4,6 +4,7 @@ import Image from "next/image";
 import Link from "next/link";
 import { ScrollReveal } from "@/components/effects/ScrollReveal";
 import { useT } from "@/i18n/useT";
+import { getCharacterImageUrl } from "@/lib/storage/character-image";
 
 export function BottomCTA() {
   const { t } = useT();
@@ -30,7 +31,7 @@ export function BottomCTA() {
           <div className="flex justify-center gap-3 mt-8">
             {["arcana", "miko", "seonhwa", "hoshi"].map((id) => (
               <div key={id} className="w-10 h-10 rounded-full overflow-hidden border-2 border-white/30">
-                <Image src={`/images/characters/${id}/nukki-enhanced/idle.png`} alt="" width={40} height={40} className="object-cover" />
+                <Image src={getCharacterImageUrl(id, "idle")} alt="" width={40} height={40} className="object-cover" />
               </div>
             ))}
           </div>

--- a/src/components/home/CharacterGallery.tsx
+++ b/src/components/home/CharacterGallery.tsx
@@ -7,6 +7,7 @@ import { ScrollReveal } from "@/components/effects/ScrollReveal";
 import { GenderFilterToggle } from "@/components/home/GenderFilter";
 import { useGenderStore } from "@/hooks/useGenderStore";
 import { getCharactersByGender } from "@/data/characters";
+import { getCharacterImageUrl } from "@/lib/storage/character-image";
 import { getCharacterSpeciality } from "@/data/characters/locale-helpers";
 import { useT } from "@/i18n/useT";
 import { useLocaleStore } from "@/hooks/useLocaleStore";
@@ -40,7 +41,7 @@ export function CharacterGallery() {
                 >
                   <div className="relative aspect-[3/4] overflow-hidden">
                     <Image
-                      src={`/images/characters/${char.id}/nukki-enhanced/idle.png`}
+                      src={getCharacterImageUrl(char.id, "idle")}
                       alt={`${char.name} - ${char.personality}`}
                       fill
                       sizes="(max-width: 640px) 50vw, (max-width: 768px) 33vw, (max-width: 1024px) 25vw, 17vw"

--- a/src/components/home/DailyFortune.tsx
+++ b/src/components/home/DailyFortune.tsx
@@ -26,6 +26,7 @@ import { useT } from "@/i18n/useT";
 import Image from "next/image";
 import type { CardStyleId } from "@/data/cardStyles";
 import type { CharacterId } from "@/types/character";
+import { getCharacterImageUrl } from "@/lib/storage/character-image";
 
 const deckManager = new DeckManager();
 
@@ -220,7 +221,7 @@ export function DailyFortune() {
               }`}
             >
               <div className="w-5 h-5 rounded-full overflow-hidden">
-                <Image src={`/images/characters/${char.id}/nukki-enhanced/default.png`} alt="" width={20} height={20} className="object-cover" />
+                <Image src={getCharacterImageUrl(char.id, "default")} alt="" width={20} height={20} className="object-cover" />
               </div>
               <span className="hidden sm:inline">{char.name}</span>
             </button>

--- a/src/lib/storage/character-image.test.ts
+++ b/src/lib/storage/character-image.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { getCharacterImageUrl } from "./character-image";
+
+const KEY = "NEXT_PUBLIC_ASSET_BASE_URL";
+const orig = process.env[KEY];
+afterEach(() => {
+  if (orig === undefined) delete process.env[KEY];
+  else process.env[KEY] = orig;
+});
+
+describe("getCharacterImageUrl", () => {
+  it("NEXT_PUBLIC_ASSET_BASE_URL 설정 시 R2/CDN URL을 반환한다", () => {
+    process.env[KEY] = "https://cdn.xzawed.xyz";
+    expect(getCharacterImageUrl("arcana", "idle")).toBe(
+      "https://cdn.xzawed.xyz/characters/arcana/nukki-enhanced/idle.png",
+    );
+  });
+
+  it("base URL 끝 슬래시를 정규화한다(이중 슬래시 방지)", () => {
+    process.env[KEY] = "https://cdn.xzawed.xyz/";
+    expect(getCharacterImageUrl("luna", "default")).toBe(
+      "https://cdn.xzawed.xyz/characters/luna/nukki-enhanced/default.png",
+    );
+  });
+
+  it("env 미설정 시 로컬 public 경로로 폴백한다", () => {
+    delete process.env[KEY];
+    expect(getCharacterImageUrl("seonhwa", "mystical")).toBe(
+      "/images/characters/seonhwa/nukki-enhanced/mystical.png",
+    );
+  });
+});

--- a/src/lib/storage/character-image.ts
+++ b/src/lib/storage/character-image.ts
@@ -1,0 +1,22 @@
+/**
+ * 캐릭터 이미지(nukki-enhanced) URL 생성.
+ *
+ * NEXT_PUBLIC_ASSET_BASE_URL(예: https://cdn.xzawed.xyz) 설정 시 R2/CDN을 사용하고,
+ * 미설정 시 로컬 public 폴백(`/images/characters/...`)을 사용한다. 카드 자산(card-style.ts)과
+ * 동일한 env 토글 패턴 — env만으로 즉시 롤백 가능.
+ *
+ * 배포 이미지는 `.dockerignore`로 `public/images/characters`를 제외하므로 프로덕션은 R2를 사용한다
+ * (프로덕션 env에 NEXT_PUBLIC_ASSET_BASE_URL이 설정되어 있어야 한다 — 카드 자산과 동일 전제).
+ * 로컬 개발·CI는 env 미설정 시 repo의 public 폴더에서 서빙한다.
+ *
+ * @param characterId 캐릭터 id (예: "arcana")
+ * @param fileName    확장자 없는 파일명 (예: "idle", "default", "smile", "mystical")
+ */
+export function getCharacterImageUrl(characterId: string, fileName: string): string {
+  const base = process.env.NEXT_PUBLIC_ASSET_BASE_URL;
+  if (base) {
+    const b = base.endsWith("/") ? base.slice(0, -1) : base;
+    return `${b}/characters/${characterId}/nukki-enhanced/${fileName}.png`;
+  }
+  return `/images/characters/${characterId}/nukki-enhanced/${fileName}.png`;
+}


### PR DESCRIPTION
## 배경
PR #482(배포 이미지 최소화)에 이어, 배포 이미지의 최대 잔여 비중인 **캐릭터 이미지 283MB**(84개 nukki-enhanced 2816×1536 PNG)를 R2로 이전해 배포 이미지를 추가 슬림화한다. 카드·서비스 배경 R2 이전(#450~#452)과 동일 패턴.

## 접근 (리스크 최소화)
로컬/CI를 깨지 않도록 **repo에서 삭제하지 않고 배포 이미지에서만 제외**:
- 프로덕션: `NEXT_PUBLIC_ASSET_BASE_URL` 설정됨 → R2(`cdn.xzawed.xyz/characters/...`) 서빙, `.dockerignore`로 배포 이미지에서 제외
- 로컬/CI: env 미설정 → repo `public/images/characters` 폴백 (그대로 유지) → 무파손·CI env 변경 불필요·완전 가역

## 변경
- **`getCharacterImageUrl(id, fileName)`** 헬퍼 (`src/lib/storage/character-image.ts`) — R2↔로컬 env 토글(card-style.ts와 동일 패턴)
- **소비처 6곳 리팩터**: CharacterCard · SpriteAnimator · CharacterGallery · DailyFortune · BottomCTA · character/[id]
- **`.dockerignore`**: `public/images/characters` 제외 (배포 이미지만)
- **업로드 스크립트** `pnpm upload:characters:r2` (`:skip` 지원, ETag=md5 검증)

## 검증
- **R2 업로드 84개 완료** (md5 검증, 실패 0) → **`cdn.xzawed.xyz/characters/...` 200 확인** (없는 키 404 대조)
- **로컬 Docker**: 이미지 내 `public` **317MB→35MB**(캐릭터 폴더 부재 확인), 컨테이너 `/api/health` 200·`/` 200
- 이미지 누적 효과: node_modules 580→38MB(#482) + public 317→35MB → **~1.1GB → ~300MB(amd64)**
- type-check · lint · test:coverage(임계값 전 통과) · doc-links · i18n 통과
- 헬퍼 단위 테스트 3건(R2/슬래시정규화/폴백)

## ⚠️ 배포 전제
- 프로덕션 `NEXT_PUBLIC_ASSET_BASE_URL` 필수(카드 자산이 이미 의존 — 설정되어 있음). 미설정 시 캐릭터 이미지가 배포 이미지에 없어 404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)