### PR TITLE
docs: 감사 확인 문서 부정확 15건 일괄 정정 (코드 대조 CONFIRMED)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,7 @@ src/
 │   ├── session/     # ResultTextCard, SessionActionButtons, ReadingErrorState, ReadingSectionBlock (3서비스 공통)
 │   └── tarot/       # CardInterpretationList (카드별 해석 목록), TarotResultPanel (결과 패널),
 │                    # CardFlipEffect, ReadingProgressIndicator, CardSpreadEffects
-├── data/            # cards, characters, home, saju, shinjeom/, skins, spreads, topics, mbti, topics-meta, error-messages
+├── data/            # cards, characters, home, saju, shinjeom/, skins, spreads, topics, mbti, topics-meta
 │   └── cardStyles.ts  # CardStyleId, 4가지 아트 스타일, THEME_TO_STYLE_MAP
 ├── hooks/           # Zustand store와 UI/streaming hooks
 │   ├── useCardStyleStore.ts   # 카드 스타일 persist 스토어 (arcana-card-style)
@@ -76,7 +76,7 @@ src/
 ├── test-helpers/    # Vitest 공통 mock/setup
 └── types/           # 공유 타입
 
-docs/                # architecture, conventions, workflow, operations, archive
+docs/                # architecture, archive, conventions, design, operations, superpowers, workflow
 e2e/                 # Playwright specs
 scripts/
 ├── e2e-full/        # E2E 전수 검증 오케스트레이터
@@ -96,7 +96,7 @@ supabase/migrations/ # Supabase SQL migrations
 - 카드 아트 스타일: `CardStyleId`(dark-fantasy·art-nouveau·anime-mystical·modern-digital), `THEME_TO_STYLE_MAP`으로 테마 자동 매핑. `useCardStyleStore`가 사용자 override를 persist. `CardFace`/`CardBack`/`CardItem`은 styleId → skinId → SVG 순으로 이미지 우선순위 처리.
 - 테마 이펙트: `ThemeEffectEngine`이 CSS 변수(`--theme-glow-color`, `--theme-particle-color` 등)를 주입. `ThemeAtmosphereLayer`(글로우·파티클 5-레이어), `InteractionEffects`(`InteractionClickParticles` — `document.addEventListener` 방식, pointer-events-none), `ServiceBackground`(AI 배경 이미지 `getServiceBackgroundUrl(service, activeTheme)` + `CanvasParticleLayer` + `ThemeAtmosphere` 내장 — `fixed inset-0 -z-10`, `loading="lazy"` 으로 `window.load` 비블로킹), `src/styles/theme-effects.css` 로 구성.
 - 타로 텍스트 reveal: `useReadingReveal` 스토어가 `showLabel` 플래그를 관리. `CardFace` → `CardItem` → `CardSpread` → 타로 세션 페이지로 prop 체인 전달. result phase 진입 시에만 카드명 텍스트 노출.
-- 프리미엄 리딩 구조 (PR #414 + #420): 타로 `CardInterpretationItem`에 `symbolism`/`situation`/`action` 3-섹션 추가. 사주 `SajuSections`(structure/elements/fortune/guidance), 신점 `ShinjeomSections`(spiritual/current/obstacles/future)가 `ReadingResult`에 optional로 포함. `ReadingSectionBlock` 컴포넌트가 3서비스 공통 섹션 UI 렌더링. 타로 max_tokens 공식: `min(15000 + cardCount × 9000 + 15000, 65000)` (cap 65,000). 사주·신점 최대 60,000. 하위 호환: `interpretation` 필드 기존 데이터 fallback 유지.
+- 프리미엄 리딩 구조 (PR #414 + #420): 타로 `CardInterpretationItem`에 `symbolism`/`situation`/`action` 3-섹션 추가. 사주 `SajuSections`(structure/elements/fortune/guidance), 신점 `ShinjeomSections`(spiritual/current/obstacles/future)가 `ReadingResult`에 optional로 포함. `ReadingSectionBlock` 컴포넌트가 3서비스 공통 섹션 UI 렌더링. 타로 max_tokens 공식: `min(15000 + cardCount × 9000 + 15000, 65000)` (cap 65,000). 사주 최대 60,000, 신점 최종 리딩 48,000 고정. 하위 호환: `interpretation` 필드 기존 데이터 fallback 유지.
 - 질문 직답(directAnswer) — answer-first 계약: `ReadingResult.directAnswer`는 사용자의 구체 질문에 "먼저" 답하는 필드다. `buildDirectAnswerContract(domain)`(`prompt-builder.ts`)가 **schemaLine(JSON 스켈레톤)·systemSpec(작성 지침)·footerReminder를 한 곳에서 방출**해 지시-스키마-파서 드리프트를 구조적으로 차단(이전 결함: 사주 route가 directAnswer 지시를 붙였으나 사주 스키마·파서·UI엔 필드가 없어 답이 소실). 지침: ① 질문 재진술 → ② 가장 유력한 한 방향 단언 → ③ 확신 수위 문체 표기("분명히" / "~쪽으로 기울어 있습니다" / "단서는 있으나 확정하기엔 이릅니다") → ④ 근거(도메인별: 카드/세운·월운/상)+전제조건. "모든 상황 균등 나열" 헤지는 안티패턴으로 **금지**. 사적 사실은 완충하되 방향은 커밋(2축 분리), 민감 도메인(건강·재정·법률)은 확답 대신 경향+전문가 상담 권유로 강등. **3서비스 공통 배선**(타로·사주·신점 모두 스키마+parseResult+결과화면 최상단 `ResultTextCard` 렌더). 앵커: 타로·사주는 자유질문 입력창(200자, `buildFreeQuestionPrompt`), 신점은 chat 첫 사용자 메시지를 핵심질문으로 재노출.
 - 쉬운 말 계약(가독성): `buildReadabilityContract(domain)`(`prompt-builder.ts`)가 3서비스 공통 `systemSpec`(쉬운말·대화체 규칙)·`fewShot`(도메인별 before→after)·`footerReminder`를 방출. 원칙은 **"분량 축소가 아니라 같은 분량을 쉬운 말로"** — 문단 수·max_tokens 불변, 깊이의 실현 수단만 미문→구체성으로 재조준. 일반 성인 누구나 한 번에 이해하는 해요체, 전문용어 즉시 풀어쓰기(사주는 [용어→비유→당신 삶] 3단 착지 병기), 추상 명사는 "예를 들어 ~할 때처럼" 구체 장면으로 착지. 타로 화려체("원형·신화·감각적 묘사")·신점 신탁체("신명이 감지합니다"→"제가 보기엔") 완화, 사주·신점 `overallReading`/`advice`의 `【】` 소제목을 평이 헤더로 rename(`【사주 전체 구조】`→`【타고난 성격】`, `【신명의 메시지】`→`【마음에 닿는 말】`). 캐릭터 12명 `speechStyle`도 개성(어미·톤)은 보존하되 어려운 레지스터(문어체·시적·비유 상시)를 쉬운 말 지향으로 손질. 사주 시간 지평 연계: `detectSajuTimeHorizon`+`applyHorizonToCalcOptions`가 질문의 시간창(이번 주/달/올해/내년)을 감지해 드롭다운과 무관하게 해당 월운/세운 데이터를 결정론적으로 주입. 타로는 결과 최상단에 `directAnswer` 렌더(answer-first). DB 영속(마이그 023 `direct_answer` 컬럼): `persistDirectAnswer`가 본 리딩 insert와 **분리된 best-effort UPDATE**로 기록 → 재방문(`result/[id]`)·공유 결과에도 노출. 컬럼 미적용 환경에서도 UPDATE만 조용히 실패해 본 저장 무영향. 마이그 023 운영 DB 적용 완료(2026-07-04). 같은 관용 패턴으로 사주·신점 4-섹션(`sajuSections`/`shinjeomSections`)도 `persistReadingSections`가 본 insert와 분리된 best-effort UPDATE로 영속(마이그 024 `saju_sections`·`shinjeom_sections` JSONB DEFAULT `{}`) → `result/[id]` 재방문·공유에 `ReadingSectionBlock` 렌더. 마이그 024 운영 DB 적용 완료(2026-07-05). (타로는 섹션 컬럼 없음 — `card_interpretation`으로 저장)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -51,6 +51,11 @@ docs/
 │   ├── image-assets.md
 │   ├── layout-rules.md
 │   └── zod-schemas.md
+├── design/
+│   ├── CLAUDE_DESIGN_BRIEF.md
+│   ├── IMPLEMENTATION_PLAN.md
+│   ├── characters/
+│   └── screenshots/
 ├── workflow/
 │   ├── ci-cd.md
 │   ├── claude-codex-collaboration.md

--- a/docs/architecture/ai-infrastructure.md
+++ b/docs/architecture/ai-infrastructure.md
@@ -206,18 +206,18 @@ shinjeomSections(spiritual/current/obstacles/future) 4-섹션 기준 3배 확장
 
 ## 클라이언트 타임아웃 패턴 (tarot/saju 세션 공통)
 
-타로·사주 세션 페이지는 240s 하드 타임아웃 + `AbortController` + `finished` 가드 패턴을 공통 적용합니다:
+타로·사주 세션 페이지는 280s 하드 타임아웃 + `AbortController` + `finished` 가드 패턴을 공통 적용합니다:
 
 ```ts
 const abortController = new AbortController();
 let finished = false;
 
-// 240s 하드 타임아웃 — 10장+ 타로/full-fortune 사주의 reasoning+stream 시간 대응
+// 280s 하드 타임아웃 — 10장+ 타로/full-fortune 사주의 reasoning+stream 시간 대응
 const timer = setTimeout(() => {
   if (finished) return;
   abortController.abort();
   setReadingErrorReason("timeout");
-}, 240_000);
+}, 280_000);
 
 await fetchSSEStream({ signal: abortController.signal, ... });
 finished = true;

--- a/docs/architecture/data-model.md
+++ b/docs/architecture/data-model.md
@@ -214,7 +214,6 @@ export interface EffectTheme {
 | 카드 아트 스타일 | `src/data/cardStyles.ts` |
 | 팔레트 스킨 | `src/data/skins/index.ts` |
 | 홈 페이지 정적 데이터 | `src/data/home/` (faq.ts) |
-| 에러 메시지 상수 | `src/data/error-messages.ts` |
 | MBTI 16타입 상수 | `src/data/mbti.ts` |
 | 토픽 메타 정보 | `src/data/topics-meta.ts` |
 | 신점 문화적 해석 데이터 | `src/data/shinjeom/cultural-readings.ts` |

--- a/docs/architecture/i18n.md
+++ b/docs/architecture/i18n.md
@@ -38,13 +38,13 @@ src/i18n/
 ├── useT.ts                   # 클라이언트 컴포넌트 훅
 └── translations/
     ├── index.ts              # buildDict + t(key, locale) + fallback chain
-    ├── shared/keys.ts        # SharedKeys 타입 (17 namespace) + flatten 헬퍼
+    ├── shared/keys.ts        # SharedKeys 타입 (19 namespace) + flatten 헬퍼
     ├── ko/index.ts           # SSOT
     ├── en/index.ts           # 영문 사전
     └── ja/index.ts           # 일본어 사전
 ```
 
-### namespace (17개)
+### namespace (19개)
 - `common` — skip-link, loading, retry, language 등 공유 키
 - `header` — nav, auth, theme 라벨
 - `footer` — tagline, section, link
@@ -56,6 +56,8 @@ src/i18n/
 - `mypage` — page, profile, stats, history, favorite
 - `character` — page, service 선택 관련 키
 - `user-info` — UserInfoForm 타이틀·서브타이틀·제출 버튼·플레이스홀더
+- `birth-time` — 생년월일시 입력 관련 키
+- `privacy-consent` — 개인정보 동의 모달 키
 - `auth` — 로그인 페이지 키
 - `share` — 공유 버튼 라벨
 - `chat` — 채팅 기본 라벨

--- a/docs/conventions/coding-style.md
+++ b/docs/conventions/coding-style.md
@@ -55,7 +55,7 @@ ArcanaInsight 코드 작성 시 반드시 준수해야 하는 스타일 규칙�
 | **메이저 업그레이드 금지** (사용자 승인 필요) | Next.js, React, Framer Motion, Tailwind CSS, Zustand |
 | **마이너·패치 허용** | 보안 패치, 버그 픽스 |
 | **버전 고정** | `pnpm@10.33.0` — lock 파일 및 Docker 스크립트 동기화 |
-| **버전 고정** | `playwright:v1.59.1-noble` — CI Docker 이미지 동기화 |
+| **버전 고정** | `@playwright/test@^1.59.1` — CI는 ubuntu 러너 + `npx playwright install`. `mcr.microsoft.com/playwright:v1.59.1-noble`는 로컬 Docker E2E 전용 이미지(CI는 컨테이너 미사용) |
 
 ---
 

--- a/docs/conventions/i18n-style.md
+++ b/docs/conventions/i18n-style.md
@@ -86,12 +86,6 @@ export async function POST(req: NextRequest) {
 - server-locale.ts: exclusion (Next.js headers API 의존, 단위 테스트는 vitest setup mock)
 - vitest `coverage.include`와 `sonar.coverage.exclusions` 항상 동기 (PR-A 표류 정리 교훈)
 
-## 외부 번역 의뢰 자료
-
-- `docs/i18n/glossary.md`: 사주 십성·오방색·타로 표준 영문 용어집
-- `docs/i18n/character-voice-guide.md`: 12 캐릭터 영문·일문 화법 시그니처
-- `docs/i18n/character-qa-checklist.md`: 페르소나 톤 일관성 QA
-
 ## 참조
 
 - 인프라 개요: [`docs/architecture/i18n.md`](../architecture/i18n.md)

--- a/docs/superpowers/plans/archive/README.md
+++ b/docs/superpowers/plans/archive/README.md
@@ -8,7 +8,7 @@
 - 파일 자체는 삭제하지 않는다 (의사결정 흐름·논의 맥락 보존).
 - 새 계획서를 작성하면 부모 디렉토리에 위치시키고, 머지 후 본 디렉토리로 옮긴다.
 
-## 인벤토리 (23개)
+## 인벤토리 (37개)
 
 | 파일 | 작성 시점 | 주제 | 관련 PR/구현 |
 |---|---|---|---|
@@ -26,7 +26,8 @@
 | `2026-04-11-db-provider-migration.md` | 2026-04-11 | DB Provider 마이그레이션 | Supabase ↔ PostgreSQL 전환 |
 | `2026-04-26-railway-sonarcloud-mcp.md` | 2026-04-26 | Railway·SonarCloud MCP 연동 | MCP 자율 진단 규칙 |
 | `2026-05-01-character-experience-enhancement.md` | 2026-05-01 | 캐릭터 경험 강화 | 6-mood·waiting-lines·메모리 |
-| `2026-05-01-code-doc-cleanup.md` | 2026-05-01 | 코드·문서 심층 정리 (계획) | 결과는 부모 `2026-05-01-code-doc-cleanup-result.md`에 보관 |
+| `2026-05-01-code-doc-cleanup.md` | 2026-05-01 | 코드·문서 심층 정리 (계획) | 결과는 `2026-05-01-code-doc-cleanup-result.md`(본 archive/)에 보관 |
+| `2026-05-01-code-doc-cleanup-result.md` | 2026-05-01 | 코드·문서 정리 결과 기록(메타) | #426·#437·#440 후속 정리 기준점 |
 | `2026-05-01-e2e-multiagent.md` | 2026-05-01 | 멀티 에이전트 E2E 전수 검증 | `scripts/e2e-full/` |
 | `2026-05-01-phase1-ui-revitalization.md` | 2026-05-01 | UI 리바이탈 Phase 1 | 비주얼 FX 1차 |
 | `2026-05-01-phase2-ui-revitalization.md` | 2026-05-01 | UI 리바이탈 Phase 2 | 비주얼 FX 2차 |
@@ -34,8 +35,23 @@
 | `2026-05-02-shuffle-ceremony.md` | 2026-05-02 | ShuffleCeremony 도입 | `src/components/tarot/ShuffleCeremony.tsx` |
 | `2026-05-05-rls-security-fix.md` | 2026-05-05 | RLS 보안 취약점 수정 | PR #219 (013·014·015 마이그레이션) |
 | `2026-05-06-share-token-streaming-resilience.md` | 2026-05-06 | share_token 스트리밍 통합 | PR #221 |
+| `2026-05-06-grok-i18n-completion-plan.md` | 2026-05-06 | Grok i18n 완성 계획 | i18n 다국어 |
+| `2026-05-07-retrospective-quality-improvement.md` | 2026-05-07 | 회고 기반 품질 개선 | 프로세스 개선 |
+| `2026-05-10-doc-audit-role-alignment.md` | 2026-05-10 | 문서 감사·역할 정렬 | 문서 정합성 |
+| `2026-05-10-visual-overhaul-phase1-image-generation.md` | 2026-05-10 | Visual Overhaul P1 이미지 생성 | 카드 아트 스타일 |
+| `2026-05-10-visual-overhaul-phase2-theme-effects.md` | 2026-05-10 | Visual Overhaul P2 테마 이펙트 | 테마 FX |
+| `2026-05-10-visual-overhaul-phase3-service-effects.md` | 2026-05-10 | Visual Overhaul P3 서비스 이펙트 | 서비스 일러스트 |
+| `2026-05-11-daily-fortune.md` | 2026-05-11 | 데일리 포춘 | daily-fortune |
+| `2026-05-11-doc-full-rewrite-plan-B.md` | 2026-05-11 | 문서 전면 재작성 (Plan B) | 문서 구조 |
+| `2026-05-12-userinfo-birthtime-mbti.md` | 2026-05-12 | UserInfo 생년월일시·MBTI | UserInfoForm |
 | `2026-05-15-code-doc-cleanup.md` | 2026-05-15 | 전체 코드·문서 정리 (3-PR) | 문서 감사·컴포넌트 분리(#426·#437·#440) |
+| `2026-05-26-premium-reading-experience.md` | 2026-05-26 | 프리미엄 리딩 경험 | PR #414·#420 |
+| `2026-05-29-tarot-reading-quality.md` | 2026-05-29 | 타로 리딩 품질 | 리딩 프롬프트 |
+| `i18n-consistency-fix.md` | (초기) | i18n 정합성 수정 | i18n 다국어 |
+| `i18n-master-plan.md` | (초기) | i18n 마스터 플랜 | i18n 다국어 |
 
-## 상위 디렉토리 보존 파일
+## 상위 디렉토리(활성 `plans/`) 현재 파일
 
-- `docs/superpowers/plans/2026-05-01-code-doc-cleanup-result.md` — 정리 작업의 결과 기록(메타). 후속 정리 작업의 기준점이 되므로 활성 위치 유지.
+- `docs/superpowers/plans/2026-06-26-supabase-storage-r2-migration.md` — Supabase Storage → R2 자산 이전 계획(#450·#451·#452).
+
+> `2026-05-01-code-doc-cleanup-result.md`는 본 `archive/`로 이동되어 위 인벤토리에 포함됨(과거 상위 `plans/` 보존 항목이었음).

--- a/docs/workflow/ci-cd.md
+++ b/docs/workflow/ci-cd.md
@@ -88,7 +88,7 @@ pnpm test:coverage   # Vitest + lcov 커버리지 생성
 **트리거**: main 브랜치 push → Railway 자동 빌드+배포
 
 ```
-설정 파일: railway.toml (nixpacks 빌더)
+설정 파일: railway.toml (dockerfile 빌더 — Next.js standalone 멀티스테이지, startCommand=node server.js, healthcheckPath=/api/health)
 GitHub Secrets 필요:
   RAILWAY_TOKEN       Railway API 토큰
   RAILWAY_SERVICE_ID  Railway 서비스 ID

--- a/docs/workflow/claude-codex-collaboration.md
+++ b/docs/workflow/claude-codex-collaboration.md
@@ -25,7 +25,7 @@
 |---|-----------|--------|
 | C1 | 기능 요구사항 분석 및 스펙 문서 작성 | `docs/superpowers/specs/*.md` |
 | C2 | 아키텍처 설계·기술 결정 문서 | `docs/architecture/*.md` 갱신 |
-| C3 | 에이전트 정의 및 Task Playbook | `.claude/agents/*.md`, `docs/workflow/task-playbooks.md` — 현재 8종: `character-add`, `divination-scaffold`, `page-builder`, `skin-manager`, `theme-creator`, `quality-gate`, `i18n-manager`, `post-merge-doc-refresher` |
+| C3 | 에이전트 정의 및 Task Playbook | `.claude/agents/*.md`, `docs/workflow/task-playbooks.md` — 현재 9종: `character-add`, `card-style-manager`, `divination-scaffold`, `page-builder`, `skin-manager`, `theme-creator`, `quality-gate`, `i18n-manager`, `post-merge-doc-refresher` |
 | C4 | DB 스키마 설계 및 마이그레이션 계획 | SQL 초안, Drizzle 스키마 구조 명세 |
 | C5 | 새 서비스·페이지 뼈대 스캐폴딩 | 파일 구조, 인터페이스, 타입 정의, 빈 함수 시그니처 |
 | C6 | `CLAUDE.md` / `AGENTS.md` 최신화 | 구조 트리, 아키텍처 섹션 갱신 |
@@ -82,7 +82,7 @@ Codex에게 작업을 전달할 때 **아래 항목을 모두 포함**해야 한
 ### 완료 조건 (Definition of Done)
 - [ ] pnpm type-check — 0 error
 - [ ] pnpm lint       — 0 error
-- [ ] pnpm test:coverage — branches≥92 / functions≥98 / lines≥98 / statements≥98
+- [ ] pnpm test:coverage — branches≥90 / functions≥97 / lines≥98 / statements≥98
 - [ ] [기능별 추가 조건]
 
 ### 재진입 조건 (아래 상황이면 구현 중단 후 Claude에게 반환)

--- a/docs/workflow/e2e-testing.md
+++ b/docs/workflow/e2e-testing.md
@@ -8,7 +8,7 @@
 
 - **27개 spec 파일** (Desktop Chrome 기준 197개 테스트; 실제 수는 `npx playwright test --list --project="Desktop Chrome"` 기준)
 - **3개 디바이스 프로필**: Desktop Chrome · Mobile Android (Pixel 7) · Mobile iOS (iPhone 14)
-- **Playwright 버전**: `v1.59.1` — CI Docker 이미지와 버전 고정, 임의 변경 금지
+- **Playwright 버전**: `@playwright/test@^1.59.1` — package.json 고정, 임의 변경 금지 (CI는 ubuntu 러너 + `npx playwright install`; `mcr.microsoft.com/playwright:v1.59.1-noble`는 로컬 Docker E2E 전용)
 
 ---
 

--- a/docs/workflow/task-playbooks.md
+++ b/docs/workflow/task-playbooks.md
@@ -13,10 +13,9 @@
 1. `src/data/characters/index.ts` — 캐릭터 메타데이터 추가
 2. `src/data/characters/waiting-lines.ts` — 대기 대사 추가
 3. `src/types/character.ts` — 타입 확인
-4. `public/images/characters/[id]/nukki/` — 원본 이미지 7종 배치
-5. `public/images/characters/[id]/nukki/backup-v2/` — 운영본 색상 기준 1408×768 고해상도 원본 7종 배치
-6. `public/images/characters/[id]/nukki-enhanced/` — `backup-v2` 색상과 누끼 알파를 결합한 2816×1536 보정본 생성
-7. → `.claude/agents/character-add.md` 에이전트 활용
+4. `public/images/characters/[id]/nukki-enhanced/[mood].png` — 표정별 이미지(2816×1536 고DPI 2x본) 배치. ⚠️ `nukki/`·`nukki/backup-v2/` 폴더는 #447로 제거됨 — 현재는 `nukki-enhanced/` 단일 폴더만 사용(다운스케일 금지)
+5. `pnpm upload:characters:r2` — 캐릭터 이미지를 Cloudflare R2에 업로드(프로덕션은 `cdn.xzawed.xyz/characters` 서빙, `.dockerignore`가 배포 이미지에서 제외)
+6. → `.claude/agents/character-add.md` 에이전트 활용
 
 참고: [`docs/architecture/data-model.md`](../architecture/data-model.md) — 캐릭터 이미지 경로 규칙
 

--- a/docs/workflow/unit-testing.md
+++ b/docs/workflow/unit-testing.md
@@ -44,12 +44,12 @@ import 방식:
 import { POST } from "@/app/api/tarot/reading/route";
 ```
 
-현재 `src/__tests__/api/` 파일 목록 (15개):
+현재 `src/__tests__/api/` 파일 목록 (16개):
 - `tarot-session.test.ts` (14개), `saju-session.test.ts` (12개), `shinjeom-session.test.ts` (13개)
 - `tarot-result.test.ts` (4개), `saju-result.test.ts` (4개), `shinjeom-result.test.ts` (5개)
 - `tarot-reading.test.ts` (23개), `saju-reading.test.ts` (22개), `shinjeom-message.test.ts` (20개)
 - `favorite-character.test.ts` (11개), `daily-card.test.ts` (10개), `locale-wiring.test.ts` (15개)
-- `daily-fortune.test.ts`, `reading-dlq-retry.test.ts`, `sessions-claim.test.ts`
+- `daily-fortune.test.ts`, `reading-dlq-retry.test.ts`, `sessions-claim.test.ts`, `health.test.ts`
 
 ---
 


### PR DESCRIPTION
## 배경
전체 품질 감사(26-에이전트 워크플로 + 적대검증)에서 **제기 15건 전부 CONFIRMED**(REFUTED 0)된 문서 부정확을 코드 대조로 일괄 정정.

## 정정 (severity)
**HIGH**: `ci-cd.md` railway.toml nixpacks→dockerfile

**MEDIUM**: 신점 토큰 48k(CLAUDE.md) · i18n namespace 17→19 · 클라 타임아웃 240→280s · error-messages.ts 행 삭제 · 외부번역 섹션 삭제 · 에이전트 8→9종·커버리지 92/98→90/97 · API 테스트 15→16 · 캐릭터 이미지 절차(#447) · archive 인벤토리 23→37

**LOW**: CLAUDE.md data/·docs/ 트리 · playwright noble(로컬 Docker) · README design/

doc-links·env-docs 통과. 문서 전용.

🤖 Generated with [Claude Code](https://claude.com/claude-code)