### PR TITLE
fix(deploy): railway.toml 주석 'HOSTNAME 조작 불필요' 정정 (#491 누락분)

### DIFF
--- a/railway.toml
+++ b/railway.toml
@@ -5,7 +5,8 @@ builder = "dockerfile"
 
 [deploy]
 # standalone 서버를 순수 단일 실행파일로 기동. Railway는 startCommand를 shell 없이 argv로 분해하므로
-# env 프리픽스(HOSTNAME=…)·따옴표·sh -c 금지. HOSTNAME 조작 불필요(컨테이너ID가 실제 IP로 해석됨).
+# env 프리픽스(HOSTNAME=…)·따옴표·sh -c 금지(순수 `node server.js`만).
+# ⚠️ standalone은 컨테이너 HOSTNAME(IPv6-우선 해석)에 바인딩 → 서비스 변수 `HOSTNAME=0.0.0.0` 필수(없으면 IPv4 헬스체크 미도달로 배포 FAILED). 상세: docs/operations/deploy-safety-guide.md
 # ⚠️ 서비스(대시보드/GraphQL) startCommand가 이 값보다 우선하므로, 배포 시 serviceInstanceUpdate로 동일하게 맞춰야 함.
 startCommand = "node server.js"
 # 경량 /api/health로 기동 판정(무거운 홈 SSR 대기 회피). standalone에서 200 반환 검증됨.


### PR DESCRIPTION
## 배경
#491 머지 시 GitHub head-sync 지연으로 railway.toml 정정 커밋(155232e)이 누락됨. 단일 커밋으로 재적용.

## 변경
- `railway.toml` 인라인 주석의 잘못된 **"HOSTNAME 조작 불필요"** → standalone은 컨테이너 HOSTNAME(IPv6-우선)에 바인딩하므로 **서비스 변수 `HOSTNAME=0.0.0.0` 필수**로 정정 (deploy-safety-guide.md 링크 추가).
- 주석 전용 (동작 무영향).

#490(deployment.md)·#491(deploy-safety-guide.md)에서 이미 정정한 내용과 repo 전체 정합성을 맞춤.

🤖 Generated with [Claude Code](https://claude.com/claude-code)