### PR TITLE
fix(deploy): Dockerfile HOSTNAME 강제 — Railway 배포 실패(헬스체크 도달 불가) 수정

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,6 @@ RUN pnpm build
 FROM node:20-slim AS runtime
 WORKDIR /app
 ENV NODE_ENV=production \
-    HOSTNAME=0.0.0.0 \
     NEXT_TELEMETRY_DISABLED=1
 # 비루트 실행
 RUN addgroup --system --gid 1001 nodejs && adduser --system --uid 1001 nextjs
@@ -42,5 +41,8 @@ COPY --from=build --chown=nextjs:nodejs /app/.next/static ./.next/static
 COPY --from=build --chown=nextjs:nodejs /app/public ./public
 USER nextjs
 EXPOSE 3000
-# PORT는 Railway가 런타임에 주입(standalone server.js가 process.env.PORT 사용)
-CMD ["node", "server.js"]
+# PORT는 Railway가 런타임에 주입(standalone server.js가 process.env.PORT 사용).
+# ⚠️ HOSTNAME은 실행 시점에 0.0.0.0으로 강제한다 — Railway(컨테이너 런타임)가 HOSTNAME=<컨테이너ID>를
+#    주입해 Dockerfile ENV를 덮어쓰면 Next standalone이 라우팅 불가 호스트에 바인딩 → 헬스체크 실패로 배포 실패.
+#    `HOSTNAME=0.0.0.0 exec node`로 주입값을 무시하고, exec으로 node를 PID 1로 유지(SIGTERM 전달).
+CMD ["sh", "-c", "HOSTNAME=0.0.0.0 exec node server.js"]

--- a/docs/operations/deployment.md
+++ b/docs/operations/deployment.md
@@ -22,9 +22,12 @@ Railway는 `main` 브랜치의 모든 push에 자동으로 반응합니다. 수�
 - standalone이 런타임 필요한 의존성만 추적 → 런타임 `node_modules` 580MB → ~38MB
 - 슬림 런타임 스테이지에 `.next/standalone` + `.next/static` + `public`만 복사 (전체 node_modules·빌드 툴 제외)
 - `.dockerignore`로 빌드 컨텍스트 슬림화 (e2e·docs·scripts·supabase·테스트·.env 제외)
-- 실측(amd64): 전체 이미지 ~1.1GB(nixpacks 추정) → **~416MB**. 캐릭터 이미지 R2 이전 시 public 축소로 추가 감소.
+- 캐릭터 이미지(283MB)는 R2로 이전하고 `.dockerignore`로 배포 이미지에서 제외(로컬/CI는 public 폴백 유지) → 이미지 내 `public` 317MB→35MB
+- 실측(amd64): 전체 이미지 ~1.1GB(nixpacks 추정) → standalone(#482) → 캐릭터 R2 제외(#483)로 **~300MB**대
 
 > ⚠️ **NEXT_PUBLIC_* 빌드 인자 필수**: `NEXT_PUBLIC_SUPABASE_URL`·`NEXT_PUBLIC_SUPABASE_ANON_KEY`·`NEXT_PUBLIC_SITE_URL`·`NEXT_PUBLIC_ASSET_BASE_URL`은 `next build` 시 클라이언트 번들에 인라인되므로, Railway 서비스 변수로 설정되어 있어야 Dockerfile `ARG`로 주입된다. 누락 시 빌드는 되지만 클라이언트가 잘못된 값(예: R2 base 미설정 → 이미지 깨짐)으로 동작한다.
+
+> ⚠️ **HOSTNAME 바인딩(배포 실패 방지)**: Railway 컨테이너 런타임이 `HOSTNAME=<컨테이너ID>`를 주입해 Dockerfile `ENV HOSTNAME`을 덮어쓴다. Next standalone 서버는 `process.env.HOSTNAME`에 바인딩하므로, 그대로 두면 라우팅 불가 호스트에 바인딩되어 **헬스체크가 도달하지 못하고 배포가 FAILED**된다(배포 로그엔 "Stopping Container"만, 앱 stdout 없음). 그래서 CMD를 `sh -c "HOSTNAME=0.0.0.0 exec node server.js"`로 두어 실행 시점에 강제한다(주입값 무시, exec으로 node를 PID 1 유지). 2026-07-06 최초 Dockerfile 전환 시 이 문제로 3회 배포 실패 → 수정. 로컬 재현: `docker run -e HOSTNAME=<임의값>` 시 health 도달 불가로 확인.
 
 ---
 


### PR DESCRIPTION
## 증상
#482(nixpacks→Dockerfile 전환) 후 Railway 배포가 **3회 연속 FAILED**. 배포 로그엔 \`Stopping Container\`만 있고 앱 stdout 없음. **빌드는 성공**(Railway build 로그상 `pnpm build`·runtime COPY·image push 완료), **배포(헬스체크) 단계에서 실패**.

## 근본원인 (로컬 재현으로 확정)
Railway 컨테이너 런타임이 **`HOSTNAME=<컨테이너ID>`를 주입**해 Dockerfile `ENV HOSTNAME=0.0.0.0`을 덮어쓴다. Next standalone 서버는 `process.env.HOSTNAME`에 바인딩하므로 → 라우팅 불가 호스트에 바인딩 → **헬스체크가 도달하지 못해 배포 FAILED**.

로컬 재현:
| 컨테이너 | HOSTNAME | health | 로그 |
|---|---|---|---|
| 주입 `some-container-id` | 주입됨 | **000 실패** | **없음** (Railway와 동일) |
| Dockerfile ENV `0.0.0.0` | 0.0.0.0 | 200 | `✓ Ready` |

## 수정
`CMD ["sh","-c","HOSTNAME=0.0.0.0 exec node server.js"]` — 실행 시점에 HOSTNAME을 강제(주입값 무시), `exec`으로 node를 PID 1로 유지(SIGTERM graceful shutdown).

## 검증
HOSTNAME 주입(`-e HOSTNAME=some-container-id-abc123`) 상태로 재빌드·기동:
- **health 200 · home 200**, 로그 `Network: http://0.0.0.0:3000 ✓ Ready` (주입값 무시하고 정상 바인딩)
- doc-links 통과. 배포 문서에 HOSTNAME 함정 기록.

> 진단은 Railway CLI(`railway logs -b/-d`)로 실패 배포 로그 확보 → 로컬 Docker로 재현·수정·재검증. 병합 시 새 Dockerfile 배포가 성공해야 함(헬스체크 통과 전 트래픽 미스왑이라 현재 프로덕션은 안전).

🤖 Generated with [Claude Code](https://claude.com/claude-code)