### PR TITLE
test(e2e): 잔존 networkidle·load 대기 제거 + eslint 가드 범위 확장

### DIFF
--- a/.claude/rules/e2e-testing.md
+++ b/.claude/rules/e2e-testing.md
@@ -41,7 +41,8 @@ grep -rn "service-navigation" e2e/ --include="*.ts"
 2. **CI vs 로컬 차이**
    - CI: `pnpm start` (프로덕션 빌드), retries: 2(단 **결함 탐지 가드는 0** — 아래 참조), **workers: 1**, **프로젝트당 2샤드**
    - 로컬: `pnpm dev`, retries: 0, workers 무제한, reuseExistingServer: true
-   - CI `workers: 1` 이유(#462): 2코어/7GB 러너에서 브라우저 2개 + `pnpm start` + sharp 2816×1536 원본 디코드 공존이 호스트 OOM → OOM-killer가 브라우저 kill → "Target closed" 크래시(chromium·webkit 공통). 3개 디바이스 프로젝트의 매트릭스 레벨 병렬은 유지.
+   - CI `workers: 1` 이유(#462): 브라우저 2개 + `pnpm start` + sharp 2816×1536 원본 디코드 공존이 호스트 OOM → OOM-killer가 브라우저 kill → "Target closed" 크래시(chromium·webkit 공통). 3개 디바이스 프로젝트의 매트릭스 레벨 병렬은 유지.
+     > ⚠️ **전제 정정 (2026-07-30 실측)**: #462가 근거로 든 "2코어/7GB 러너"는 사실이 아니다. PR #512가 추가한 계측 스텝이 실제 값을 찍었다 — `Mem: 15989 total / 14476 available`, **swap 미사용**, `OOM 흔적 없음`(dmesg). 즉 **16GB 러너**다. `workers:1`은 틀린 전제 위에 정해졌으므로, 상향 여지가 있는지 재측정 후 판단한다(지금 바꾸지는 말 것 — 실측 없는 변경은 같은 실수의 반복이다).
    - Pre-PR 훅에 E2E 전체 포함 권장 안 함 — CI에서 재검증
 
 3. **hidden 요소 확인**  
@@ -75,6 +76,28 @@ Cloudflare R2/CDN(`cdn.xzawed.xyz`)·Supabase Storage 등 외부 URL을 `src`로
 `priority` 는 `<link rel="preload">` 를 `<head>` 에 추가하므로 CI 환경에서 외부 이미지 응답이
 느리면 `waitForLoadState("load")` 가 20-30s 블로킹 → E2E 타임아웃 유발.  
 LCP 요소(히어로 이미지 등)가 아닌 배경·데코 이미지에는 절대 사용하지 않는다. (PR #412 2차 실패 원인)
+
+## ⚠️ `page.goto()`의 기본값은 `load`다 — 인자 없는 goto 금지
+
+가장 자주 재발하는 함정. `waitForLoadState` 호출이 없어도 **`goto` 자체가 `window.load`를 기다린다.**
+
+```ts
+// ❌ 금지 — goto가 이미 load를 기다린다. 뒤의 waitForLoadState는 no-op이라 안전해 보일 뿐이다.
+await page.goto("/");
+await page.waitForLoadState("domcontentloaded");   // 이미 load 이후라 즉시 통과 = 무의미
+
+// ✅ goto에서 끊는다
+await page.goto("/", { waitUntil: "domcontentloaded" });
+```
+
+**진단 단서**: 실패 에러가 `Test timeout of 30000ms exceeded`인데 정작 터진 액션의 옵션은
+`{ timeout: 2000 }`처럼 훨씬 짧다면, 그 액션이 아니라 **앞의 `goto`가 예산을 다 태운 것**이다.
+액션 자체가 실패했다면 `Timeout 2000ms exceeded`가 찍힌다.
+
+홈(`/`)은 캐릭터 이미지가 `nukki-enhanced/*.png` **장당 약 4.8MB × 12명**을 `next/image`+sharp로
+처리하므로 `load`가 30초를 넘기기 쉽다. 홈·`/character/*` 등 이미지 무거운 라우트는 예외 없이
+`{ waitUntil: "domcontentloaded" }`를 붙인다. (2026-07-30 실증: `navigation.spec.ts:190`·
+`theme-effects.spec.ts:11`이 이 이유로 PR 4건에서 연쇄 실패, `retries:2`가 일부를 `1 flaky`로 가림.)
 
 ## 테스트 측: `waitForLoadState("load")` 대신 web-first 대기
 

--- a/e2e/auth-session.spec.ts
+++ b/e2e/auth-session.spec.ts
@@ -38,7 +38,7 @@ test.describe("인증 — 로그인 상태 테스트", () => {
     if (!tokens) return;
 
     // Supabase 세션 쿠키 설정
-    await page.goto("/");
+    await page.goto("/", { waitUntil: "domcontentloaded" });
     await page.evaluate(({ url, access, refresh }) => {
       const storageKey = `sb-${new URL(url).hostname.split(".")[0]}-auth-token`;
       localStorage.setItem(storageKey, JSON.stringify({

--- a/e2e/character.spec.ts
+++ b/e2e/character.spec.ts
@@ -8,7 +8,7 @@ const CHARACTER_IDS = [
 test.describe("캐릭터 상세 페이지", () => {
   for (const id of CHARACTER_IDS) {
     test(`/character/${id} — 페이지 로드 및 기본 요소`, async ({ page }) => {
-      await page.goto(`/character/${id}`);
+      await page.goto(`/character/${id}`, { waitUntil: "domcontentloaded" });
 
       // 캐릭터 이미지 존재 (Next.js Image는 /_next/image?url=...characters... 로 렌더링)
       const img = page.locator('img[src*="characters"]').first();
@@ -20,14 +20,14 @@ test.describe("캐릭터 상세 페이지", () => {
   }
 
   test("존재하지 않는 캐릭터 ID → 에러 표시", async ({ page }) => {
-    await page.goto("/character/nonexistent");
+    await page.goto("/character/nonexistent", { waitUntil: "domcontentloaded" });
 
     // 존재하지 않는 캐릭터 → 404 (web-first — body에 에러 텍스트 노출 대기)
     await expect(page.locator("body")).toContainText(/찾을 수 없|404|not found/i);
   });
 
   test("서비스 카드 — 비활성 항목 클릭 불가", async ({ page }) => {
-    await page.goto("/character/arcana");
+    await page.goto("/character/arcana", { waitUntil: "domcontentloaded" });
     await expect(page.locator("h2", { hasText: "서비스 선택" })).toBeVisible();
 
     // "준비 중" 표시된 비활성 카드 확인

--- a/e2e/cross-platform.spec.ts
+++ b/e2e/cross-platform.spec.ts
@@ -30,7 +30,7 @@ test.describe("크로스 플랫폼 품질 검증", () => {
       const errors: string[] = [];
       page.on("pageerror", (err) => errors.push(err.message));
 
-      await page.goto("/");
+      await page.goto("/", { waitUntil: "domcontentloaded" });
       await page.waitForLoadState("domcontentloaded");
       expect(errors).toHaveLength(0);
     });
@@ -54,7 +54,7 @@ test.describe("크로스 플랫폼 품질 검증", () => {
 
   test("MobileNav — safe area 하단 패딩 존재", async ({ page }) => {
     await page.setViewportSize({ width: 390, height: 844 });
-    await page.goto("/");
+    await page.goto("/", { waitUntil: "domcontentloaded" });
     await page.waitForLoadState("domcontentloaded");
 
     // MobileNav에 safe-area-inset-bottom 스타일 존재 확인
@@ -244,7 +244,7 @@ test.describe("크로스 플랫폼 품질 검증", () => {
     const characters = ["arcana", "miko", "seonhwa", "hoshi", "luna", "rei", "cairn", "zero", "haru", "ren", "lix", "ethan"];
     const moods = ["default", "idle", "smile", "serious", "surprised", "wink", "mystical"];
 
-    await page.goto("/");
+    await page.goto("/", { waitUntil: "domcontentloaded" });
     const failures = await page.evaluate(
       async ({ characters, moods }) => {
         const loadImage = (src: string) =>

--- a/e2e/home.spec.ts
+++ b/e2e/home.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from "@playwright/test";
 
 test.describe("홈 페이지", () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto("/");
+    await page.goto("/", { waitUntil: "domcontentloaded" });
   });
 
   test("페이지 로드 성공 및 콘솔 에러 없음", async ({ page }) => {

--- a/e2e/i18n-matrix.spec.ts
+++ b/e2e/i18n-matrix.spec.ts
@@ -82,7 +82,7 @@ test.describe("i18n — 설정 페이지 locale 렌더링", () => {
 test.describe("i18n — LanguageSwitcher 데스크탑", () => {
   test.beforeEach(async ({ page }) => {
     await page.setViewportSize({ width: 1280, height: 800 });
-    await page.goto("/");
+    await page.goto("/", { waitUntil: "domcontentloaded" });
     await page.waitForLoadState("domcontentloaded");
   });
 
@@ -144,7 +144,7 @@ test.describe("i18n — LanguageSwitcher 데스크탑", () => {
 test.describe("i18n — LanguageSwitcher 모바일", () => {
   test.beforeEach(async ({ page }) => {
     await page.setViewportSize({ width: 390, height: 844 });
-    await page.goto("/");
+    await page.goto("/", { waitUntil: "domcontentloaded" });
     await page.waitForLoadState("domcontentloaded");
   });
 

--- a/e2e/navigation.spec.ts
+++ b/e2e/navigation.spec.ts
@@ -18,14 +18,14 @@ test.describe("네비게이션 — Header 데스크탑 링크", () => {
     const link = page.locator("nav a[href='/tarot']").first();
     await expect(link).toBeVisible();
     await link.click();
-    await page.waitForURL("**/tarot");
+    await page.waitForURL("**/tarot", { waitUntil: "commit" });
   });
 
   test("사주 상담 링크", async ({ page }) => {
     const link = page.locator("nav a[href='/saju']").first();
     await expect(link).toBeVisible();
     await link.click();
-    await page.waitForURL("**/saju");
+    await page.waitForURL("**/saju", { waitUntil: "commit" });
   });
 
   test("마이페이지 링크", async ({ page }) => {
@@ -144,7 +144,7 @@ test.describe("네비게이션 — 모바일 Header", () => {
     await expect(tarotTab).toBeVisible();
     if (await tarotTab.isVisible()) {
       await tarotTab.evaluate((el) => (el as HTMLElement).click());
-      await page.waitForURL("**/tarot");
+      await page.waitForURL("**/tarot", { waitUntil: "commit" });
       await expect(page).toHaveURL(/\/tarot$/);
     }
   });

--- a/e2e/navigation.spec.ts
+++ b/e2e/navigation.spec.ts
@@ -3,7 +3,7 @@ import { test, expect } from "@playwright/test";
 test.describe("네비게이션 — Header 데스크탑 링크", () => {
   test.beforeEach(async ({ page }) => {
     await page.setViewportSize({ width: 1280, height: 800 });
-    await page.goto("/");
+    await page.goto("/", { waitUntil: "domcontentloaded" });
     await page.waitForLoadState("domcontentloaded");
   });
 
@@ -39,7 +39,7 @@ test.describe("네비게이션 — Header 데스크탑 링크", () => {
 test.describe("네비게이션 — Header 테마 드롭다운", () => {
   test("테마 드롭다운 열기/닫기", async ({ page }) => {
     await page.setViewportSize({ width: 1280, height: 800 });
-    await page.goto("/");
+    await page.goto("/", { waitUntil: "domcontentloaded" });
     await page.waitForLoadState("domcontentloaded");
 
     // 테마 버튼 클릭 (데스크탑 헤더 버튼만, 모바일 헤더 버튼 제외)
@@ -76,7 +76,7 @@ test.describe("네비게이션 — Header 테마 드롭다운", () => {
 
 test.describe("네비게이션 — Footer 링크", () => {
   test("Footer 존재 + 서비스 링크", async ({ page }) => {
-    await page.goto("/");
+    await page.goto("/", { waitUntil: "domcontentloaded" });
     await page.waitForLoadState("domcontentloaded");
 
     // 앱 Footer만 선택 (Next.js error-overlay footer 제외)
@@ -91,7 +91,7 @@ test.describe("네비게이션 — Footer 링크", () => {
   });
 
   test("Footer 약관 링크 클릭", async ({ page }) => {
-    await page.goto("/");
+    await page.goto("/", { waitUntil: "domcontentloaded" });
     const footer = page.locator("footer").first();
     await footer.scrollIntoViewIfNeeded();
 
@@ -102,7 +102,7 @@ test.describe("네비게이션 — Footer 링크", () => {
   });
 
   test("Footer 개인정보 링크 클릭", async ({ page }) => {
-    await page.goto("/");
+    await page.goto("/", { waitUntil: "domcontentloaded" });
     const footer = page.locator("footer").first();
     await footer.scrollIntoViewIfNeeded();
 
@@ -116,7 +116,7 @@ test.describe("네비게이션 — Footer 링크", () => {
 test.describe("네비게이션 — 모바일 Header", () => {
   test("모바일 설정 아이콘 표시", async ({ page }) => {
     await page.setViewportSize({ width: 390, height: 844 });
-    await page.goto("/");
+    await page.goto("/", { waitUntil: "domcontentloaded" });
     await page.waitForLoadState("domcontentloaded");
 
     const settingsIcon = page.locator("[data-testid='mobile-settings-link']");
@@ -125,7 +125,7 @@ test.describe("네비게이션 — 모바일 Header", () => {
 
   test("모바일 설정 아이콘 클릭 → /settings 이동", async ({ page }) => {
     await page.setViewportSize({ width: 390, height: 844 });
-    await page.goto("/");
+    await page.goto("/", { waitUntil: "domcontentloaded" });
     await page.waitForLoadState("domcontentloaded");
 
     const settingsIcon = page.locator("[data-testid='mobile-settings-link']");
@@ -136,7 +136,7 @@ test.describe("네비게이션 — 모바일 Header", () => {
 
   test("MobileNav 5탭 표시 + 클릭", async ({ page }) => {
     await page.setViewportSize({ width: 390, height: 844 });
-    await page.goto("/");
+    await page.goto("/", { waitUntil: "domcontentloaded" });
     await page.waitForLoadState("domcontentloaded");
 
     // 타로 탭 클릭 — evaluate로 직접 DOM click (nextjs-portal 가로채기 우회)
@@ -153,7 +153,7 @@ test.describe("네비게이션 — 모바일 Header", () => {
 test.describe("네비게이션 — 페이지 이동 후 스크롤 최상단 초기화", () => {
   test("MobileNav 탭 클릭 후 scrollY === 0 (모바일)", async ({ page }) => {
     await page.setViewportSize({ width: 390, height: 844 });
-    await page.goto("/");
+    await page.goto("/", { waitUntil: "domcontentloaded" });
     await page.waitForLoadState("domcontentloaded");
 
     // 홈에서 아래로 스크롤
@@ -189,7 +189,7 @@ test.describe("네비게이션 — 페이지 이동 후 스크롤 최상단 초�
 
   test("Header 데스크탑 링크 클릭 후 scrollY === 0", async ({ page }) => {
     await page.setViewportSize({ width: 1280, height: 800 });
-    await page.goto("/");
+    await page.goto("/", { waitUntil: "domcontentloaded" });
     await page.waitForLoadState("domcontentloaded");
 
     // 홈에서 아래로 스크롤

--- a/e2e/theme-atmosphere.spec.ts
+++ b/e2e/theme-atmosphere.spec.ts
@@ -63,7 +63,7 @@ test.describe("테마 atmosphere 적용 범위", () => {
 
   test("캐릭터 상세 서비스 선택 화면에도 테마 atmosphere가 적용된다", async ({ page }) => {
     await forceTheme(page, "spring");
-    await page.goto("/character/arcana");
+    await page.goto("/character/arcana", { waitUntil: "domcontentloaded" });
 
     await expect(page.getByRole("heading", { name: "아르카나" })).toBeVisible({ timeout: 5_000 });
     await expectAtmosphere(page, "character-theme-atmosphere", "spring");

--- a/e2e/theme-effects.spec.ts
+++ b/e2e/theme-effects.spec.ts
@@ -9,7 +9,7 @@ test.describe("Theme Effect Layers", () => {
   });
 
   test("InteractionClickParticles 오버레이가 존재한다", async ({ page }) => {
-    await page.goto("/");
+    await page.goto("/", { waitUntil: "domcontentloaded" });
     await expect(page.getByTestId("interaction-click-particles")).toBeAttached();
   });
 

--- a/e2e/theme.spec.ts
+++ b/e2e/theme.spec.ts
@@ -162,8 +162,9 @@ test.describe("테마 — 설정 페이지 상태 일치", () => {
     await themeOptionBtn(page, "summer").evaluate((el) => (el as HTMLElement).click());
     await page.waitForFunction(() => localStorage.getItem("arcana-theme-mode") === "summer", { timeout: 3000 });
 
-    await page.goto("/settings");
-    await page.waitForLoadState("load");
+    // `load` 대기 제거 — 바로 아래 toBeVisible이 이미 web-first 게이트다.
+    // 외부 R2 이미지가 window.load를 지연시키면 이 대기가 그대로 타임아웃이 된다(#459 계열).
+    await page.goto("/settings", { waitUntil: "domcontentloaded" });
 
     const activeBtn = page.locator("button:has-text('한여름 밤')").first();
     await expect(activeBtn).toBeVisible();

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -11,8 +11,10 @@ const eslintConfig = defineConfig([
   // E2E 재발 방지 가드: networkidle 대기 금지. 외부 R2 배경(ServiceBackground)이 Mobile Android CI에서
   // window.load·networkidle을 게이트 → 타임아웃 플레이키(#121~#428). web-first 어서션
   // (toBeVisible/waitForFunction/toHaveCount)으로 대체한다. 정본: docs/operations/known-issues.md, PR #459 sweep.
+  // scripts/e2e-full/**도 포함 — 가드가 e2e/**만 덮던 탓에 shinjeom-flow.ts의 networkidle이
+  // 살아남아 `pnpm test:e2e:full`만 조용히 flaky했다(2026-07-29 검토에서 발견).
   {
-    files: ["e2e/**/*.ts"],
+    files: ["e2e/**/*.ts", "scripts/e2e-full/**/*.ts"],
     plugins: { playwright },
     rules: { "playwright/no-networkidle": "error" },
   },

--- a/scripts/e2e-full/flows/shinjeom-flow.ts
+++ b/scripts/e2e-full/flows/shinjeom-flow.ts
@@ -17,8 +17,7 @@ export async function executeShinjeomFlow(
   baseUrl: string
 ): Promise<{ responseText: string }> {
   // 1. 캐릭터 선택
-  await page.goto(`${baseUrl}/shinjeom`);
-  await page.waitForLoadState('networkidle');
+  await page.goto(`${baseUrl}/shinjeom`, { waitUntil: 'domcontentloaded' });
   const charName = CHAR_KO[tc.characterId] ?? tc.characterId;
   const charBtn = page.locator('button').filter({ hasText: charName });
   await charBtn.first().waitFor({ timeout: 15000 });


### PR DESCRIPTION
Grok 협업 전체 검토의 **항목 D+E**. 5개 PR 계획 중 마지막으로, **제품 코드는 건드리지 않고** 대기 방식만 web-first로 맞췄습니다. E2E flake가 다른 PR을 막지 않도록 맨 뒤에 배치했습니다.

#459/#460 sweep이 놓친 잔여분입니다.

## D. `scripts/e2e-full`이 가드 밖에 있었습니다

`playwright/no-networkidle` 규칙이 **`e2e/**`만 덮고 있어** [shinjeom-flow.ts:21](scripts/e2e-full/flows/shinjeom-flow.ts)의 `networkidle`이 살아남았습니다. 문서상으로는 "e2e에 networkidle 0건"이지만 `pnpm test:e2e:full`만 조용히 flaky한 상태였습니다.

- `goto`를 `{ waitUntil: 'domcontentloaded' }`로 전환 (바로 다음 줄의 `charBtn.waitFor`가 이미 web-first 게이트)
- **eslint 가드 범위를 `scripts/e2e-full/**`로 확장** → 재발 시 lint가 차단

## E. 잔존 `load` 대기

| 위치 | 조치 |
|---|---|
| [theme.spec.ts:166](e2e/theme.spec.ts) | `waitForLoadState("load")` 제거 → `goto`를 `domcontentloaded`로. 바로 아래 `toBeVisible`이 이미 게이트라 중복이었습니다 |
| [navigation.spec.ts:21·28·147](e2e/navigation.spec.ts) | 몰입형 `waitForURL`에 `{ waitUntil: "commit" }` 추가 |

`waitForURL`의 기본값은 `load`입니다. 몰입형 라우트는 외부 R2 배경(`ServiceBackground`)이 `window.load`를 게이트하므로 그대로 두면 Mobile Android CI에서 타임아웃이 됩니다. 같은 파일 168행 이하는 **이미 `commit`을 쓰고 있어** 형식을 통일한 것입니다.

> `/mypage`·`/terms`·`/privacy`·`/settings`의 `waitForURL`은 `(site)` 라우트라 대상이 아니어서 **건드리지 않았습니다.**

## 검증

- `networkidle`·`waitForLoadState("load")` 실사용 잔존 **0건** (`e2e/` + `scripts/`)
- **확장한 eslint 가드가 실제로 발화하는지 위반을 일부러 주입해 확인**했습니다

```
21:31  error  Unexpected use of networkidle  playwright/no-networkidle
✖ 1 problem (1 error, 0 warnings)
```

(확인 후 원복)

| 항목 | 결과 |
|---|---|
| `pnpm type-check` · `pnpm lint` | 통과 / 오류 0 |
| `pnpm test:coverage` | 65파일 **1094개 전부 통과** |

대기 방식 변경이라 최종 확인은 CI E2E 4샤드입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
