### PR TITLE
fix(deploy): railway.toml startCommand 명시 — 'pnpm not found' 배포 실패 수정

### DIFF
--- a/railway.toml
+++ b/railway.toml
@@ -4,6 +4,10 @@
 builder = "dockerfile"
 
 [deploy]
+# standalone 서버 기동 명령을 명시. Railway에 남아있던 nixpacks 시절 시작 명령("pnpm start")이
+# Dockerfile CMD를 덮어써 슬림 런타임(pnpm 없음)에서 "pnpm not found"로 실패했으므로 여기서 확정한다.
+# HOSTNAME은 실행 시점에 0.0.0.0으로 강제(Railway가 HOSTNAME=<컨테이너ID> 주입 시 바인딩 보호).
+startCommand = "HOSTNAME=0.0.0.0 node server.js"
 # 홈(/) 대신 경량 /api/health로 기동 판정 → 무거운 홈 SSR 대기·불필요한 재기동 방지.
 healthcheckPath = "/api/health"
 restartPolicyType = "on_failure"


### PR DESCRIPTION
## 증상 (Railway 대시보드)
Build **성공** → **Deploy > Create container 실패**: `The executable pnpm could not be found.`
#482(Dockerfile 전환) 이후 모든 배포 실패의 **실제 원인**(이전 CLI 로그의 "Stopping Container"는 create-container 실패 정리 메시지였음).

## 근본원인
nixpacks 시절 서비스에 설정된 시작 명령 **`pnpm start`가 Dockerfile `CMD`를 덮어써** 컨테이너를 pnpm으로 기동하려 하나, 슬림 standalone 런타임 이미지엔 pnpm이 없어 실패. railway.toml에서 `startCommand`를 **제거**해도 Railway가 이전 값을 초기화하지 않고 유지했다.

## 수정
railway.toml `[deploy]`에 standalone 시작 명령을 **명시**(config-as-code 우선순위로 stale 값 override):
```toml
startCommand = "HOSTNAME=0.0.0.0 node server.js"
```
- standalone `server.js`(WORKDIR /app)를 직접 기동 (pnpm 불필요)
- `HOSTNAME=0.0.0.0` 강제 — Railway가 HOSTNAME=<컨테이너ID> 주입 시 바인딩 보호(방어적)

## 검증
- 런타임 이미지에서 `node server.js` 기동은 로컬 Docker로 이미 검증됨(health 200·home 200)
- config-only 변경

> 만약 이 배포도 여전히 "pnpm not found"면, Railway 대시보드 Service → Settings → Deploy의 **Custom Start Command**에 남은 `pnpm start`를 지워야 함(대시보드 값이 config를 덮는 경우 대비).

🤖 Generated with [Claude Code](https://claude.com/claude-code)