### PR TITLE
feat(scripts): 리딩 품질 eval 하네스 신설 (계약 회귀 검증)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,6 +122,7 @@ pnpm sync:test-count      # 고정 테스트 수가 있는 문서 동기화
 pnpm check:env-docs       # env.ts와 env 문서 정합성
 pnpm check:doc-links      # 문서 링크 검증
 pnpm i18n:check           # 번역 키 drift 검출
+pnpm eval:reading         # 리딩 품질 계약 검증(directAnswer·4섹션·parseError, SSE 파싱). EVAL_BASE_URL로 대상 지정, 실 AI 호출(온디맨드)
 pnpm generate:assets      # Replicate API로 카드/배경/데코 이미지 생성 (REPLICATE_API_KEY 필요)
 pnpm generate:assets:skip # 이미 존재하는 이미지 건너뛰고 생성
 pnpm upload:assets:r2     # 카드/배경을 Cloudflare R2에 업로드 (정본, etag=md5 검증, .env.r2.local 필요)

--- a/docs/workflow/scripts.md
+++ b/docs/workflow/scripts.md
@@ -14,6 +14,7 @@
 | `check-doc-links.ts` | `.github/workflows/docs-sync.yml` + `pnpm check:doc-links` | docs/ 내 상대 링크(파일 존재) 검증. 동결 스냅샷(`superpowers/plans/archive`·`superpowers/specs`)은 제외, 깨진 링크 발견 시 exit 1(push·CI 차단) |
 | `check-translation-keys.ts` | `.github/workflows/docs-sync.yml` + `pnpm i18n:check` | 번역 키 drift 검출 (ko/en/ja 동기화 검증) |
 | `e2e-full/orchestrator.ts` | `pnpm test:e2e:full` / `pnpm test:e2e:full:ci` | 252 조합 멀티 에이전트 E2E (CI 자동 미연동, 수동 또는 별도 트리거) |
+| `eval-reading.ts` | `pnpm eval:reading` | 리딩 품질 계약 회귀 검증 — 타로·사주·신점 리딩 API에 익명 요청→SSE 파싱→directAnswer·4섹션·parseError·본문 검증. CI 미연동(실 AI 호출·온디맨드), `EVAL_BASE_URL`로 대상 지정 |
 
 ## 2. 명령어 등록 (`pnpm <name>`)
 
@@ -23,6 +24,7 @@
 | `pnpm check:env-docs` | `check-env-docs.ts` | `src/lib/env.ts` ↔ `docs/operations/env-variables.md` 정합성 |
 | `pnpm i18n:check` | `check-translation-keys.ts` | 번역 키 drift 검출 (로컬·CI) |
 | `pnpm sync:test-count` | `sync-test-count.ts` | vitest 실제 테스트 수 측정 후 CLAUDE.md·unit-testing.md 자동 갱신 |
+| `pnpm eval:reading` | `eval-reading.ts` | 리딩 품질 계약 검증(directAnswer·4섹션·parseError·SSE). `EVAL_BASE_URL` 지정(기본 프로덕션), `--service=` 필터. 실 AI 호출·온디맨드 |
 | `pnpm generate:assets` | `generate-assets/index.ts` | Replicate API로 카드·배경·데코 이미지 생성 (`REPLICATE_API_KEY` 필요) |
 | `pnpm generate:assets:skip` | `generate-assets/index.ts --skip-existing` | 이미 존재하는 이미지를 건너뛰고 생성 |
 | `pnpm generate:service-bg` | `generate-service-backgrounds.ts` | 서비스(타로/사주/신점) 배경 이미지 생성 |

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "check:env-docs": "tsx scripts/check-env-docs.ts",
     "i18n:check": "tsx scripts/check-translation-keys.ts",
     "sync:test-count": "tsx scripts/sync-test-count.ts",
+    "eval:reading": "tsx scripts/eval-reading.ts",
     "download:skins": "tsx --env-file=.env.local scripts/download-skin-images.ts",
     "generate:assets": "npx tsx scripts/generate-assets/index.ts",
     "generate:assets:skip": "npx tsx scripts/generate-assets/index.ts --skip-existing",

--- a/scripts/eval-reading.ts
+++ b/scripts/eval-reading.ts
@@ -1,0 +1,248 @@
+/**
+ * 리딩 품질 eval 하네스 — 타로·사주·신점 리딩 API에 익명 요청을 보내 SSE를 파싱하고
+ * 프리미엄 리딩 계약(directAnswer·4섹션·parseError·본문 길이)을 검증한다.
+ *
+ * 최근 리딩 작업(directAnswer #467·readability #471·섹션 영속 #474·무결과 근본수정 #480)의
+ * 프로덕션 수동 fetch+SSE 파싱을 재사용 가능한 회귀 하네스로 대체한다.
+ *
+ * 사용:
+ *   pnpm eval:reading                          # 프로덕션 대상
+ *   EVAL_BASE_URL=http://localhost:3000 pnpm eval:reading   # 로컬 dev 서버 대상
+ *   pnpm eval:reading -- --service=tarot       # 특정 서비스만
+ *
+ * ⚠️ 실제 AI 생성을 호출한다(비용 발생·익명 세션 row 생성 가능). CI 자동 실행용이 아닌 온디맨드 도구다.
+ */
+
+const BASE = process.env.EVAL_BASE_URL ?? "https://arcanainsight-production.up.railway.app";
+const TIMEOUT_MS = 285_000;
+const CONCURRENCY = 3;
+
+const onlyService = process.argv.find((a) => a.startsWith("--service="))?.split("=")[1];
+
+type Json = Record<string, unknown>;
+
+const userInfo = {
+  name: "검증",
+  birthDate: "1993-05-14",
+  gender: "male",
+  birthTime: "09:30",
+  mbti: "INFJ",
+};
+
+const tarotCards = (n: number) =>
+  Array.from({ length: n }, (_, i) => ({
+    cardId: `major-${String(i).padStart(2, "0")}`,
+    position: i,
+    isReversed: i % 3 === 0,
+  }));
+
+interface Task {
+  service: string;
+  path: string;
+  body: Json;
+  question: string;
+}
+
+const ALL_TASKS: Task[] = [
+  {
+    service: "tarot",
+    path: "/api/tarot/reading",
+    question: "이직 시기가 궁금해요.",
+    body: {
+      topic: "love",
+      spreadType: "three-card",
+      characterId: "arcana",
+      userInfo,
+      freeQuestion: "이직 시기가 궁금해요.",
+      cards: tarotCards(3),
+    },
+  },
+  {
+    service: "saju",
+    path: "/api/saju/reading",
+    question: "올해 재물운은?",
+    body: {
+      topic: "saju-general",
+      timeRange: "this-year",
+      includeMonthly: false,
+      characterId: "seonhwa",
+      freeQuestion: "올해 재물운은?",
+      userInfo,
+    },
+  },
+  {
+    service: "shinjeom",
+    path: "/api/shinjeom/message",
+    question: "요즘 일이 안 풀려 답답해요. 앞으로 어떻게 될까요?",
+    body: {
+      topic: "shinjeom-general",
+      characterId: "luna",
+      userInfo,
+      isFinalTurn: true,
+      messageIndex: 2,
+      chatHistory: [
+        { id: "u1", role: "user", content: "요즘 일이 안 풀려 답답해요. 앞으로 어떻게 될까요?", timestamp: Date.now() },
+        { id: "c1", role: "character", content: "많이 힘드셨겠어요. 어떤 일이 가장 걸리나요?", mood: "default", timestamp: Date.now() },
+      ],
+    },
+  },
+];
+
+const nonEmpty = (v: unknown): boolean => typeof v === "string" && v.trim().length > 0;
+
+/** 섹션 객체의 모든 하위 필드가 비어있지 않은지 확인 */
+function sectionsComplete(sections: unknown, keys: string[]): { ok: boolean; missing: string[] } {
+  if (!sections || typeof sections !== "object") return { ok: false, missing: keys };
+  const s = sections as Json;
+  const missing = keys.filter((k) => !nonEmpty(s[k]));
+  return { ok: missing.length === 0, missing };
+}
+
+interface CheckResult {
+  service: string;
+  term: string;
+  ms: number;
+  chunks: number;
+  checks: { name: string; pass: boolean; detail?: string }[];
+  err?: string;
+}
+
+/** 서비스별 프리미엄 리딩 계약 검증 */
+function verifyContract(service: string, result: Json): CheckResult["checks"] {
+  const checks: CheckResult["checks"] = [];
+  const add = (name: string, pass: boolean, detail?: string) => checks.push({ name, pass, detail });
+
+  add("parseError 없음", !result.parseError, result.parseError ? String(result.parseError) : undefined);
+  add("directAnswer 존재", nonEmpty(result.directAnswer), `len=${String(result.directAnswer ?? "").length}`);
+  add("overallReading 존재", nonEmpty(result.overallReading), `len=${String(result.overallReading ?? "").length}`);
+  add("advice 존재", nonEmpty(result.advice), `len=${String(result.advice ?? "").length}`);
+
+  if (service === "tarot") {
+    const ci = result.cardInterpretations;
+    const arr = Array.isArray(ci) ? (ci as Json[]) : [];
+    add("cardInterpretations 존재", arr.length > 0, `count=${arr.length}`);
+    if (arr.length > 0) {
+      const first = arr[0];
+      const has3 = nonEmpty(first.symbolism) && nonEmpty(first.situation) && nonEmpty(first.action);
+      const hasLegacy = nonEmpty(first.interpretation);
+      add("카드 3-섹션(symbolism/situation/action)", has3 || hasLegacy, hasLegacy && !has3 ? "legacy interpretation" : undefined);
+    }
+  } else if (service === "saju") {
+    const r = sectionsComplete(result.sajuSections, ["structure", "elements", "fortune", "guidance"]);
+    add("sajuSections 4개 완결", r.ok, r.missing.length ? `누락: ${r.missing.join(",")}` : undefined);
+  } else if (service === "shinjeom") {
+    const r = sectionsComplete(result.shinjeomSections, ["spiritual", "current", "obstacles", "future"]);
+    add("shinjeomSections 4개 완결", r.ok, r.missing.length ? `누락: ${r.missing.join(",")}` : undefined);
+  }
+
+  return checks;
+}
+
+async function runTask(task: Task): Promise<CheckResult> {
+  const start = Date.now();
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
+  const out: CheckResult = { service: task.service, term: "?", ms: 0, chunks: 0, checks: [] };
+
+  try {
+    const res = await fetch(BASE + task.path, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(task.body),
+      signal: controller.signal,
+    });
+    if (!res.ok || !res.body) {
+      out.term = `http_${res.status}`;
+      try {
+        const j = (await res.json()) as Json;
+        out.err = String(j.error ?? `HTTP ${res.status}`);
+      } catch {
+        /* no json body */
+      }
+      return out;
+    }
+
+    let buf = "";
+    const decoder = new TextDecoder();
+    let done = false;
+    let result: Json | null = null;
+
+    for await (const chunk of res.body as unknown as AsyncIterable<Uint8Array>) {
+      buf += decoder.decode(chunk, { stream: true });
+      const lines = buf.split("\n");
+      buf = lines.pop() ?? "";
+      for (const line of lines) {
+        if (!line.startsWith("data: ")) continue;
+        let evt: Json;
+        try {
+          evt = JSON.parse(line.slice(6)) as Json;
+        } catch {
+          continue;
+        }
+        if (evt.chunk) {
+          out.chunks++;
+          continue;
+        }
+        if (evt.error) {
+          out.term = "error";
+          out.err = String(evt.error).slice(0, 160);
+          done = true;
+          break;
+        }
+        if (evt.done) {
+          result = (evt.result as Json) ?? null;
+          out.term = "done";
+          done = true;
+          break;
+        }
+      }
+      if (done) break;
+    }
+    if (out.term === "?") out.term = "closed_no_done";
+    if (result) out.checks = verifyContract(task.service, result);
+    else if (out.term === "done") out.checks = [{ name: "result 페이로드 존재", pass: false }];
+  } catch (e) {
+    const err = e as { name?: string; message?: string };
+    out.term = err?.name === "AbortError" ? "timeout" : "exception";
+    out.err = (err?.message ?? String(e)).slice(0, 160);
+  } finally {
+    clearTimeout(timer);
+    out.ms = Date.now() - start;
+  }
+  return out;
+}
+
+async function main() {
+  const tasks = onlyService ? ALL_TASKS.filter((t) => t.service === onlyService) : ALL_TASKS;
+  if (tasks.length === 0) {
+    console.error(`알 수 없는 서비스: ${onlyService} (tarot|saju|shinjeom)`);
+    process.exit(2);
+  }
+  console.log(`리딩 eval 하네스 — 대상: ${BASE}\n서비스: ${tasks.map((t) => t.service).join(", ")}\n`);
+
+  const results: CheckResult[] = [];
+  let next = 0;
+  async function worker() {
+    while (next < tasks.length) {
+      const i = next++;
+      const r = await runTask(tasks[i]);
+      results.push(r);
+      const failed = r.checks.filter((c) => !c.pass);
+      const status = r.term === "done" && failed.length === 0 ? "✅ PASS" : "❌ FAIL";
+      console.log(`${status}  ${r.service.padEnd(9)} ${r.term.padEnd(13)} ${(r.ms / 1000).toFixed(1)}s  chunks=${r.chunks}${r.err ? "  err=" + r.err : ""}`);
+      for (const c of r.checks) {
+        console.log(`   ${c.pass ? "✓" : "✗"} ${c.name}${c.detail ? `  (${c.detail})` : ""}`);
+      }
+    }
+  }
+  await Promise.all(Array.from({ length: Math.min(CONCURRENCY, tasks.length) }, () => worker()));
+
+  const passed = results.filter((r) => r.term === "done" && r.checks.every((c) => c.pass)).length;
+  console.log(`\n결과: ${passed}/${results.length} 서비스 계약 통과`);
+  if (passed !== results.length) process.exit(1);
+}
+
+main().catch((e) => {
+  console.error("eval 하네스 실행 오류:", e);
+  process.exit(1);
+});


### PR DESCRIPTION
## 배경
품질 감사에서 식별한 공백(**리딩 품질 SSE eval 하네스 부재**, gap Top3) 보강. directAnswer(#467)·readability(#471)·섹션 영속(#474)·무결과 근본수정(#480) 작업마다 프로덕션에서 수동 fetch+SSE 파싱을 반복하던 것을 재사용 회귀 하네스로 대체.

## 추가
- **`scripts/eval-reading.ts`** — 타로·사주·신점 리딩 API에 익명 요청 → SSE 파싱 → 프리미엄 리딩 **계약 검증**:
  - 공통: `directAnswer`·`overallReading`·`advice` 존재, `parseError` 없음
  - 타로: `cardInterpretations` 3-섹션(symbolism/situation/action)
  - 사주: `sajuSections`(structure/elements/fortune/guidance) 4개 완결
  - 신점: `shinjeomSections`(spiritual/current/obstacles/future) 4개 완결
  - 계약 미충족 시 `exit 1`
- `EVAL_BASE_URL`로 대상 지정(기본 프로덕션), `--service=` 필터. 실 AI 호출·**온디맨드**(CI 미연동, `sonar.sources=src`라 Sonar 대상 아님).
- `pnpm eval:reading` 등록 + CLAUDE.md·scripts.md 문서화.

## 검증
- **프로덕션 실행 3/3 서비스 계약 통과** (directAnswer·4섹션·3-섹션 전부 존재, parseError 0 — 프로덕션 리딩 품질도 정상 확인)
- `pnpm type-check` 0 error · `pnpm lint` 0 error · `pnpm check:doc-links` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)