### PR TITLE
fix(api): result 라우트 에러 로깅 추가 + favorite-character 검증 순서 교정

### DIFF
--- a/src/__tests__/api/favorite-character.test.ts
+++ b/src/__tests__/api/favorite-character.test.ts
@@ -121,4 +121,18 @@ describe("POST /api/profile/favorite-character", () => {
     expect(res.status).toBe(400)
     expect((await res.json()).error).toBe("Invalid request body")
   });
+
+  // Rate Limit → Zod → Auth 순서를 잠그는 테스트. 이 라우트는 Auth가 Zod보다 앞서 있어
+  // 미인증 + 잘못된 body가 401을 받았다. Zod가 먼저 도는 지금은 400이어야 한다.
+  it("미인증 + 잘못된 body → 401이 아니라 400 (Zod가 Auth보다 먼저)", async () => {
+    const { POST } = await setup({ user: null });
+    const req = new Request("http://localhost/api/profile/favorite-character", {
+      method: "POST",
+      body: JSON.stringify({}),
+      headers: { "Content-Type": "application/json" },
+    })
+    const res = await POST(req as unknown as import("next/server").NextRequest)
+    expect(res.status).toBe(400)
+    expect((await res.json()).error).toBe("Invalid request body")
+  });
 });

--- a/src/app/api/profile/favorite-character/route.ts
+++ b/src/app/api/profile/favorite-character/route.ts
@@ -41,9 +41,11 @@ export async function POST(request: NextRequest) {
     const ip = getClientIp(request.headers)
     if (!(await checkRateLimit(`favorite-character:${ip}`, 10, 60_000))) return rateLimitResponse(locale)
 
-    const user = await requireUser()
+    // 순서 엄수: Rate Limit → Zod → Auth (.claude/rules/api-routes.md).
+    // 이 라우트만 Auth가 앞서 있어, 미인증 + 잘못된 body가 400이 아닌 401을 받았다.
     const parsed = FavoriteCharacterSchema.safeParse(await request.json())
     if (!parsed.success) return NextResponse.json({ error: "Invalid request body" }, { status: 400 })
+    const user = await requireUser()
     const { characterId } = parsed.data
     if (characterId !== null && !getCharacterById(characterId)) {
       return NextResponse.json({ error: "Invalid character" }, { status: 400 })

--- a/src/app/api/saju/result/[id]/route.ts
+++ b/src/app/api/saju/result/[id]/route.ts
@@ -26,7 +26,9 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
     const reading = await db.findOne<Record<string, unknown>>("saju_readings", { share_token: id })
     if (!reading) return NextResponse.json({ error: "Reading not found" }, { status: 404 })
     return NextResponse.json({ reading: pickFields(reading, SAFE_KEYS) })
-  } catch {
+  } catch (e) {
+    // 마커 근거는 tarot/result/[id]/route.ts 참조 — 3서비스 동일 형식으로 남긴다.
+    console.error("[result-fetch-failed]", { service: "saju", err: e instanceof Error ? e.message : String(e) })
     return NextResponse.json({ error: "Failed to fetch reading" }, { status: 500 })
   }
 }

--- a/src/app/api/shinjeom/result/[id]/route.ts
+++ b/src/app/api/shinjeom/result/[id]/route.ts
@@ -20,7 +20,9 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
     const reading = await db.findOne<Record<string, unknown>>("shinjeom_readings", { share_token: id })
     if (!reading) return NextResponse.json({ error: "Reading not found" }, { status: 404 })
     return NextResponse.json({ reading: pickFields(reading, SAFE_KEYS) })
-  } catch {
+  } catch (e) {
+    // 마커 근거는 tarot/result/[id]/route.ts 참조 — 3서비스 동일 형식으로 남긴다.
+    console.error("[result-fetch-failed]", { service: "shinjeom", err: e instanceof Error ? e.message : String(e) })
     return NextResponse.json({ error: "Failed to fetch reading" }, { status: 500 })
   }
 }

--- a/src/app/api/tarot/result/[id]/route.ts
+++ b/src/app/api/tarot/result/[id]/route.ts
@@ -20,7 +20,10 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
     const reading = await db.findOne<Record<string, unknown>>("readings", { share_token: id })
     if (!reading) return NextResponse.json({ error: "Reading not found" }, { status: 404 })
     return NextResponse.json({ reading: pickFields(reading, SAFE_KEYS) })
-  } catch {
+  } catch (e) {
+    // 공유 링크의 500은 서버 신호가 없으면 원인 추적이 불가능하다(DB 장애·어댑터 오류가 조용히 묻힘).
+    // reading-saver의 `[reading-save-failed]`와 같은 방식으로 grep·알림 가능한 단일 마커를 남긴다.
+    console.error("[result-fetch-failed]", { service: "tarot", err: e instanceof Error ? e.message : String(e) })
     return NextResponse.json({ error: "Failed to fetch reading" }, { status: 500 })
   }
 }


### PR DESCRIPTION
Grok 협업 전체 검토의 **항목 F+G**. 5개 PR 계획 중 두 번째로, 둘 다 API 표면만 건드리고 UI/E2E 영향이 없어 한 PR로 묶었습니다.

## F. result 라우트 3종이 예외를 통째로 삼켰습니다

```ts
} catch {
  return NextResponse.json({ error: "Failed to fetch reading" }, { status: 500 })
}
```

공유 링크(`/tarot/result/[id]` 등)에서 DB 장애나 어댑터 오류가 나도 **서버에 아무 신호가 남지 않아** 원인 추적이 불가능했습니다. 리딩 저장 경로가 `[reading-save-failed]` 마커로 관측 가능한 것과 대비됩니다.

`[result-fetch-failed]` 단일 마커를 3서비스 동일 형식으로 남깁니다. **응답(500·메시지)은 불변**이라 클라이언트 계약은 그대로입니다.

## G. `favorite-character` POST가 Rate Limit → **Auth** → Zod 순서였습니다

문서([.claude/rules/api-routes.md](.claude/rules/api-routes.md))와 다른 라우트(`sessions/claim` 등) 기준은 **Rate Limit → Zod → Auth**입니다. 이 라우트만 어긋나 있어 새 API가 이걸 템플릿 삼아 복제할 위험이 있었습니다.

### 동작 변화는 한 경우뿐

| 요청 | 기존 | 변경 후 |
|---|---|---|
| 미인증 + 정상 body | 401 | 401 (불변) |
| 인증 + 잘못된 body | 400 | 400 (불변) |
| **미인증 + 잘못된 body** | **401** | **400** |
| 인증 + 정상 body | 200 | 200 (불변) |

기존 테스트는 이 엣지 케이스를 **잠그고 있지 않아** 무수정으로 통과합니다. 즉 계약이 명시된 적이 없었습니다. 새 계약을 고정하는 테스트를 추가했습니다.

> GET의 비로그인 200 `{characterId:null}` 동작(#465, 몰입형 진입 콘솔 401 제거 목적)은 **의도된 것이라 건드리지 않았습니다.**

## 검증

| 항목 | 결과 |
|---|---|
| 관련 4개 테스트 파일 | 25건 전부 통과 |
| `pnpm type-check` · `pnpm lint` | 통과 / 오류 0 |
| `pnpm test:coverage` | 65파일 **1095개 전부 통과** (1094 → 1095, 추가한 1건) |
| 커버리지 | stmts 98.85 / branches 91.52 / funcs 99 — 임계치(98/90/97) 상회 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
