### PR TITLE
perf(deploy): standalone Dockerfile 재적용 — 배포 이미지 ~1.1GB→~300MB (근본원인 확정)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,36 @@
+# Railway/nixpacks 빌드 컨텍스트 슬림화 — 배포 이미지·업로드 시간 축소.
+# 런타임(next start/standalone)·빌드(next build)에 불필요한 것만 제외한다.
+# 유지: src/, public/, package.json, pnpm-lock.yaml, next.config.ts, tsconfig.json,
+#       postcss.config.*, middleware.ts, nixpacks.toml, railway.toml
+
+.git
+node_modules
+.next
+
+# 테스트·E2E (배포 불필요)
+e2e
+coverage
+playwright-report
+test-results
+**/*.test.ts
+**/*.test.tsx
+
+# 개발 스크립트·도구 (빌드/런타임 미참조)
+scripts
+n8n
+.claude
+.vscode
+.github
+
+# 문서·DB 마이그레이션 (런타임 미참조)
+docs
+supabase
+
+# 캐릭터 이미지 283MB — 프로덕션은 R2(cdn.xzawed.xyz/characters)로 서빙하므로 배포 이미지에서 제외.
+# repo/로컬/CI는 유지(getCharacterImageUrl이 env 미설정 시 이 폴더로 폴백). 배포 이미지만 슬림화.
+# ⚠️ 프로덕션은 NEXT_PUBLIC_ASSET_BASE_URL 필수(미설정 시 이미지 폴더가 이미지에 없어 404).
+public/images/characters
+
+# 시크릿·로컬 env (이미지에 포함 금지). Railway는 대시보드 변수를 주입한다.
+.env
+.env.*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,48 @@
+# 멀티스테이지 빌드 — Next.js standalone 출력으로 런타임 이미지를 최소화한다.
+# 목적: Railway 배포 이미지 축소(전체 node_modules 580MB·빌드 툴 제외) → export/push/pull·배포 가속.
+# 참고: output:"standalone"(next.config.ts)이 런타임 필요한 의존성만 추적해 .next/standalone에 담는다.
+
+# ── 1) 의존성 설치 ─────────────────────────────────────────────
+FROM node:20-slim AS deps
+RUN corepack enable && corepack prepare pnpm@10.33.0 --activate
+WORKDIR /app
+COPY package.json pnpm-lock.yaml ./
+RUN pnpm install --frozen-lockfile
+
+# ── 2) 빌드 ────────────────────────────────────────────────────
+FROM node:20-slim AS build
+RUN corepack enable && corepack prepare pnpm@10.33.0 --activate
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+# NEXT_PUBLIC_* 는 next build 시 클라이언트 번들에 "인라인"되므로 빌드 인자로 주입해야 한다.
+# Railway는 서비스 변수를 Dockerfile 빌드 ARG로 제공한다(각 변수를 대시보드에 설정).
+ARG NEXT_PUBLIC_SUPABASE_URL
+ARG NEXT_PUBLIC_SUPABASE_ANON_KEY
+ARG NEXT_PUBLIC_SITE_URL
+ARG NEXT_PUBLIC_ASSET_BASE_URL
+ENV NEXT_PUBLIC_SUPABASE_URL=$NEXT_PUBLIC_SUPABASE_URL \
+    NEXT_PUBLIC_SUPABASE_ANON_KEY=$NEXT_PUBLIC_SUPABASE_ANON_KEY \
+    NEXT_PUBLIC_SITE_URL=$NEXT_PUBLIC_SITE_URL \
+    NEXT_PUBLIC_ASSET_BASE_URL=$NEXT_PUBLIC_ASSET_BASE_URL \
+    NEXT_TELEMETRY_DISABLED=1
+RUN pnpm build
+
+# ── 3) 런타임 (슬림) ───────────────────────────────────────────
+FROM node:20-slim AS runtime
+WORKDIR /app
+ENV NODE_ENV=production \
+    NEXT_TELEMETRY_DISABLED=1
+# 비루트 실행
+RUN addgroup --system --gid 1001 nodejs && adduser --system --uid 1001 nextjs
+# standalone 서버 + 정적 자산 + public 만 복사 (전체 node_modules·빌드 툴 제외)
+COPY --from=build --chown=nextjs:nodejs /app/.next/standalone ./
+COPY --from=build --chown=nextjs:nodejs /app/.next/static ./.next/static
+COPY --from=build --chown=nextjs:nodejs /app/public ./public
+USER nextjs
+EXPOSE 3000
+# PORT는 Railway가 런타임에 주입(standalone server.js가 process.env.PORT 사용).
+# HOSTNAME은 Railway가 컨테이너ID로 주입하며, 이는 /etc/hosts에서 컨테이너 실제 IP로 해석되므로
+# standalone이 그 HOSTNAME에 바인딩해도 헬스체크가 도달한다(SSH 실측 확인). 따라서 HOSTNAME 조작 불필요 —
+# 순수 `node server.js`로 기동한다. (Railway는 startCommand를 shell 없이 argv 분해하므로 env 프리픽스/따옴표 금지.)
+CMD ["node", "server.js"]

--- a/docs/operations/deployment.md
+++ b/docs/operations/deployment.md
@@ -10,28 +10,35 @@ ArcanaInsight는 Railway를 사용하여 자동 배포됩니다.
 ## 자동 배포 흐름
 
 ```
-PR 머지 → main push → Railway 자동 빌드(nixpacks) → 헬스체크(/) 통과 → 트래픽 스왑
+PR 머지 → main push → Railway 자동 빌드(Dockerfile/standalone) → /api/health 통과 → 트래픽 스왑
 ```
 
 Railway는 `main` 브랜치의 모든 push에 자동으로 반응합니다. 수동 배포 트리거는 필요하지 않습니다.
-헬스체크가 통과해야만 새 배포로 트래픽이 넘어가므로, 빌드/기동 실패 시 기존 배포가 계속 서빙됩니다(무중단·안전 스왑).
+**헬스체크(`/api/health`)가 통과해야만 새 배포로 트래픽이 넘어가므로**, 빌드/기동 실패 시 기존 배포가 계속 서빙됩니다(무중단·안전 스왑).
 
-### 자산(이미지) 서빙
+### 빌드 최적화 (배포 이미지 최소화 → 배포 가속)
 
-- **카드·서비스 배경·캐릭터 이미지는 Cloudflare R2**(`cdn.xzawed.xyz`)에서 서빙된다. 캐릭터는 `getCharacterImageUrl`(`src/lib/storage/character-image.ts`)이 `NEXT_PUBLIC_ASSET_BASE_URL` 설정 시 R2(`characters/…`), 미설정 시 로컬 public 폴백. 업로드: `pnpm upload:characters:r2`.
+`next.config.ts` `output:"standalone"` + 멀티스테이지 `Dockerfile`로 런타임 이미지를 최소화한다:
+- standalone이 런타임 필요한 의존성만 추적 → 런타임 `node_modules` 580MB → **38MB**(실측)
+- 슬림 런타임 스테이지에 `.next/standalone`+`.next/static`+`public`만 복사
+- `.dockerignore`로 `node_modules`·`.next`·테스트·docs·`.env`, 그리고 **`public/images/characters`(283MB)** 제외 → 이미지 내 `public` 317MB→35MB (캐릭터는 R2 서빙)
+- 실측(amd64): 전체 이미지 ~1.1GB(nixpacks 추정) → **~300MB**
 
-> ⚠️ **프로덕션 `NEXT_PUBLIC_ASSET_BASE_URL` 필수**: 카드·캐릭터 이미지가 R2에서 서빙되므로 이 변수가 없으면 이미지가 로컬 폴백을 시도한다(카드 자산이 이미 의존).
+**시작 명령 — 반드시 `node server.js`** (env 프리픽스·따옴표·`sh -c` 금지):
+Railway는 startCommand를 **shell 없이 공백으로 argv 분해(따옴표 미존중)** 한다. 그래서 `HOSTNAME=0.0.0.0 node server.js`는 `HOSTNAME=0.0.0.0`을 실행파일로 오인, `sh -c "..."`는 따옴표가 깨져 서버가 안 뜬다(2026-07-06 배포 3회 실패의 실제 원인). HOSTNAME 조작은 불필요 — Railway가 주입하는 `HOSTNAME=<컨테이너ID>`는 `/etc/hosts`에서 컨테이너 실제 IP로 해석되므로 standalone이 그 HOSTNAME:PORT(8080)에 바인딩해도 헬스체크가 도달한다(SSH 실측 + 로컬 재현 확인).
 
-> **배포 이미지 최소화(standalone Dockerfile) — 2026-07-06 시도·롤백, 다음 세션 재분석 예정**: `output:"standalone"` + 멀티스테이지 Dockerfile로 런타임 이미지를 ~300MB로 줄이려 했으나(node_modules 580→38MB, `public/images/characters` 283MB 제외), Railway 서비스 특유의 문제가 연속 발생해 nixpacks로 롤백했다 — ① 서비스에 남은 `pnpm start` 시작 명령이 슬림 런타임(pnpm 없음)에서 실패, ② Railway가 시작 명령을 shell 없이 argv로 파싱해 `HOSTNAME=0.0.0.0` 프리픽스를 실행파일로 오인, ③ `sh -c` 래핑 후에도 DEPLOYING(헬스체크) 단계에서 실패(런타임 로그가 CLI·GraphQL 모두 접근 불가로 미규명). **재시도 전 규명 필요**: 대시보드에서 실패 배포의 Deploy 단계 로그(헬스체크 실패 사유·앱 바인딩 host:port)를 확보할 것. 관련 브랜치 히스토리: #482·#483·#485·#486·#487.
+> ⚠️ **NEXT_PUBLIC_* 빌드 인자 필수**: `NEXT_PUBLIC_SUPABASE_URL`·`_ANON_KEY`·`_SITE_URL`·`_ASSET_BASE_URL`은 `next build` 시 클라이언트 번들에 인라인되므로 Railway 서비스 변수로 설정되어 있어야 Dockerfile `ARG`로 주입된다. 특히 `NEXT_PUBLIC_ASSET_BASE_URL` 누락 시 R2 캐릭터 이미지가 이미지에서도 제외돼 404.
+
+> ⚠️ **서비스 startCommand가 railway.toml보다 우선**(GraphQL `serviceInstance.startCommand`). railway.toml에 `node server.js`를 두더라도 서비스에 남은 값(과거 `pnpm start`)이 우선하므로, 배포 시 `serviceInstanceUpdate`로 `node server.js`로 맞춰야 한다.
 
 ---
 
 ## 설정 파일
 
-- `railway.toml` — 빌드/배포 설정 (`builder = "nixpacks"`, `startCommand = "pnpm start"`, `healthcheckPath = "/"`)
-- `.github/workflows/deploy.yml` — PR CI 워크플로우 (Railway 배포 전 게이트)
-
-> ⚠️ Railway **서비스 시작 명령**은 서비스 설정 값이 railway.toml보다 우선한다(2026-07-06 확인 — GraphQL `serviceInstance.startCommand`가 우선). 시작 명령을 바꾸려면 서비스 설정(또는 GraphQL `serviceInstanceUpdate`)을 함께 갱신해야 한다.
+- `Dockerfile` — 멀티스테이지 (deps → build → 슬림 runtime, `node server.js` 기동)
+- `.dockerignore` — 빌드 컨텍스트 제외 (node_modules·.next·테스트·docs·캐릭터 이미지·.env)
+- `railway.toml` — (`builder = "dockerfile"`, `startCommand = "node server.js"`, `healthcheckPath = "/api/health"`)
+- `.github/workflows/deploy.yml` — PR CI 워크플로우 (Railway 배포 전 게이트, CI는 `next start` 사용)
 
 ### GitHub Secrets (CI 전용)
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -39,6 +39,9 @@ const securityHeaders = [
 ];
 
 const nextConfig: NextConfig = {
+  // 런타임 필요한 의존성만 추적해 최소 서버 번들 생성 → Railway 배포 이미지 축소·배포 가속.
+  // 배포: Dockerfile 멀티스테이지가 .next/standalone + static + public을 슬림 런타임에 복사, node server.js로 기동.
+  output: "standalone",
   async headers() {
     return [{ source: "/:path*", headers: securityHeaders }];
   },

--- a/railway.toml
+++ b/railway.toml
@@ -1,13 +1,14 @@
 [build]
-# nixpacks 빌더 (검증된 방식). Dockerfile+standalone 전환은 Railway 서비스 특유의
-# 시작명령/바인딩/헬스체크 문제로 반복 실패해 롤백함(2026-07-06). 상세: docs/operations/deployment.md
-builder = "nixpacks"
-buildCommand = "pnpm install --frozen-lockfile && pnpm build"
+# Dockerfile 멀티스테이지 빌드 — Next.js standalone으로 런타임 이미지 최소화(배포 가속).
+# NEXT_PUBLIC_* 서비스 변수는 Railway가 Dockerfile 빌드 ARG로 제공(대시보드에 설정되어 있어야 함).
+builder = "dockerfile"
 
 [deploy]
-startCommand = "pnpm start"
-# 마지막 성공 배포(cabcf8e)와 동일하게 "/"로 유지(안정화 우선). 경량 /api/health 전환은
-# 다음 세션에서 정밀 검증 후 적용.
-healthcheckPath = "/"
+# standalone 서버를 순수 단일 실행파일로 기동. Railway는 startCommand를 shell 없이 argv로 분해하므로
+# env 프리픽스(HOSTNAME=…)·따옴표·sh -c 금지. HOSTNAME 조작 불필요(컨테이너ID가 실제 IP로 해석됨).
+# ⚠️ 서비스(대시보드/GraphQL) startCommand가 이 값보다 우선하므로, 배포 시 serviceInstanceUpdate로 동일하게 맞춰야 함.
+startCommand = "node server.js"
+# 경량 /api/health로 기동 판정(무거운 홈 SSR 대기 회피). standalone에서 200 반환 검증됨.
+healthcheckPath = "/api/health"
 restartPolicyType = "on_failure"
 restartPolicyMaxRetries = 3


### PR DESCRIPTION
## 배경 — 근본원인 확정 후 재적용
이전 Dockerfile 전환(#482)이 Railway 배포 3회 실패해 롤백(#487)했으나, 이번에 **SSH 실측 + 로컬 재현으로 근본원인을 확정**하고 수정을 검증해 재적용한다.

### 확정된 근본원인
1. **Railway는 startCommand를 shell 없이 argv로 분해(따옴표 미존중)**. → `HOSTNAME=0.0.0.0 node server.js`는 `HOSTNAME=0.0.0.0`을 실행파일로 오인, `sh -c "..."`는 따옴표가 깨져 서버 미기동.
2. **HOSTNAME 조작 불필요** — SSH 실측 결과 Railway가 주입하는 `HOSTNAME=<컨테이너ID>`(예 f47c8b41151b)는 `/etc/hosts`에서 컨테이너 실제 IP(10.168.67.211)로 해석됨. standalone이 그 HOSTNAME:PORT(8080)에 바인딩해도 헬스체크 도달.
3. 최초 실패의 `pnpm not found`는 서비스에 남은 `pnpm start`가 슬림 런타임을 만난 것.

### 수정 (핵심: 시작 명령 = 순수 `node server.js`)
- `next.config`: `output:"standalone"`
- `Dockerfile`: 멀티스테이지, `CMD ["node","server.js"]`
- `.dockerignore`: node_modules·.next·테스트·docs·**`public/images/characters`(283MB)**·.env 제외
- `railway.toml`: `builder=dockerfile`, `startCommand="node server.js"`, `healthcheckPath="/api/health"`

## 단위별 검증 (로컬 Docker, Railway 조건 정확 모사)
| 단위 | 결과 |
|---|---|
| .dockerignore | node_modules·.next·characters·.env 제외, 필요파일 유지 ✅ |
| 빌드 | next build 성공 ✅ |
| 이미지 내용 | node_modules **38MB**(vs 580) · public **35MB**(캐릭터 없음) · server.js /app · 레이어합 ~308MB ✅ |
| 기동 | `node server.js`+PORT=8080+HOSTNAME=<id>→IP 해석 → **/api/health 200 · / 200** ✅ |
| R2 서빙 | 홈 HTML `cdn.xzawed.xyz` 223회 참조(`/_next/image` 경유), 이미지엔 캐릭터 제외 ✅ |
| CI 로컬 | type-check · lint · test:coverage(임계값 통과) · doc-links ✅ |

## ⚠️ 머지 시 필수 조치 (배포 성공 조건)
1. **서비스 startCommand를 `node server.js`로 설정** — GraphQL `serviceInstanceUpdate`(서비스 값이 railway.toml보다 우선). *현재는 프로덕션 nixpacks 보호를 위해 `pnpm start`로 두었으며, 머지 시 빌드 창에서 변경 예정.*
2. `NEXT_PUBLIC_ASSET_BASE_URL` — 프로덕션에 이미 설정됨(확인 완료).
3. 헬스체크 통과 전 트래픽 미스왑 → 실패해도 기존 배포 유지(안전).

> 이 PR은 **생성까지만** 요청됨. 머지·배포는 별도. 머지 시 위 서비스 startCommand 설정 + 배포 SUCCESS/health 200을 확인하겠습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)