### PR TITLE
chore(agents,skills): 에이전트·스킬 HIGH 결함 수정 + deploy-safety 스킬 신설

### DIFF
--- a/.claude/agents/character-add.md
+++ b/.claude/agents/character-add.md
@@ -117,24 +117,35 @@ node scripts/generate-character-images-v2.mjs {id}
 node scripts/generate-character-images-v2.mjs {id} smile
 ```
 
-> **[필수] 이미지 사이즈 규격: 1408×768**
-> `grok-imagine-image-pro` API 기본 출력 사이즈이므로 별도 지정 불필요.
+> **[필수] 이미지 사이즈 규격: 2816×1536** (고DPI 표시용 의도적 2x본 — **다운스케일 금지**)
+> `nukki-enhanced` 이미지는 캐릭터 상세(모바일 100vw)·세션 등 큰 표시를 위해 2816×1536 2x본으로 유지한다.
 > 생성 후 반드시 아래 명령으로 사이즈를 검증한다:
 > ```bash
 > python3 -c "
 > from PIL import Image; import glob
 > files = sorted(glob.glob('public/images/characters/{id}/nukki-enhanced/*.png'))
-> bad = [(f, Image.open(f).size) for f in files if Image.open(f).size != (1408, 768)]
-> print('비표준 파일:', bad if bad else '없음 (모두 1408x768)')
+> bad = [(f, Image.open(f).size) for f in files if Image.open(f).size != (2816, 1536)]
+> print('비표준 파일:', bad if bad else '없음 (모두 2816x1536)')
 > "
 > ```
 > 비표준 사이즈가 있으면 해당 표정을 재생성한다. 사이즈가 맞지 않으면 이후 작업을 중단하고 수정한다.
+
+### 6. R2 업로드 (필수 — 프로덕션 서빙)
+
+프로덕션은 캐릭터 이미지를 **Cloudflare R2(`cdn.xzawed.xyz/characters`)**에서 서빙하고, `.dockerignore`가 `public/images/characters`를 배포 이미지에서 제외한다(배포 슬림화). 따라서 **로컬 생성만으로는 프로덕션에서 404**가 되므로 반드시 R2에 업로드한다.
+
+```bash
+pnpm upload:characters:r2        # 신규/변경분 R2 업로드 (md5 검증)
+pnpm upload:characters:r2:skip   # 이미 존재하는 키 건너뛰고 업로드
+```
+
+`src/lib/storage/character-image.ts`의 `getCharacterImageUrl(id, mood)`가 `NEXT_PUBLIC_ASSET_BASE_URL` 설정 시 R2를, 미설정 시 로컬 `public`을 사용한다.
 
 ## 이미지 표시 규칙
 
 캐릭터 이미지를 화면에 표시할 때 **항상** 아래 두 가지를 동시에 지킨다:
 
-### 1. 사이즈 규격 — 1408×768 (필수)
+### 1. 사이즈 규격 — 2816×1536 (필수, 고DPI 2x본 · 다운스케일 금지)
 생성 후 반드시 검증 (위 4단계 참조).
 
 ### 2. 테두리 투명도 — CSS mask 표준값 (필수)
@@ -190,8 +201,9 @@ sonar.coverage.exclusions=\
 - [ ] `waitingLines`에 대사 추가됨
 - [ ] `buildCardPreviewLine`의 `cardPreviewTemplates`에 항목 추가됨
 - [ ] nukki-enhanced 이미지 7개(default/idle/smile/serious/surprised/wink/mystical) 존재
-- [ ] **모든 nukki-enhanced 이미지가 1408×768 사이즈** (python3 사이즈 검증 명령으로 확인)
+- [ ] **모든 nukki-enhanced 이미지가 2816×1536 사이즈** (python3 사이즈 검증 명령으로 확인 · 고DPI 2x본, 다운스케일 금지)
+- [ ] **`pnpm upload:characters:r2`로 R2 업로드 완료** (프로덕션은 `cdn.xzawed.xyz/characters` 서빙 — 미업로드 시 프로덕션 404)
 - [ ] **캐릭터 이미지 표시 시 표준 mask 스타일 적용** (CharacterDisplay 사용 또는 직접 스타일 명시)
 - [ ] SpriteAnimator의 MOOD_TO_FILE 매핑과 파일명 일치 (default→idle.png)
-- [ ] **이미지 생성 전 backup-v2/ 백업 완료**
+- [ ] **이미지 생성 전 백업 완료**
 - [ ] **신규 .ts 파일 추가 시 sonar-project.properties exclusions 동기화 완료**

--- a/.claude/agents/page-builder.md
+++ b/.claude/agents/page-builder.md
@@ -9,15 +9,24 @@ ArcanaInsight의 디자인 시스템과 레이아웃 규칙을 준수하는 새 
 
 ## 참조 파일
 
-- `src/app/layout.tsx` — 루트 레이아웃 (Header + Footer + MobileNav + ThemeProvider)
+- `src/app/layout.tsx` — 루트 레이아웃: **`html`/`body`(sticky-footer 컨테이너) + Provider + `Header` + 전역 오버레이만** 담당. ⚠️ `main`/`Footer`/`MobileNav`는 **라우트 그룹 레이아웃**이 소유(루트엔 없음).
+- `src/app/(immersive)/layout.tsx` — 몰입형 그룹: **Footer 미렌더**(100dvh 풀스크린, 이중 스크롤 방지)
+- `src/app/(site)/layout.tsx` — 일반 그룹: `main` + `Footer` + `MobileNav` 포함
 - `src/app/globals.css` — Tailwind v4 @theme 커스텀 컬러
-- `src/app/tarot/page.tsx` — 캐릭터가 있는 페이지 패턴
-- `src/app/saju/page.tsx` — 멀티스텝 + 카테고리 선택이 있는 페이지 패턴
-- `src/app/terms/page.tsx` — 정적 콘텐츠 페이지 패턴
-- `src/app/mypage/page.tsx` — 서버 컴포넌트 + Supabase 데이터 페이지 패턴
+- `src/app/(immersive)/tarot/page.tsx` — 캐릭터가 있는 몰입형 진입 페이지 패턴
+- `src/app/(immersive)/saju/page.tsx` — 멀티스텝 + 카테고리 선택 패턴
+- `src/app/(site)/terms/page.tsx` — 정적 콘텐츠 페이지 패턴
+- `src/app/(site)/mypage/page.tsx` — 서버 컴포넌트 + Supabase 데이터 페이지 패턴
 - `src/components/layout/Header.tsx` — 네비게이션 링크
 - `src/components/layout/MobileNav.tsx` — 모바일 탭
 - `src/components/layout/Footer.tsx` — 푸터 링크
+
+## 라우트 그룹 배치 (먼저 결정)
+
+새 페이지는 **어느 그룹에 둘지 먼저 결정**한다:
+
+- **`(immersive)`** — 타로·사주·신점 세션/진입, `character/[id]` 등 100dvh 풀스크린 몰입 경험. **Footer 미렌더.** 스테이지가 높이를 지배(`h-[calc(100dvh-7rem)]`)하며 outer 래퍼엔 min-height를 두지 않는다(`relative overflow-hidden`).
+- **`(site)`** — 홈·결과·마이페이지·약관 등 일반 페이지. Footer 포함. ⚠️ **`min-h-screen`(=100vh) 금지**(PR #428 — `main` 패딩과 합산돼 유령 스크롤+Footer 가림). 높이는 sticky-footer 컨테이너에 위임하고, 중앙정렬이 필요하면 `min-h-[calc(100dvh-7rem)] md:min-h-[calc(100dvh-3.5rem)]`.
 
 ## 필수 레이아웃 규칙
 
@@ -37,22 +46,24 @@ ArcanaInsight의 디자인 시스템과 레이아웃 규칙을 준수하는 새 
 </div>
 ```
 
-### 정적 콘텐츠 페이지 (약관, 개인정보 등)
-- `min-h-screen bg-arcana-bg`
+### 정적 콘텐츠 페이지 (약관, 개인정보 등) — `(site)` 그룹
+- ⚠️ **`min-h-screen` 금지 (PR #428)** — 높이는 sticky-footer 컨테이너에 위임(페이지 래퍼에 min 높이 두지 않음)
+- `bg-arcana-bg`
 - `max-w-3xl mx-auto px-4 py-12`
 - "← 홈으로" 뒤로가기 링크
 - `font-serif font-bold text-arcana-purple` 제목
 - `text-arcana-text text-sm leading-relaxed` 본문
 
-### 배경 이미지가 있는 페이지
+### 배경 이미지가 있는 페이지 (주로 `(immersive)`)
+⚠️ 외부 lazy 이미지(`ServiceBackground`) 페이지엔 **dvh 기반 min-height 금지**(E2E `load` 지연, PR #428). outer는 min-height 없이 `relative overflow-hidden`으로 두고, 높이는 스테이지(`h-[calc(100dvh-7rem)]`)가 지배하게 한다.
 ```tsx
-<div className="relative min-h-screen overflow-hidden">
+<div className="relative overflow-hidden">
   <div className="fixed inset-0 -z-10">
-    <Image src="/images/backgrounds/..." alt="" fill className="object-cover" />
+    <Image src="/images/backgrounds/..." alt="" fill className="object-cover" loading="lazy" />
     <div className="absolute inset-0 bg-arcana-bg/50" />
   </div>
   <ParticleOverlay density="low" />
-  {/* 콘텐츠 */}
+  {/* 콘텐츠 — 스테이지 height로 높이 지배 */}
 </div>
 ```
 

--- a/.claude/agents/quality-gate.md
+++ b/.claude/agents/quality-gate.md
@@ -1,7 +1,6 @@
 ---
 name: quality-gate
 description: 코드 품질 검증을 강도 높게 수행한다. "코드 검증", "품질 검사", "전체 테스트", "코드 품질 향상" 등의 요청에 사용한다.
-model: claude-sonnet-4-6
 tools: Read, Grep, Glob, Bash
 ---
 
@@ -44,19 +43,23 @@ pnpm lint              # ESLint (0 error 필수, warning 기록)
 - `src/app/tarot/session/page.tsx` — SSE 버퍼링, 카드 확인, 대기 연출
 - `src/app/saju/session/page.tsx` — SSE 처리, 결과 표시
 
-### Phase 3: 27개 테스트 케이스 실행
+### Phase 3: 자동화 테스트 + 커버리지 게이트 (실제 실행)
 
-코드를 직접 읽고 아래 항목을 검증한다 (자동화 테스트 프레임워크 없음, 정적 코드 분석 + 파일 존재 확인):
+프로젝트는 Vitest(단위·통합) + Playwright(E2E) 기반이다. **정적 시뮬레이션이 아니라 실제 스위트를 실행**한다:
 
-1. **사주 계산 엔진** (5개) — 알려진 사주, 윤년, 십성, 12운성, 대운
-2. **상수 데이터 무결성** (4개) — 천간 10개, 지지 12개, 오행 5개, 12시진
-3. **카드 데이터** (2개) — 메이저 22장, 스프레드 10종
-4. **캐릭터 데이터** (2개) — 전체 캐릭터 수 12명, 모든 expressions가 nukki-enhanced PNG 경로(`/nukki-enhanced/*.png`) 형식
-5. **API 입력 검증** (2개) — 유효 토픽(15개 / 사주 8개+타로 7개), 스프레드 타입(10종)
-6. **SSE 패턴** (4개) — 버퍼링, error 처리, done+break, 사주 동일 패턴
-7. **타입 안전성** (4개) — spreadType nullable, cardInterpretations optional, 타임아웃, 플레이스홀더
-8. **레이아웃 규칙** (2개) — 타로/사주 5:5 레이아웃 (md:w-1/2 적용 여부)
-9. **보안** (2개) — 환경변수 하드코딩 없음, 법적 페이지 존재
+```bash
+pnpm test:coverage      # Vitest 전체 + v8 커버리지 임계값 게이트
+```
+
+- **전체 테스트 통과 필수** — 1개라도 실패 시 게이트 실패.
+- **커버리지 임계값**(`vitest.config.ts`): branches 90 / functions 97 / lines 98 / statements 98. 미달 시 실패.
+- 실패·미달 항목은 아래 결과 보고에 파일·수치와 함께 기록한다.
+
+```bash
+pnpm test:e2e:full:ci   # (선택) 대표 케이스 E2E — UI/플로우 변경 시
+```
+
+Vitest가 이미 커버하는 도메인(사주 계산·상수 무결성·카드/캐릭터 데이터·API 입력 검증·SSE 패턴·타입 안전성 등)은 위 실행으로 검증된다. 추가로 구조적 스팟 체크가 필요하면 Phase 2·4의 파일 대조를 병행한다.
 
 ### Phase 4: 이미지 에셋 검증
 
@@ -65,12 +68,12 @@ pnpm lint              # ESLint (0 error 필수, warning 기록)
 - 필수 표정 6종: `default`, `smile`, `serious`, `surprised`, `wink`, `mystical`
 - SpriteAnimator MOOD_TO_FILE 매핑과 파일명 일치
 - expressions 경로가 실제 파일과 일치
-- **[필수] 모든 nukki PNG 사이즈가 1408×768인지 검증**:
+- **[필수] 모든 nukki PNG 사이즈가 2816×1536인지 검증** (고DPI 2x본 · 다운스케일 금지):
   ```bash
   python3 -c "
   from PIL import Image; import glob
   files = glob.glob('public/images/characters/*/nukki-enhanced/*.png')
-  bad = [f for f in files if Image.open(f).size != (1408, 768)]
+  bad = [f for f in files if Image.open(f).size != (2816, 1536)]
   print(f'전체 {len(files)}개 | 비표준: {len(bad)}개')
   for f in bad: print(' !!', f, Image.open(f).size)
   "
@@ -101,11 +104,12 @@ git diff HEAD~1 --name-only --diff-filter=A | grep "^src/.*\.tsx\?$"
 tsc: 0 error
 lint: 0 error, N warning
 
-=== 테스트 케이스 ===
-총 N개 | ✓ N 통과 | ✗ N 실패
+=== 테스트 + 커버리지 (실제 실행) ===
+Vitest: N passed / N files
+커버리지: branches X / functions X / lines X / statements X (임계값 90/97/98/98)
 
 === 이미지 에셋 ===
-N개 캐릭터 × 7 누끼 = N개 확인
+12개 캐릭터 × nukki-enhanced 표정 = N개 확인 (2816×1536)
 
 === 발견된 이슈 ===
 | # | 심각도 | 파일 | 이슈 | 수정 |

--- a/.claude/skills/add-translation-key/SKILL.md
+++ b/.claude/skills/add-translation-key/SKILL.md
@@ -21,20 +21,24 @@ src/i18n/translations/
     └── index.ts         ← 일본어 번역
 ```
 
-현재 namespace 19개: `common`, `home`, `tarot`, `saju`, `shinjeom`, `character`, `settings`, `result`, `error`, `reading`, `card`, `skin`, `session`, `auth`, `legal`, `share`, `theme`, `birth-time`, `privacy-consent`
+현재 top-level namespace 19개 (`shared/keys.ts` 정본): `common`, `header`, `footer`, `home`, `settings`, `locale`, `tarot`, `saju`, `mypage`, `character`, `user-info`, `birth-time`, `privacy-consent`, `auth`, `share`, `chat`, `api`, `meta`, `shinjeom`
 
 ## 단계별 절차
 
 ### Step 1 — SharedKeys에 타입 추가
 
-`src/i18n/translations/shared/keys.ts`에서 해당 namespace 인터페이스에 키를 추가한다.
+`src/i18n/translations/shared/keys.ts`의 **단일 `SharedKeys` 인터페이스**에서 해당 namespace(중첩 객체)에 키를 추가한다. (namespace별 `XxxKeys` 인터페이스는 존재하지 않는다.)
 
 ```typescript
-// 예시: tarot namespace에 새 키 추가
-export interface TarotKeys {
-  // 기존 키들...
-  newFeatureTitle: string;    // ← 추가
-  newFeatureDesc: string;     // ← 추가
+// 예시: tarot namespace 객체에 새 키 추가 (키는 kebab-case 관례)
+export interface SharedKeys {
+  // ...
+  tarot: {
+    // 기존 키들...
+    "new-feature-title": string;   // ← 추가
+    "new-feature-desc": string;    // ← 추가
+  };
+  // ...
 }
 ```
 
@@ -45,8 +49,8 @@ export interface TarotKeys {
 ```typescript
 tarot: {
   // 기존 항목들...
-  newFeatureTitle: "새 기능 제목",
-  newFeatureDesc: "새 기능 설명",
+  "new-feature-title": "새 기능 제목",
+  "new-feature-desc": "새 기능 설명",
 }
 ```
 
@@ -57,14 +61,14 @@ tarot: {
 ```typescript
 // en/index.ts
 tarot: {
-  newFeatureTitle: "New Feature Title",
-  newFeatureDesc: "New feature description",
+  "new-feature-title": "New Feature Title",
+  "new-feature-desc": "New feature description",
 }
 
 // ja/index.ts
 tarot: {
-  newFeatureTitle: "新機能タイトル",
-  newFeatureDesc: "新機能の説明",
+  "new-feature-title": "新機能タイトル",
+  "new-feature-desc": "新機能の説明",
 }
 ```
 
@@ -79,13 +83,15 @@ drift(키 불일치) 없음 확인. 에러 발생 시 누락된 언어의 키를
 ### Step 5 — UI에서 사용
 
 ```tsx
-// 클라이언트 컴포넌트
-const { t } = useT("tarot");
-return <h1>{t("newFeatureTitle")}</h1>;
+// 클라이언트 컴포넌트 — useT()는 인자 없음, 전체 키(namespace.key)로 조회
+const { t } = useT();
+return <h1>{t("tarot.new-feature-title")}</h1>;
 
-// 서버 컴포넌트 / API
-const t = await getT("tarot", locale);
-return t("newFeatureTitle");
+// 서버 컴포넌트 / API — getRequestLocale + t(key, locale)  (getT는 존재하지 않음)
+import { t as translate } from "@/i18n/translations";
+import { getRequestLocale } from "@/i18n/server-locale";
+const locale = await getRequestLocale();
+return translate("tarot.new-feature-title", locale);
 ```
 
 ## 주의사항

--- a/.claude/skills/deploy-safety/SKILL.md
+++ b/.claude/skills/deploy-safety/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: deploy-safety
+description: 배포 영향 변경(Dockerfile·railway.toml·next.config·서비스 config) 시 품질 손상을 막는 배포 전 체크리스트와 배포 후 스모크를 안내한다. "배포 안전", "Dockerfile 수정", "railway 배포", "배포 전 확인", "standalone 배포", "배포 실패" 등의 요청에 사용한다.
+when_to_use: Dockerfile·railway.toml·next.config.ts·.dockerignore·Railway 서비스 config 변경/커밋 시, 배포 실패 진단 시, 배포 후 검증 시
+allowed-tools: Read Grep Bash(git diff*) Bash(curl*) Bash(railway *)
+---
+
+# 배포 안전 절차 (배포 품질 손상 최소화)
+
+> 정본은 [`docs/operations/deploy-safety-guide.md`](../../../docs/operations/deploy-safety-guide.md). 이 스킬은 그 절차를 실행 시점에 상기시킨다.
+> 배경: 2026-07-06 Railway standalone 전환에서 배포가 ~7회 실패(3겹 원인). CI 게이트(tsc/lint/test)는 **배포 런타임**(IPv6 바인딩·startCommand argv 분해·헬스체크)을 잡지 못한다.
+
+## 핵심 원칙 3
+
+1. **헬스체크-게이트 안전망** — `healthcheckPath` 통과해야만 트래픽 스왑. 실패해도 기존 배포 유지(무중단). 단, 실패는 원인 규명 후 넘어간다.
+2. **관측 먼저** — 불투명한 실패는 대시보드/SSH/앱 로그로 실제 오류를 확보한 뒤 수정한다(가설 위에 수정 쌓지 말 것).
+3. **로컬 ≠ 프로덕션** — 인프라·네트워크·런타임 주입 env 수정은 로컬 통과만으로 단정하지 말고 프로덕션 런타임 증거로 확정한다.
+
+## 1. 배포 영향 변경 위험도
+
+| 위험 | 대상 |
+|------|------|
+| **高** | `Dockerfile`, `railway.toml`, `next.config`(output/images), Railway 서비스 config(startCommand·HOSTNAME·env), 의존성(`package.json`/`pnpm-lock`) |
+| **中** | `middleware.ts`, API 라우트 시그니처, 새 env, R2 자산 경로 |
+| **低** | 컴포넌트·스타일·문서·테스트 |
+
+## 2. 배포 전 체크리스트 (高/中위험)
+
+- [ ] CI 9종 green + 로컬 `pnpm build` 통과
+- [ ] **Dockerfile 변경 시**: 로컬 `docker build` + `docker run -e PORT=8080 <img> node server.js` → `/api/health` 200 (Railway 조건 모사)
+- [ ] **railway.toml/서비스 config 변경 시**: 서비스 `startCommand=node server.js` · `HOSTNAME=0.0.0.0` · `NEXT_PUBLIC_*` 확인 (§3)
+- [ ] **R2 자산 관련**: 프로덕션 `NEXT_PUBLIC_ASSET_BASE_URL` 설정 확인 (미설정 시 이미지 404)
+- [ ] 배포설정 PR은 **main 최신에서 분기** (squash 머지가 stacked 브랜치 merge-base를 어긋냄)
+
+## 3. Railway 특유 함정 (반드시 숙지)
+
+- **서비스 startCommand > railway.toml** — 대시보드/GraphQL 값이 railway.toml을 덮는다.
+- **startCommand는 shell 없이 argv 분해** — env 프리픽스·따옴표·`sh -c` 금지. 순수 `node server.js`.
+- **컨테이너 HOSTNAME은 IPv6 먼저 해석** — standalone은 그대로 두면 IPv6에만 바인딩 → IPv4 헬스체크 미도달. **서비스 변수 `HOSTNAME=0.0.0.0` 필수.**
+- **NEXT_PUBLIC_*는 빌드 ARG** — 누락 시 클라이언트 값 깨짐(특히 R2 이미지 404).
+- **실패 로그는 CLI에 안 뜰 수 있음** — create-container/헬스체크 실패는 대시보드 Details·SSH·GraphQL `deploymentLogs`로 확인.
+
+## 4. 배포 후 스모크 (헬스체크만으론 부족)
+
+> `/api/health` 200 = "서버가 떴다"일 뿐, 기능 정상이 아니다(예 env 누락 시 이미지 404여도 통과).
+
+```bash
+curl -s -o /dev/null -w "home=%{http_code}\n" https://arcanainsight-production.up.railway.app/
+curl -s -o /dev/null -w "health=%{http_code}\n" https://arcanainsight-production.up.railway.app/api/health
+```
+
+1. `/api/health` 200 · 홈 `/` 200
+2. **캐릭터 이미지 로드**(홈 `cdn.xzawed.xyz` → `/_next/image` 200) — Playwright 콘솔 에러 0 권장
+3. **리딩 1건씩**(tarot/saju/shinjeom): 익명 요청으로 실제 결과(SSE) 생성 확인
+4. **배포 방식 변경 시**: 앱 로그 `Network: http://0.0.0.0:8080`(0.0.0.0 바인딩) 확인
+
+## 5. 실패 진단 순서
+
+1. 대시보드 Details → 어느 단계(Build / Create container / Healthcheck) 실패인지
+2. 빌드 실패 → build 로그 / 배포 실패 → deploy·앱 로그(SSH `printenv`·바인딩 host:port)
+3. **3회+ 서로 다른 실패** → 멈추고 롤백(직전 SUCCESS Redeploy)으로 안정화 후 관측 재수집
+
+## 6. 롤백
+
+- 대시보드 → Deployments → 직전 SUCCESS → Redeploy (즉시)
+- 또는 `git revert <hash>` + push
+- 배포 방식(builder) 원복 시 서비스 config(startCommand·변수)도 함께 원복

--- a/.claude/skills/generate-reading-prompt/SKILL.md
+++ b/.claude/skills/generate-reading-prompt/SKILL.md
@@ -18,35 +18,37 @@ allowed-tools: Read Grep Bash(pnpm type-check) Bash(pnpm lint) Bash(pnpm test:co
 
 ### 1. max_tokens 적정성 확인
 
-현재 `computeReadingMaxTokens` 정책:
+> ⚠️ 수치는 코드가 정본이다. 이 표는 참고용이며, 실제 값은 **`src/app/api/tarot/reading/route.ts`(`computeReadingMaxTokens`)**·**`src/services/CLAUDE.md`**를 확인한다(휘발성 수치 drift 방지).
 
-전 구간 단일 공식: `min(4000 + cardCount × 2500 + 5000, 60000)`
+**타로** `computeReadingMaxTokens(cardCount)`: `min(15000 + cardCount × 9000 + 15000, 65000)` (cap 65,000)
 
-| 카드 수 | max_tokens | 비고 |
-|---------|-----------|------|
-| 1장 | 11,500 | |
-| 3장 | 16,500 | |
-| 5장 | 21,500 | |
-| 7장 | 26,500 | |
-| 9장 | 31,500 | |
-| 10장 | 34,000 | |
-| 12장(zodiac) | 39,000 | |
-| 20장 이상 | 60,000 (cap) | |
+| 카드 수 | max_tokens |
+|---------|-----------|
+| 1장 | 39,000 |
+| 2장 | 48,000 |
+| 3장 | 57,000 |
+| 4장 이상 | 65,000 (cap) |
 
-> **주의**: Grok-3은 reasoning 토큰이 output max_tokens 예산을 공유한다.  
-> reasoning ~1500토큰 소모 시 실제 출력 가능 토큰이 그만큼 줄어든다.
+**사주** `computeSajuReadingMaxTokens`: 기본 48,000 / 복잡 범위(includeMonthly·5년·전체운세 등) 60,000 cap
+**신점**: 최종 리딩 `SHINJEOM_TOKENS_FINAL = 48,000` 고정 · 중간 대화 `SHINJEOM_TOKENS_CHAT = 6,000`
+
+> **주의**: Grok-3은 reasoning 토큰이 output max_tokens 예산을 공유한다(reasoning 소모분만큼 실제 출력 감소) → 충분한 버퍼 필수.
 
 - [ ] 실제 AI 응답 길이가 기대에 못 미친다면 max_tokens 상향을 검토한다
-- [ ] 변경 후 `src/__tests__/api/tarot-reading.test.ts`의 기댓값도 동시 수정 필수
+- [ ] 변경 후 `src/__tests__/api/tarot-reading.test.ts` 등 상수를 기댓값으로 쓰는 테스트 동시 수정 필수
 
-### 2. depthGuide 지침 확인
+### 2. 프리미엄 리딩 구조 + 계약 (PR #414·#420·#467·#471)
 
-현재 정책 (`prompt-builder.ts`):
-- 각 카드 해석(interpretation): **카드 수 무관 3~4문단**
-- 종합 해석(overallReading): **4~5문단**
-- 조언(advice): **2~3문단**
+**타로 카드 해석은 단일 필드가 아니라 3-섹션**이다(`prompt-builder.ts`):
+- `symbolism` 3~4문단 · `situation` 3~4문단 · `action` 1~2문단
+- 종합 해석(overallReading): **5~6문단** · 조언(advice): **3~4문단**
+- 사주 `sajuSections`(structure/elements/fortune/guidance), 신점 `shinjeomSections`(spiritual/current/obstacles/future) 4-섹션
 
-- [ ] depthGuide 변경 시 `src/services/core/prompt-builder.test.ts` 테스트 기댓값 동시 수정
+**두 공통 계약을 반드시 함께 검토**한다:
+- **`buildDirectAnswerContract(domain)`** — 질문 직답(answer-first). `directAnswer`를 결과 최상단에 렌더. schemaLine·systemSpec·footerReminder를 한 곳에서 방출(지시-스키마-파서 drift 차단). "균등 나열" 헤지 금지.
+- **`buildReadabilityContract(domain)`** — 쉬운 말 계약. "분량 축소가 아니라 같은 분량을 쉬운 말로"(문단 수·max_tokens 불변). 해요체·전문용어 즉시 풀어쓰기·구체 장면 착지.
+
+- [ ] 문단 수/구조 변경 시 `src/services/core/prompt-builder.test.ts` 테스트 기댓값 동시 수정
 
 ### 3. 시스템 프롬프트 구조
 
@@ -59,13 +61,16 @@ allowed-tools: Read Grep Bash(pnpm type-check) Bash(pnpm lint) Bash(pnpm test:co
 - [ ] 새 캐릭터 추가 시 persona 완성도 확인 (personality + speechStyle 필수)
 - [ ] 언어 파라미터가 `x-locale` 헤더에서 올바르게 전달되는지 확인
 
-### 4. JSON 파싱 안전성
+### 4. JSON 파싱 안전성 (PR #480 무결성 파이프라인)
 
-`parseJsonSafe()` + `cleanReadingText()` 파이프라인:
-- AI가 JSON 외 텍스트를 포함해도 `fallback_text` 처리
-- `parseError` 신호: `truncated`, `fallback_text`, `invalid_json`
+간헐적 무결과 근본 수정으로 3중 내성 파이프라인이 있다:
+- **`parseJsonSafe()`** — 3차 파싱에 **트레일링 콤마 제거**(`stripTrailingCommas`) 포함
+- **`promoteNestedFields(parsed, "sajuSections"|"shinjeomSections", [...])`** — 모델이 flat 필드를 섹션 객체 *내부*에 잘못 중첩한 경우 top-level로 승격(`missing_fields` 복구). 사주·신점 `parseResult`에서 호출
+- **`streamReadingWithParseRetry`** (`reading-generator.ts`) — 3개 리딩 라우트가 사용. 1차 파싱이 `parseError`면 1회 non-stream 재생성
+- `parseError` 신호 4종: `truncated`, `fallback_text`, `invalid_json`, `missing_fields`
 
 - [ ] 새 필드 추가 시 Zod schema와 `ReadingResult` 타입 동시 업데이트
+- [ ] 섹션 내부 중첩 가능 필드는 `promoteNestedFields` 대상 목록에 추가
 - [ ] `parseError` 케이스를 UI가 적절히 처리하는지 확인
 
 ## 프롬프트 개선 작업 절차
@@ -79,7 +84,9 @@ allowed-tools: Read Grep Bash(pnpm type-check) Bash(pnpm lint) Bash(pnpm test:co
 
 ## 실제 리딩 품질 확인 방법
 
-개발 서버에서 타로 리딩 1장 요청 후 SSE 스트림 길이 확인:
-- overallReading: 4~5문단 (각 200~300자)
-- cardInterpretations[0]: 3~4문단
-- advice: 2~3문단
+개발 서버(또는 프로덕션 익명 요청)에서 타로 리딩 요청 후 SSE 스트림 파싱:
+- `directAnswer`: 질문 재진술 + 한 방향 단언(최상단 렌더)
+- overallReading: 5~6문단
+- cardInterpretations[0]: `symbolism`(3~4) + `situation`(3~4) + `action`(1~2)
+- advice: 3~4문단
+- `parseError` 없음(무결과 아님) 확인


### PR DESCRIPTION
## 배경
품질 감사에서 확인된 에이전트·스킬 **HIGH stale 결함** 수정 + 최대 공백(운영·장애) 보강.

## 에이전트
- **character-add**: 이미지 규격 `1408×768`→`2816×1536`(실자산, 다운스케일 금지) + **R2 업로드 단계 추가**(없으면 프로덕션 404)
- **quality-gate**: "테스트 프레임워크 없음/27케이스 정적" → `pnpm test:coverage` **실제 실행** + 임계값 검증. 구형 `model` 핀 제거
- **page-builder**: **라우트 그룹 인지형 개편**((immersive)/(site) 배치기준, 루트 layout=Header+ThemeProvider만, `(site)` min-h-screen 금지 #428)

## 스킬
- **generate-reading-prompt**: max_tokens 공식 3배 오류 교정(`15000+9000` cap 65k) + 3섹션·directAnswer·readability·PR#480 파서 반영
- **add-translation-key**: 비컴파일 예제 교정(`useT()` 무인자·`getT` 삭제·`translate`+`getRequestLocale`), namespace 목록 19개 재생성
- **deploy-safety (신규)**: 배포 영향 변경 시 배포 전 체크리스트 + Railway 함정 + 배포 후 스모크

`.claude/*.md` 전용, 앱 코드/빌드 무영향.

🤖 Generated with [Claude Code](https://claude.com/claude-code)