### PR TITLE
docs(ops)+fix(deploy): 배포 품질 손상 최소화 가이드 + 회고 후속 항목 + railway.toml 주석 정정

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -29,6 +29,7 @@
 | 운영자 가이드 | [operations/operation-guide.md](operations/operation-guide.md) |
 | 미구현/기술부채 | [operations/known-issues.md](operations/known-issues.md) |
 | 배포/롤백 | [operations/deployment.md](operations/deployment.md) |
+| 배포 품질/안전 가이드 | [operations/deploy-safety-guide.md](operations/deploy-safety-guide.md) |
 | 모니터링/QA | [operations/monitoring.md](operations/monitoring.md) |
 
 ## 폴더 구조
@@ -60,6 +61,7 @@ docs/
 │   └── unit-testing.md
 ├── operations/
 │   ├── deployment.md
+│   ├── deploy-safety-guide.md
 │   ├── env-variables.md
 │   ├── known-issues.md
 │   ├── monitoring.md

--- a/docs/operations/deploy-safety-guide.md
+++ b/docs/operations/deploy-safety-guide.md
@@ -1,0 +1,86 @@
+# 배포 품질 손상 최소화 가이드
+
+> 2026-07-06 Railway standalone 전환 과정에서 배포가 ~7회 실패한 경험을 바탕으로 만든 가이드.
+> 배포 관련 변경이 프로덕션 품질을 해치지 않도록 하는 절차·체크리스트·함정 모음.
+> 상세 배포 설정은 [`deployment.md`](deployment.md), 원인 분석은 아래 §7 참고.
+
+---
+
+## 핵심 원칙 3가지
+
+1. **헬스체크-게이트 스왑은 안전망이다.** Railway는 `healthcheckPath`가 통과해야만 새 배포로 트래픽을 넘긴다. 즉 빌드/기동 실패 시 **기존 배포가 계속 서빙**된다(무중단). 이 안전망 덕에 배포 실패가 곧 장애는 아니다 — 다만 남용하지 말고, 실패는 원인을 규명하고 넘어간다.
+2. **관측 먼저, 가설은 나중.** 불투명한 실패는 실제 오류 로그를 확보한 뒤 수정한다. 관측 없이 세운 가설로 수정 PR을 쌓지 않는다.
+3. **로컬 검증 ≠ 프로덕션 검증.** 인프라·네트워크·런타임 주입 env 관련 수정은 로컬 통과만으로 단정하지 말고 프로덕션 런타임 증거로 확정한다.
+
+---
+
+## 1. 배포 영향 변경 위험도
+
+| 위험 | 대상 | 추가 검증 |
+|------|------|-----------|
+| **高** | `Dockerfile`, `railway.toml`, `next.config`(output/images), 서비스 config(startCommand·HOSTNAME·env), 의존성(`package.json`/`pnpm-lock`) | 로컬 Docker + 배포 후 스모크(§4) 필수 |
+| **中** | `middleware.ts`, API 라우트 시그니처, 새 env 사용, R2 자산 경로 | 배포 후 해당 기능 스모크 |
+| **低** | 컴포넌트·스타일·문서·테스트 | 표준 CI로 충분 |
+
+---
+
+## 2. 배포 전 체크리스트 (高/中위험 PR)
+
+- [ ] CI 9종 green (type-check·lint·test:coverage·E2E Desktop/Mobile·SonarCloud·codecov·문서)
+- [ ] 로컬 `pnpm build` 통과
+- [ ] **Dockerfile 변경 시**: 로컬 `docker build` + `docker run -e PORT=8080 <img> node server.js` → `/api/health` 200 (Railway 조건 모사)
+- [ ] **railway.toml/서비스 config 변경 시**: 서비스 `startCommand`·`HOSTNAME=0.0.0.0`·`NEXT_PUBLIC_*`가 의도대로인지 확인 (§3)
+- [ ] **R2 자산 관련**: 프로덕션 `NEXT_PUBLIC_ASSET_BASE_URL` 설정 확인 (미설정 시 이미지 404)
+- [ ] **배포 방식(builder) 변경 시**: 롤백 경로(§6) 미리 확인
+- [ ] 배포설정 PR은 **main 최신에서 분기** (squash 머지가 stacked 브랜치 merge-base를 어긋냄 → §3)
+
+---
+
+## 3. Railway 특유 함정 (반드시 숙지)
+
+- **서비스 startCommand가 railway.toml보다 우선.** 대시보드/GraphQL `serviceInstance.startCommand` 값이 railway.toml을 덮는다. 시작 명령을 바꾸려면 서비스 config(`railway variable`/GraphQL `serviceInstanceUpdate`/대시보드)를 함께 갱신해야 한다.
+- **startCommand는 shell 없이 argv로 분해**(따옴표·env 프리픽스 미지원). `HOSTNAME=0.0.0.0 node server.js`·`sh -c "..."` 금지 → 순수 단일 실행파일(`node server.js`).
+- **컨테이너 HOSTNAME은 IPv6 먼저 해석.** `HOSTNAME`=컨테이너ID가 `/etc/hosts`에서 IPv6→IPv4 순으로 해석돼, Next standalone이 그대로 두면 IPv6에만 바인딩 → IPv4 헬스체크 미도달. **서비스 변수 `HOSTNAME=0.0.0.0` 필수**(0.0.0.0 = IPv4 전 인터페이스). PORT는 Railway가 8080 주입.
+- **NEXT_PUBLIC_*는 빌드 시 인라인** → Dockerfile 빌드 `ARG`로 주입돼야 함(누락 시 클라이언트 값 깨짐, 특히 R2 이미지 404).
+- **실패 로그는 CLI에 안 뜰 수 있음.** create-container/헬스체크 실패는 `railway logs`에 비어 나옴 → **대시보드 Details** 또는 SSH·GraphQL `deploymentLogs`(로그인 필요)로 확인.
+- **squash 머지**는 stacked 브랜치의 merge-base를 어긋내 후속 PR에 전체 충돌을 유발 → 배포/문서 PR은 항상 main 최신에서 분기.
+
+---
+
+## 4. 배포 후 스모크 검증 (헬스체크만으론 부족)
+
+> `/api/health` 200 = "서버가 떴다"일 뿐, **기능이 정상이란 뜻은 아니다.** (예: NEXT_PUBLIC_ASSET_BASE_URL 누락 시 헬스체크는 통과해도 이미지가 전부 404)
+
+배포 SUCCESS 후 최소 확인:
+1. `/api/health` 200, 홈 `/` 200
+2. **캐릭터 이미지 로드**: 홈에서 `cdn.xzawed.xyz`(R2) 이미지가 `/_next/image` 경유 200 — Playwright로 콘솔 에러 0 확인 권장
+3. **리딩 1건씩**(tarot/saju/shinjeom): 익명 요청으로 실제 결과(SSE) 생성 확인 (DB 무오염, 리딩 회귀 감지)
+4. **배포 방식 변경 시**: 앱 로그에 `Network: http://0.0.0.0:8080` (0.0.0.0 바인딩) 확인
+
+---
+
+## 5. 실패 시 진단 순서
+
+1. **대시보드 Details** → 어느 단계(Build / Deploy>Create container / Deploy>Healthcheck)에서 실패인지 먼저 확인
+2. **빌드 실패** → build 로그 / **배포 실패** → deploy·앱 로그(SSH `printenv`·`deploymentLogs`, 바인딩 host:port 확인)
+3. **3회+ 서로 다른 실패**가 이어지면 → systematic-debugging대로 **멈추고 롤백해 안정화**(§6) 후 관측 재수집. 관측 없이 4번째 수정을 시도하지 않는다.
+
+---
+
+## 6. 롤백
+
+- **즉시**: 대시보드 → Deployments → 직전 SUCCESS 배포 → Redeploy
+- **코드**: `git revert <hash>` + push (Railway 자동 재배포)
+- **배포 방식(builder) 원복 시**: 서비스 config(`startCommand`·변수)도 함께 원복해야 함 (railway.toml만 되돌리면 서비스 값이 남아 불일치)
+- 프로덕션은 헬스체크-게이트라 롤백 중에도 기존 배포가 서빙됨(무중단)
+
+---
+
+## 7. 배경 — 2026-07-06 standalone 전환 3겹 원인 (사후 기록)
+
+standalone Dockerfile 배포가 연속 실패한 실제 원인(각 수정이 다음을 드러냄):
+1. 서비스에 남은 `pnpm start`가 슬림 런타임(pnpm 없음)에서 실패
+2. Railway가 startCommand를 shell 없이 argv 분해 → env 프리픽스/따옴표 깨짐
+3. standalone이 컨테이너 HOSTNAME(IPv6-우선 해석)에 바인딩 → IPv4 헬스체크 미도달
+
+최종: 서비스 `startCommand=node server.js` + 서비스 변수 `HOSTNAME=0.0.0.0` → 배포 성공(이미지 ~1.1GB→~300MB, 배포 1m13s). 진단은 대시보드 로그·SSH 실측·앱 로그로 확정.

--- a/docs/operations/deployment.md
+++ b/docs/operations/deployment.md
@@ -5,6 +5,8 @@
 
 ArcanaInsight는 Railway를 사용하여 자동 배포됩니다.
 
+> 배포 관련 변경 시 품질 손상을 막는 절차·체크리스트·함정은 [`deploy-safety-guide.md`](deploy-safety-guide.md)를 먼저 확인한다.
+
 ---
 
 ## 자동 배포 흐름

--- a/docs/operations/known-issues.md
+++ b/docs/operations/known-issues.md
@@ -90,3 +90,20 @@ Quality Gate: **PASSED** | Bugs: 0 | Vulnerabilities: 0 | **Open code smell: 0�
 | **외부 번역가 미사용** | — | **사용자 확정(2026-05-14)**: 외부 번역 발주 계획 없음. 현행 직역 사전으로 운영 지속. |
 
 상세 인프라: [`../architecture/i18n.md`](../architecture/i18n.md) / 컨벤션: [`../conventions/i18n-style.md`](../conventions/i18n-style.md)
+
+---
+
+## 리딩·배포 후속 항목 (2026-07-06 회고 도출)
+
+이번 세션(리딩 안정성 #480, 배포 최적화 #482~#490)에서 **해결은 됐으나 근본/부차적으로 남은 개선 항목**. 배포 안전 절차는 [`deploy-safety-guide.md`](deploy-safety-guide.md) 참고.
+
+| 항목 | 영역 | 상태·근거 | 우선순위 |
+|------|------|-----------|----------|
+| **리딩 스키마 중복 근본 제거** | `saju-service.ts`·`shinjeom-service.ts` 프롬프트 | 간헐 무결과의 뿌리는 `sajuSections`/`shinjeomSections`가 flat 필드(overallReading/advice)와 **내용 중복**인 과적재 스키마. #480은 파서 내성(트레일링콤마·`promoteNestedFields`)+1회 재생성이라는 **방어**로 0%까지 낮췄으나, 스키마를 flat/섹션 중 하나로 정리하면 재발 여지·토큰이 줄어든다. UX(섹션 렌더) 영향이 있어 별도 설계 필요. | 中 |
+| **parseError 실패 계량/dead-letter** | reading route·`reading-saver.ts` | parseError 리딩은 DB·DLQ에 흔적을 안 남겨(저장 게이트 `!result.parseError`) 지배적 실패 모드가 **관측 불가**. 별도 카운터/전용 dead-letter로 truncation/missing_fields/fallback_text 분포를 계량해야 회귀를 조기 감지. | 中 |
+| **배포 이미지 추가 슬림** | `public/images/{icons,backgrounds}` | standalone+캐릭터R2로 ~300MB 달성. 잔여 이미지 내 `icons`(21MB)·`backgrounds`(13MB)도 R2 이전 시 추가 축소 가능(캐릭터와 동일 패턴). 효과 대비 소규모. | 低 |
+| **Railway 서비스 config 취약성** | Railway 서비스(startCommand·`HOSTNAME=0.0.0.0`) | standalone 배포 필수 2조건이 **repo가 아닌 Railway 서비스 config**에 있어 서비스 재생성 시 유실 위험. 문서화(가이드·deployment.md)는 완료했으나 자동화는 미구현. | 中 |
+| **배포 후 자동 스모크 검증 부재** | CI/배포 | 헬스체크(`/api/health`) 통과가 이미지·리딩 정상을 보장하지 않음(예 `NEXT_PUBLIC_ASSET_BASE_URL` 누락 시 이미지 404여도 헬스체크 통과). 현재는 수동 스모크(가이드 §4). 배포 후 자동 스모크(홈 이미지·리딩 1건) 도입 여지. | 中 |
+| **로컬 Docker의 IPv6 미재현** | 로컬 검증 | 로컬 Docker는 Railway의 IPv6-우선 `/etc/hosts`를 재현 못 함 → 바인딩 이슈가 로컬에서 안 보임. 인프라 수정은 프로덕션 실측으로 확정하는 원칙 준수. 도구화 여지 낮음. | 低 |
+
+> 조사용으로 Railway에 SSH 키(`claude-railway-debug`) 등록 + 로컬 `~/.ssh/config`에 `StrictHostKeyChecking accept-new` 추가 상태. 향후 배포 디버깅에 유용하나 불필요 시 제거 가능.


### PR DESCRIPTION
## 배경
2026-07-06 세션(리딩 안정성 #480, 배포 최적화 #482~#490) **회고 산출물**. 배포가 ~7회 실패한 경험을 절차·가이드로 자산화하고, 회고에서 발견한 문서 불일치를 정정.

## 추가/변경
- **`deploy-safety-guide.md` 신설** — 배포 품질 손상 최소화:
  - 핵심 원칙 3: 헬스체크-게이트 안전망 / 관측 먼저 / 로컬≠프로덕션
  - 배포 영향 변경 위험도 · 배포 전 체크리스트
  - **Railway 특유 함정**: 서비스 startCommand > railway.toml · argv 분해(shell 없음) · HOSTNAME IPv6-우선(→ `HOSTNAME=0.0.0.0` 필수) · NEXT_PUBLIC_* 빌드 ARG · squash 머지 충돌 · 실패 로그 CLI 부재
  - 배포 후 스모크 검증(헬스체크만으론 부족) · 실패 진단 순서 · 롤백
- **`known-issues.md`** — 회고 도출 후속 항목: 리딩 스키마 중복 근본 제거·parseError 계량/dead-letter·이미지 추가 슬림·서비스 config 취약성·배포 후 자동 스모크 부재·로컬 IPv6 미재현
- **`deployment.md`·`README.md`** — 가이드 링크·트리 반영
- **`railway.toml` 주석 정정** (fix) — #490에서 deployment.md는 고쳤으나 railway.toml 인라인 주석에 잘못된 "HOSTNAME 조작 불필요" 잔존 → IPv6 바인딩·`HOSTNAME=0.0.0.0` 필수로 정정. 주석 전용(동작 무영향).

docs+주석 only. doc-links 통과(30 파일).

🤖 Generated with [Claude Code](https://claude.com/claude-code)